### PR TITLE
Optimise economic impact workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-04-12 10:01:08
+
+### Fixed
+
+- Economic impact runtimes cut down by 9 seconds.
+
 ## [1.1.0] - 2023-04-11 22:40:05
 
 ### Added
@@ -1121,6 +1127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[1.1.1]: https://github.com/PolicyEngine/policyengine-api/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/PolicyEngine/policyengine-api/compare/1.0.7...1.1.0
 [1.0.7]: https://github.com/PolicyEngine/policyengine-api/compare/1.0.6...1.0.7
 [1.0.6]: https://github.com/PolicyEngine/policyengine-api/compare/1.0.5...1.0.6

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -931,3 +931,8 @@
     added:
     - /search endpoint for variables and parameters.
   date: 2023-04-11 22:40:05
+- bump: patch
+  changes:
+    fixed:
+    - Economic impact runtimes cut down by 9 seconds.
+  date: 2023-04-12 10:01:08

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Performance improvements

--- a/gcp/Dockerfile
+++ b/gcp/Dockerfile
@@ -10,4 +10,4 @@ RUN cd Python-3.9.7 && ./configure --enable-optimizations
 RUN cd Python-3.9.7 && make altinstall
 RUN python3.9 -m pip install --upgrade pip
 RUN apt-get update && apt-get install -y redis-server
-RUN pip install policyengine-api>=1.1.0
+RUN pip install policyengine-api>=1.1.2

--- a/policyengine_api/constants.py
+++ b/policyengine_api/constants.py
@@ -6,7 +6,7 @@ GET = "GET"
 POST = "POST"
 UPDATE = "UPDATE"
 LIST = "LIST"
-VERSION = "1.1.0"
+VERSION = "1.1.1"
 COUNTRIES = ("uk", "us", "ca", "ng")
 COUNTRY_PACKAGE_NAMES = (
     "policyengine_uk",

--- a/policyengine_api/setup_data.py
+++ b/policyengine_api/setup_data.py
@@ -1,0 +1,2 @@
+def setup_data():
+    import policyengine_api.endpoints.search

--- a/policyengine_api/worker.py
+++ b/policyengine_api/worker.py
@@ -6,7 +6,9 @@ import policyengine_uk
 import policyengine_us
 import policyengine_canada
 import policyengine_ng
-from policyengine_api.endpoints.economy.reform_impact import set_reform_impact_data
+from policyengine_api.endpoints.economy.reform_impact import (
+    set_reform_impact_data,
+)
 
 # Provide the worker with the list of queues (str) to listen to.
 w = Worker(["default"], connection=Redis())

--- a/policyengine_api/worker.py
+++ b/policyengine_api/worker.py
@@ -6,6 +6,7 @@ import policyengine_uk
 import policyengine_us
 import policyengine_canada
 import policyengine_ng
+from policyengine_api.endpoints.economy.reform_impact import set_reform_impact_data
 
 # Provide the worker with the list of queues (str) to listen to.
 w = Worker(["default"], connection=Redis())

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,10 @@ setup(
         "sentence-transformers",
         "faiss-cpu",
     ],
+    # script policyengine-api-setup -> policyengine_api.setup_data:setup_data
+    entry_points={
+        "console_scripts": [
+            "policyengine-api-setup=policyengine_api.setup_data:setup_data",
+        ],
+    },
 )


### PR DESCRIPTION
Workers previously didn't import the package before running jobs, which meant every impact job had ~9 seconds of import time repeated. This PR fixes that.