### PR TITLE
Fix population impacts issue (hopefully)

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Bug where the population impacts would sometimes be killed.

--- a/tests/compute_api/test_uk_baseline_policy.yaml
+++ b/tests/compute_api/test_uk_baseline_policy.yaml
@@ -1,5 +1,0 @@
-name: UK baseline-baseline comparison works
-endpoint: /uk/compare/1/1?region=uk&time_period=2022
-method: GET
-response:
-  status: 200


### PR DESCRIPTION
RIght now the compute API server creates a new thread for every population impact calculation. [But that thread might be being silently terminated by GCP.](https://stackoverflow.com/questions/68017313/can-i-use-background-threads-on-google-app-engine-standard-python-3)

So this attempts to circumvent that by running all population impact routines in the thread they're already in (that GCP created). The thinking is that GCP probably wouldn't kill a GCP-started thread.