### PR TITLE
Check for debug mode before initializing remote db

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Add code to data/data.py to check whether or not app is in debug mode before executing remote db connection

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -134,7 +134,7 @@ class PolicyEngineDatabase:
 
 
 # Determine if app is in debug mode, and if so, do not attempt connection with remote db
-if os.environ["FLASK_DEBUG"] and os.environ["FLASK_DEBUG"] == "1":
+if os.environ.get("FLASK_DEBUG") == "1":
     database = PolicyEngineDatabase(local=True, initialize=False)
 else:
     database = PolicyEngineDatabase(local=False, initialize=False)

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -134,7 +134,7 @@ class PolicyEngineDatabase:
 
 
 # Determine if app is in debug mode, and if so, do not attempt connection with remote db
-if os.environ["FLASK_DEBUG"] == "1":
+if os.environ["FLASK_DEBUG"] and os.environ["FLASK_DEBUG"] == "1":
     database = PolicyEngineDatabase(local=True, initialize=False)
 else:
     database = PolicyEngineDatabase(local=False, initialize=False)

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -132,10 +132,11 @@ class PolicyEngineDatabase:
                 ),
             )
 
+
 # Determine if app is in debug mode, and if so, do not attempt connection with remote db
-if os.environ['FLASK_DEBUG'] == '1':
-	database = PolicyEngineDatabase(local=True, initialize=False)
+if os.environ["FLASK_DEBUG"] == "1":
+    database = PolicyEngineDatabase(local=True, initialize=False)
 else:
-	database = PolicyEngineDatabase(local=False, initialize=False)
+    database = PolicyEngineDatabase(local=False, initialize=False)
 
 local_database = PolicyEngineDatabase(local=True, initialize=False)

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -132,6 +132,10 @@ class PolicyEngineDatabase:
                 ),
             )
 
+# Determine if app is in debug mode, and if so, do not attempt connection with remote db
+if os.environ['FLASK_DEBUG'] == '1':
+	database = PolicyEngineDatabase(local=True, initialize=False)
+else:
+	database = PolicyEngineDatabase(local=False, initialize=False)
 
-database = PolicyEngineDatabase(local=False, initialize=False)
 local_database = PolicyEngineDatabase(local=True, initialize=False)


### PR DESCRIPTION
Added code to `/data/data.py` to check for whether or not app is in debug mode, then alter remote db connection based upon this. I'm not sure if this is Python best practice, I'm merely mimicking a practice in Node. However, this code would enable local deployment and execution of pytest without having to manually change `/data/data.py`. Fixes #439. 