### PR TITLE
Add debug-test script to Makefile to allow for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ debug:
 test:
 	pytest tests/api
 
+debug-test:
+	FLASK_DEBUG=1 pytest tests/api
+
 format:
 	black . -l 79
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Added debug-test script to Makefile


### PR DESCRIPTION
Adds `make debug-test` script to Makefile to allow for local Pytest execution without altering `make test` or having to manually change database connections in `/data/data.py`. Fixes #476. 