### PR TITLE
Setup Flask-Caching for /calculate endpoint.

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    added:
+    - Flask-Cashing setup against redis, supper simple hashing to identify requests.
+    - /calculate endpoint is now be cached, thus repeated calls should be really fast. 

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -32,13 +32,15 @@ from .endpoints import (
 
 app = application = flask.Flask(__name__)
 
-app.config.from_mapping({
-    "CACHE_TYPE": "RedisCache",
-    "CACHE_KEY_PREFIX": "policyengine",
-    "CACHE_REDIS_HOST": "127.0.0.1",
-    "CACHE_REDIS_PORT": 6379,
-    "CACHE_DEFAULT_TIMEOUT": 300
-    })
+app.config.from_mapping(
+    {
+        "CACHE_TYPE": "RedisCache",
+        "CACHE_KEY_PREFIX": "policyengine",
+        "CACHE_REDIS_HOST": "127.0.0.1",
+        "CACHE_REDIS_PORT": 6379,
+        "CACHE_DEFAULT_TIMEOUT": 300,
+    }
+)
 cache = Cache(app)
 
 CORS(app)
@@ -47,9 +49,7 @@ app.route("/", methods=["GET"])(get_home)
 
 app.route("/<country_id>/metadata", methods=["GET"])(get_metadata)
 
-app.route("/<country_id>/household/<household_id>", methods=["GET"])(
-    get_household
-)
+app.route("/<country_id>/household/<household_id>", methods=["GET"])(get_household)
 
 app.route("/<country_id>/household", methods=["POST"])(post_household)
 
@@ -74,24 +74,20 @@ app.route(
 )(cache.cached(make_cache_key=make_cache_key)(get_economic_impact))
 
 app.route("/<country_id>/analysis", methods=["POST"])(
-    app.route("/<country_id>/analysis/<prompt_id>", methods=["GET"])(
-        get_analysis
-    )
+    app.route("/<country_id>/analysis/<prompt_id>", methods=["GET"])(get_analysis)
 )
 
 app.route("/<country_id>/search", methods=["GET"])(get_search)
 
+
 @app.route("/liveness_check", methods=["GET"])
 def liveness_check():
-    return flask.Response(
-        "OK", status=200, headers={"Content-Type": "text/plain"}
-    )
+    return flask.Response("OK", status=200, headers={"Content-Type": "text/plain"})
+
 
 @app.route("/readiness_check", methods=["GET"])
 def readiness_check():
-    return flask.Response(
-        "OK", status=200, headers={"Content-Type": "text/plain"}
-    )
+    return flask.Response("OK", status=200, headers={"Content-Type": "text/plain"})
 
 
 # Add OpenAPI spec (__file__.parent / openapi_spec.yaml)

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -49,7 +49,9 @@ app.route("/", methods=["GET"])(get_home)
 
 app.route("/<country_id>/metadata", methods=["GET"])(get_metadata)
 
-app.route("/<country_id>/household/<household_id>", methods=["GET"])(get_household)
+app.route("/<country_id>/household/<household_id>", methods=["GET"])(
+    get_household
+)
 
 app.route("/<country_id>/household", methods=["POST"])(post_household)
 
@@ -74,7 +76,9 @@ app.route(
 )(cache.cached(make_cache_key=make_cache_key)(get_economic_impact))
 
 app.route("/<country_id>/analysis", methods=["POST"])(
-    app.route("/<country_id>/analysis/<prompt_id>", methods=["GET"])(get_analysis)
+    app.route("/<country_id>/analysis/<prompt_id>", methods=["GET"])(
+        get_analysis
+    )
 )
 
 app.route("/<country_id>/search", methods=["GET"])(get_search)
@@ -82,12 +86,16 @@ app.route("/<country_id>/search", methods=["GET"])(get_search)
 
 @app.route("/liveness_check", methods=["GET"])
 def liveness_check():
-    return flask.Response("OK", status=200, headers={"Content-Type": "text/plain"})
+    return flask.Response(
+        "OK", status=200, headers={"Content-Type": "text/plain"}
+    )
 
 
 @app.route("/readiness_check", methods=["GET"])
 def readiness_check():
-    return flask.Response("OK", status=200, headers={"Content-Type": "text/plain"})
+    return flask.Response(
+        "OK", status=200, headers={"Content-Type": "text/plain"}
+    )
 
 
 # Add OpenAPI spec (__file__.parent / openapi_spec.yaml)

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -1,17 +1,15 @@
 """
 This is the main Flask app for the PolicyEngine API.
 """
-
-print(f"Initialising API...")
-
-import flask
-from flask_cors import CORS
 from pathlib import Path
+from flask_cors import CORS
+import flask
 import yaml
-from .constants import VERSION
-from werkzeug.middleware.profiler import ProfilerMiddleware
 from flask_caching import Cache
 from policyengine_api.utils import make_cache_key
+from .constants import VERSION
+
+# from werkzeug.middleware.profiler import ProfilerMiddleware
 
 # Endpoints
 
@@ -29,6 +27,8 @@ from .endpoints import (
     get_analysis,
     get_search,
 )
+
+print("Initialising API...")
 
 app = application = flask.Flask(__name__)
 
@@ -92,7 +92,7 @@ def readiness_check():
 
 # Add OpenAPI spec (__file__.parent / openapi_spec.yaml)
 
-with open(Path(__file__).parent / "openapi_spec.yaml") as f:
+with open(Path(__file__).parent / "openapi_spec.yaml", encoding="utf-8") as f:
     openapi_spec = yaml.safe_load(f)
     openapi_spec["info"]["version"] = VERSION
 
@@ -102,4 +102,4 @@ def get_specification():
     return flask.jsonify(openapi_spec)
 
 
-print(f"API initialised.")
+print("API initialised.")

--- a/policyengine_api/utils/__init__.py
+++ b/policyengine_api/utils/__init__.py
@@ -1,1 +1,2 @@
 from .json import *
+from .cache_utils import *

--- a/policyengine_api/utils/cache_utils.py
+++ b/policyengine_api/utils/cache_utils.py
@@ -1,18 +1,30 @@
-import json
-import flask
-import logging
+"""Tools for caching API responses."""
 
-# keep it fast, adding overhead to try to add some minor chance of a cache hit is not worth it.
+import json
+import logging
+import flask
+
+
 def make_cache_key(*args, **kwargs):
-    data = ''
+    # pylint: disable=unused-argument
+    """make a hash to uniquely identify a cache entry.
+    keep it fast, adding overhead to try to add some minor chance of a
+    cache hit is not worth it.
+    """
+    data = ""
     if flask.request.content_type == "application/json":
         data = flask.request.get_json()
-    elif flask.request.content_type in ["application/x-www-form-urlencoded", "multipart/form-data"]:
+    elif flask.request.content_type in [
+        "application/x-www-form-urlencoded",
+        "multipart/form-data",
+    ]:
         data = flask.request.form.to_dict()
-    if data != '':
-        data = json.dumps(data, separators=('',''))
-        
+    if data != "":
+        data = json.dumps(data, separators=("", ""))
+
     cache_key = str(hash(flask.request.full_path + data))
     logging.basicConfig(level=logging.DEBUG)
-    logging.getLogger().debug("PATH:" + flask.request.full_path + ", CACHE_KEY:" + cache_key)
+    logging.getLogger().debug(
+        "PATH: %s, CACHE_KEY: %s", flask.request.full_path, cache_key
+    )
     return cache_key

--- a/policyengine_api/utils/cache_utils.py
+++ b/policyengine_api/utils/cache_utils.py
@@ -1,0 +1,18 @@
+import json
+import flask
+import logging
+
+# keep it fast, adding overhead to try to add some minor chance of a cache hit is not worth it.
+def make_cache_key(*args, **kwargs):
+    data = ''
+    if flask.request.content_type == "application/json":
+        data = flask.request.get_json()
+    elif flask.request.content_type in ["application/x-www-form-urlencoded", "multipart/form-data"]:
+        data = flask.request.form.to_dict()
+    if data != '':
+        data = json.dumps(data, separators=('',''))
+        
+    cache_key = str(hash(flask.request.full_path + data))
+    logging.basicConfig(level=logging.DEBUG)
+    logging.getLogger().debug("PATH:" + flask.request.full_path + ", CACHE_KEY:" + cache_key)
+    return cache_key

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "sentence-transformers",
         "sqlalchemy>=1.4,<2",
         "streamlit",
+        "Flask-Caching==2.0.2",
     ],
     # script policyengine-api-setup -> policyengine_api.setup_data:setup_data
     entry_points={

--- a/tests/python/data/calculate_us_1_data.json
+++ b/tests/python/data/calculate_us_1_data.json
@@ -1,0 +1,4613 @@
+{
+    "household": {
+        "people": {
+            "you": {
+                "adult_index": {
+                    "2023": null
+                },
+                "age": {
+                    "2023": 40
+                },
+                "age_group": {
+                    "2023": null
+                },
+                "alimony_expense": {
+                    "2023": 0
+                },
+                "alimony_income": {
+                    "2023": 0
+                },
+                "assessed_property_value": {
+                    "2023": 0
+                },
+                "business_is_qualified": {
+                    "2023": false
+                },
+                "business_is_sstb": {
+                    "2023": false
+                },
+                "ca_cvrp": {
+                    "2023": null
+                },
+                "ca_cvrp_vehicle_rebate_amount": {
+                    "2023": 0
+                },
+                "ca_is_qualifying_child_for_caleitc": {
+                    "2023": null
+                },
+                "capital_gains": {
+                    "2023": null
+                },
+                "capital_loss": {
+                    "2023": null
+                },
+                "casualty_loss": {
+                    "2023": 0
+                },
+                "ccdf_age_group": {
+                    "2023": null
+                },
+                "ccdf_duration_of_care": {
+                    "2023": null
+                },
+                "ccdf_market_rate": {
+                    "2023": null
+                },
+                "cdcc_qualified_dependent": {
+                    "2023": null
+                },
+                "charitable_cash_donations": {
+                    "2023": 0
+                },
+                "charitable_non_cash_donations": {
+                    "2023": 0
+                },
+                "child_support_expense": {
+                    "2023": 0
+                },
+                "child_support_received": {
+                    "2023": 0
+                },
+                "childcare_days_per_week": {
+                    "2023": 0
+                },
+                "childcare_hours_per_day": {
+                    "2023": 0
+                },
+                "childcare_hours_per_week": {
+                    "2023": null
+                },
+                "childcare_provider_type_group": {
+                    "2023": "DCC_SACC"
+                },
+                "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+                    "2023": false
+                },
+                "cliff_evaluated": {
+                    "2023": null
+                },
+                "cliff_gap": {
+                    "2023": null
+                },
+                "cmbtp": {
+                    "2023": 0
+                },
+                "co_oap": {
+                    "2023": null
+                },
+                "co_oap_eligible": {
+                    "2023": null
+                },
+                "co_state_supplement": {
+                    "2023": null
+                },
+                "co_state_supplement_eligible": {
+                    "2023": null
+                },
+                "count_days_postpartum": {
+                    "2023": null
+                },
+                "cps_race": {
+                    "2023": 0
+                },
+                "ctc_adult_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum_arpa": {
+                    "2023": null
+                },
+                "ctc_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_qualifying_child": {
+                    "2023": null
+                },
+                "debt_relief": {
+                    "2023": 0
+                },
+                "disability_benefits": {
+                    "2023": 0
+                },
+                "dividend_income": {
+                    "2023": null
+                },
+                "e00200": {
+                    "2023": null
+                },
+                "e00300": {
+                    "2023": null
+                },
+                "e02300": {
+                    "2023": 0
+                },
+                "e02400": {
+                    "2023": null
+                },
+                "e87530": {
+                    "2023": 0
+                },
+                "early_withdrawal_penalty": {
+                    "2023": 0
+                },
+                "earned": {
+                    "2023": null
+                },
+                "earned_income": {
+                    "2023": null
+                },
+                "educator_expense": {
+                    "2023": 0
+                },
+                "employee_medicare_tax": {
+                    "2023": null
+                },
+                "employee_social_security_tax": {
+                    "2023": null
+                },
+                "employment_income": {
+                    "2023": null
+                },
+                "farm_income": {
+                    "2023": 0
+                },
+                "farm_rent_income": {
+                    "2023": 0
+                },
+                "general_assistance": {
+                    "2023": 0
+                },
+                "gi_cash_assistance": {
+                    "2023": 0
+                },
+                "has_disabled_spouse": {
+                    "2023": null
+                },
+                "has_marketplace_health_coverage": {
+                    "2023": true
+                },
+                "health_insurance_premiums": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_indiv": {
+                    "2023": null
+                },
+                "ia_alternate_tax_joint": {
+                    "2023": null
+                },
+                "ia_amt_indiv": {
+                    "2023": null
+                },
+                "ia_amt_joint": {
+                    "2023": null
+                },
+                "ia_base_tax_indiv": {
+                    "2023": null
+                },
+                "ia_base_tax_joint": {
+                    "2023": null
+                },
+                "ia_basic_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_basic_deduction_joint": {
+                    "2023": null
+                },
+                "ia_fedtax_deduction": {
+                    "2023": null
+                },
+                "ia_gross_income": {
+                    "2023": null
+                },
+                "ia_income_adjustments": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_indiv": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_joint": {
+                    "2023": null
+                },
+                "ia_net_income": {
+                    "2023": null
+                },
+                "ia_pension_exclusion": {
+                    "2023": null
+                },
+                "ia_prorate_fraction": {
+                    "2023": null
+                },
+                "ia_qbi_deduction": {
+                    "2023": null
+                },
+                "ia_regular_tax_indiv": {
+                    "2023": null
+                },
+                "ia_regular_tax_joint": {
+                    "2023": null
+                },
+                "ia_standard_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_standard_deduction_joint": {
+                    "2023": null
+                },
+                "ia_taxable_income_indiv": {
+                    "2023": null
+                },
+                "ia_taxable_income_joint": {
+                    "2023": null
+                },
+                "illicit_income": {
+                    "2023": 0
+                },
+                "in_is_qualifying_dependent_child": {
+                    "2023": null
+                },
+                "incapable_of_self_care": {
+                    "2023": false
+                },
+                "income_decile": {
+                    "2023": null
+                },
+                "interest_expense": {
+                    "2023": 0
+                },
+                "interest_income": {
+                    "2023": null
+                },
+                "ira_contributions": {
+                    "2023": 0
+                },
+                "irs_gross_income": {
+                    "2023": null
+                },
+                "is_adult": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_blind": {
+                    "2023": false
+                },
+                "is_breastfeeding": {
+                    "2023": false
+                },
+                "is_ca_cvrp_increased_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ca_cvrp_normal_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_age_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_home_based": {
+                    "2023": null
+                },
+                "is_ccdf_reason_for_care_eligible": {
+                    "2023": null
+                },
+                "is_cdcc_eligible": {
+                    "2023": null
+                },
+                "is_child": {
+                    "2023": null
+                },
+                "is_child_of_tax_head": {
+                    "2023": null
+                },
+                "is_citizen": {
+                    "2023": false
+                },
+                "is_disabled": {
+                    "2023": false
+                },
+                "is_eitc_qualifying_child": {
+                    "2023": null
+                },
+                "is_eligible_for_american_opportunity_credit": {
+                    "2023": false
+                },
+                "is_enrolled_in_ccdf": {
+                    "2023": false
+                },
+                "is_father": {
+                    "2023": null
+                },
+                "is_female": {
+                    "2023": false
+                },
+                "is_full_time_college_student": {
+                    "2023": false
+                },
+                "is_full_time_student": {
+                    "2023": null
+                },
+                "is_fully_disabled_service_connected_veteran": {
+                    "2023": false
+                },
+                "is_hispanic": {
+                    "2023": false
+                },
+                "is_in_k12_nonpublic_school": {
+                    "2023": false
+                },
+                "is_in_k12_school": {
+                    "2023": null
+                },
+                "is_in_medicaid_medically_needy_category": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_male": {
+                    "2023": null
+                },
+                "is_medicaid_eligible": {
+                    "2023": null
+                },
+                "is_medically_needy_for_medicaid": {
+                    "2023": null
+                },
+                "is_mother": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_on_cliff": {
+                    "2023": null
+                },
+                "is_optional_senior_or_disabled_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_permanently_and_totally_disabled": {
+                    "2023": false
+                },
+                "is_permanently_disabled_veteran": {
+                    "2023": false
+                },
+                "is_person_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_pregnant": {
+                    "2023": false
+                },
+                "is_pregnant_for_medicaid": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_retired": {
+                    "2023": null
+                },
+                "is_self_employed": {
+                    "2023": false
+                },
+                "is_senior": {
+                    "2023": null
+                },
+                "is_severely_disabled": {
+                    "2023": false
+                },
+                "is_ssi_aged": {
+                    "2023": null
+                },
+                "is_ssi_aged_blind_disabled": {
+                    "2023": null
+                },
+                "is_ssi_disabled": {
+                    "2023": null
+                },
+                "is_ssi_eligible_individual": {
+                    "2023": null
+                },
+                "is_ssi_eligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_child": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_parent": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_recipient_for_medicaid": {
+                    "2023": null
+                },
+                "is_surviving_child_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_surviving_spouse_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_tax_unit_dependent": {
+                    "2023": null
+                },
+                "is_tax_unit_head": {
+                    "2023": null
+                },
+                "is_tax_unit_spouse": {
+                    "2023": null
+                },
+                "is_usda_disabled": {
+                    "2023": null
+                },
+                "is_usda_elderly": {
+                    "2023": null
+                },
+                "is_wa_adult": {
+                    "2023": null
+                },
+                "is_wic_at_nutritional_risk": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "k1bx14": {
+                    "2023": 0
+                },
+                "long_term_capital_gains": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_collectibles": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_small_business_stock": {
+                    "2023": 0
+                },
+                "long_term_capital_losses": {
+                    "2023": 0
+                },
+                "ma_covid_19_essential_employee_premium_pay_program": {
+                    "2023": null
+                },
+                "marginal_tax_rate": {
+                    "2023": null
+                },
+                "market_income": {
+                    "2023": null
+                },
+                "maximum_state_supplement": {
+                    "2023": null
+                },
+                "md_pension_subtraction_amount": {
+                    "2023": null
+                },
+                "md_socsec_subtraction_amount": {
+                    "2023": null
+                },
+                "medicaid": {
+                    "2023": null
+                },
+                "medicaid_benefit_value": {
+                    "2023": null
+                },
+                "medicaid_category": {
+                    "2023": null
+                },
+                "medicaid_income_level": {
+                    "2023": null
+                },
+                "medical_expense": {
+                    "2023": null
+                },
+                "medical_out_of_pocket_expenses": {
+                    "2023": 0
+                },
+                "meets_ssi_resource_test": {
+                    "2023": null
+                },
+                "meets_wic_categorical_eligibility": {
+                    "2023": null
+                },
+                "military_basic_pay": {
+                    "2023": 0
+                },
+                "military_retirement_pay": {
+                    "2023": 0
+                },
+                "military_service_income": {
+                    "2023": 0
+                },
+                "miscellaneous_income": {
+                    "2023": 0
+                },
+                "mo_adjusted_gross_income": {
+                    "2023": null
+                },
+                "mo_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mo_income_tax_exempt": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_a": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_b": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_c": {
+                    "2023": null
+                },
+                "mo_qualified_health_insurance_premiums": {
+                    "2023": null
+                },
+                "mo_taxable_income": {
+                    "2023": null
+                },
+                "net_income": {
+                    "2023": 0
+                },
+                "non_qualified_dividend_income": {
+                    "2023": 0
+                },
+                "non_sch_d_capital_gains": {
+                    "2023": 0
+                },
+                "oh_has_not_taken_oh_lump_sum_credits": {
+                    "2023": false
+                },
+                "own_children_in_household": {
+                    "2023": 0
+                },
+                "pa_nontaxable_pension_income": {
+                    "2023": null
+                },
+                "partnership_s_corp_income": {
+                    "2023": 0
+                },
+                "payroll_tax_gross_wages": {
+                    "2023": null
+                },
+                "pencon": {
+                    "2023": 0
+                },
+                "pension_contributions": {
+                    "2023": null
+                },
+                "pension_income": {
+                    "2023": null
+                },
+                "people": {
+                    "2023": 1
+                },
+                "per_vehicle_payment": {
+                    "2023": null
+                },
+                "person_family_id": {
+                    "2023": 0
+                },
+                "person_household_id": {
+                    "2023": 0
+                },
+                "person_id": {
+                    "2023": null
+                },
+                "person_in_poverty": {
+                    "2023": null
+                },
+                "person_marital_unit_id": {
+                    "2023": 0
+                },
+                "person_spm_unit_id": {
+                    "2023": 0
+                },
+                "person_tax_unit_id": {
+                    "2023": 0
+                },
+                "person_weight": {
+                    "2023": null
+                },
+                "private_pension_income": {
+                    "2023": null
+                },
+                "public_pension_income": {
+                    "2023": null
+                },
+                "qbid_amount": {
+                    "2023": null
+                },
+                "qualified_adoption_assistance_expense": {
+                    "2023": 0
+                },
+                "qualified_business_income": {
+                    "2023": null
+                },
+                "qualified_dividend_income": {
+                    "2023": 0
+                },
+                "qualified_tuition_expenses": {
+                    "2023": 0
+                },
+                "qualifies_for_elderly_or_disabled_credit": {
+                    "2023": null
+                },
+                "race": {
+                    "2023": null
+                },
+                "real_estate_taxes": {
+                    "2023": 0
+                },
+                "receives_or_needs_protective_services": {
+                    "2023": false
+                },
+                "receives_wic": {
+                    "2023": false
+                },
+                "rent": {
+                    "2023": 0
+                },
+                "rental_income": {
+                    "2023": 0
+                },
+                "retired_on_total_disability": {
+                    "2023": false
+                },
+                "salt_refund_income": {
+                    "2023": 0
+                },
+                "self_employed_health_insurance_ald_person": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_premiums": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald_person": {
+                    "2023": null
+                },
+                "self_employed_pension_contributions": {
+                    "2023": 0
+                },
+                "self_employment_income": {
+                    "2023": 0
+                },
+                "self_employment_medicare_tax": {
+                    "2023": null
+                },
+                "self_employment_social_security_tax": {
+                    "2023": null
+                },
+                "self_employment_tax": {
+                    "2023": null
+                },
+                "self_employment_tax_ald_person": {
+                    "2023": null
+                },
+                "sep_simple_qualified_plan_contributions": {
+                    "2023": 0
+                },
+                "sey": {
+                    "2023": null
+                },
+                "short_term_capital_gains": {
+                    "2023": 0
+                },
+                "short_term_capital_losses": {
+                    "2023": 0
+                },
+                "social_security": {
+                    "2023": null
+                },
+                "social_security_dependents": {
+                    "2023": 0
+                },
+                "social_security_disability": {
+                    "2023": 0
+                },
+                "social_security_retirement": {
+                    "2023": 0
+                },
+                "social_security_survivors": {
+                    "2023": 0
+                },
+                "social_security_taxable_self_employment_income": {
+                    "2023": null
+                },
+                "ssi": {
+                    "2023": null
+                },
+                "ssi_amount_if_eligible": {
+                    "2023": null
+                },
+                "ssi_category": {
+                    "2023": "NONE"
+                },
+                "ssi_claim_is_joint": {
+                    "2023": null
+                },
+                "ssi_countable_income": {
+                    "2023": null
+                },
+                "ssi_countable_resources": {
+                    "2023": 0
+                },
+                "ssi_earned_income": {
+                    "2023": null
+                },
+                "ssi_earned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_ineligible_child_allocation": {
+                    "2023": null
+                },
+                "ssi_ineligible_parent_allocation": {
+                    "2023": null
+                },
+                "ssi_reported": {
+                    "2023": 0
+                },
+                "ssi_unearned_income": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_parent": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "state_or_federal_salary": {
+                    "2023": 0
+                },
+                "state_supplement": {
+                    "2023": null
+                },
+                "strike_benefits": {
+                    "2023": 0
+                },
+                "student_loan_interest": {
+                    "2023": 0
+                },
+                "tanf_person": {
+                    "2023": null
+                },
+                "tanf_reported": {
+                    "2023": 0
+                },
+                "tax_exempt_interest_income": {
+                    "2023": 0
+                },
+                "tax_exempt_pension_income": {
+                    "2023": null
+                },
+                "tax_exempt_private_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_public_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_unemployment_compensation": {
+                    "2023": null
+                },
+                "taxable_earnings_for_social_security": {
+                    "2023": null
+                },
+                "taxable_interest_income": {
+                    "2023": 0
+                },
+                "taxable_pension_income": {
+                    "2023": null
+                },
+                "taxable_private_pension_income": {
+                    "2023": 0
+                },
+                "taxable_public_pension_income": {
+                    "2023": 0
+                },
+                "taxable_self_employment_income": {
+                    "2023": null
+                },
+                "taxable_social_security": {
+                    "2023": null
+                },
+                "taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "total_disability_payments": {
+                    "2023": 0
+                },
+                "total_income": {
+                    "2023": 0
+                },
+                "unadjusted_basis_qualified_property": {
+                    "2023": 0
+                },
+                "uncapped_ssi": {
+                    "2023": null
+                },
+                "under_12_months_postpartum": {
+                    "2023": false
+                },
+                "under_60_days_postpartum": {
+                    "2023": false
+                },
+                "unemployment_compensation": {
+                    "2023": 0
+                },
+                "us_bonds_for_higher_ed": {
+                    "2023": 0
+                },
+                "vehicles_owned": {
+                    "2023": null
+                },
+                "veterans_benefits": {
+                    "2023": 0
+                },
+                "w2_wages_from_qualified_business": {
+                    "2023": 0
+                },
+                "wic": {
+                    "2023": null
+                },
+                "wic_category": {
+                    "2023": null
+                },
+                "wic_category_str": {
+                    "2023": null
+                },
+                "workers_compensation": {
+                    "2023": 0
+                },
+                "would_claim_wic": {
+                    "2023": null
+                }
+            }
+        },
+        "families": {
+            "your family": {
+                "members": [
+                    "you"
+                ],
+                "family_id": {
+                    "2023": 0
+                },
+                "family_weight": {
+                    "2023": 0
+                },
+                "is_married": {
+                    "2023": null
+                }
+            }
+        },
+        "marital_units": {
+            "your marital unit": {
+                "members": [
+                    "you"
+                ],
+                "marital_unit_id": {
+                    "2023": 0
+                },
+                "marital_unit_weight": {
+                    "2023": null
+                }
+            }
+        },
+        "tax_units": {
+            "your tax unit": {
+                "members": [
+                    "you"
+                ],
+                "a_lineno": {
+                    "2023": 0
+                },
+                "above_the_line_deductions": {
+                    "2023": null
+                },
+                "additional_medicare_tax": {
+                    "2023": null
+                },
+                "additional_standard_deduction": {
+                    "2023": null
+                },
+                "adjusted_gross_income": {
+                    "2023": null
+                },
+                "adjusted_net_capital_gain": {
+                    "2023": null
+                },
+                "advanced_main_air_circulating_fan_expenditures": {
+                    "2023": 0
+                },
+                "age_head": {
+                    "2023": null
+                },
+                "age_spouse": {
+                    "2023": null
+                },
+                "aged_blind_count": {
+                    "2023": null
+                },
+                "aged_blind_extra_standard_deduction": {
+                    "2023": null
+                },
+                "aged_head": {
+                    "2023": null
+                },
+                "aged_spouse": {
+                    "2023": null
+                },
+                "air_sealing_ventilation_expenditures": {
+                    "2023": 0
+                },
+                "al_agi": {
+                    "2023": 0
+                },
+                "al_dependent_exemption": {
+                    "2023": null
+                },
+                "al_income_tax_before_credits": {
+                    "2023": null
+                },
+                "al_personal_exemption": {
+                    "2023": null
+                },
+                "al_standard_deduction": {
+                    "2023": null
+                },
+                "al_taxable_income": {
+                    "2023": 0
+                },
+                "alternative_minimum_tax": {
+                    "2023": null
+                },
+                "american_opportunity_credit": {
+                    "2023": null
+                },
+                "amt_form_completed": {
+                    "2023": false
+                },
+                "amt_income": {
+                    "2023": null
+                },
+                "amt_non_agi_income": {
+                    "2023": 0
+                },
+                "az_standard_deduction": {
+                    "2023": null
+                },
+                "basic_income": {
+                    "2023": null
+                },
+                "basic_income_before_phase_out": {
+                    "2023": null
+                },
+                "basic_income_eligible": {
+                    "2023": null
+                },
+                "basic_income_phase_out": {
+                    "2023": null
+                },
+                "basic_standard_deduction": {
+                    "2023": null
+                },
+                "benefit_value_total": {
+                    "2023": 0
+                },
+                "biomass_stove_boiler_expenditures": {
+                    "2023": 0
+                },
+                "blind_head": {
+                    "2023": null
+                },
+                "blind_spouse": {
+                    "2023": null
+                },
+                "c01000": {
+                    "2023": null
+                },
+                "c04600": {
+                    "2023": null
+                },
+                "c05700": {
+                    "2023": 0
+                },
+                "c07100": {
+                    "2023": null
+                },
+                "c07200": {
+                    "2023": null
+                },
+                "c07230": {
+                    "2023": null
+                },
+                "c07240": {
+                    "2023": 0
+                },
+                "c07260": {
+                    "2023": 0
+                },
+                "c07300": {
+                    "2023": 0
+                },
+                "c07400": {
+                    "2023": 0
+                },
+                "c07600": {
+                    "2023": 0
+                },
+                "c08000": {
+                    "2023": 0
+                },
+                "c09600": {
+                    "2023": null
+                },
+                "c10960": {
+                    "2023": null
+                },
+                "c11070": {
+                    "2023": null
+                },
+                "c23650": {
+                    "2023": null
+                },
+                "c59660": {
+                    "2023": null
+                },
+                "c62100": {
+                    "2023": null
+                },
+                "c87668": {
+                    "2023": null
+                },
+                "ca_agi": {
+                    "2023": null
+                },
+                "ca_agi_additions": {
+                    "2023": 0
+                },
+                "ca_agi_subtractions": {
+                    "2023": null
+                },
+                "ca_cdcc": {
+                    "2023": null
+                },
+                "ca_eitc": {
+                    "2023": null
+                },
+                "ca_eitc_eligible": {
+                    "2023": null
+                },
+                "ca_exemptions": {
+                    "2023": null
+                },
+                "ca_income_tax": {
+                    "2023": null
+                },
+                "ca_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ca_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ca_itemized_deductions": {
+                    "2023": null
+                },
+                "ca_mental_health_services_tax": {
+                    "2023": null
+                },
+                "ca_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ca_refundable_credits": {
+                    "2023": null
+                },
+                "ca_renter_credit": {
+                    "2023": null
+                },
+                "ca_standard_deduction": {
+                    "2023": null
+                },
+                "ca_taxable_income": {
+                    "2023": null
+                },
+                "ca_use_tax": {
+                    "2023": null
+                },
+                "ca_yctc": {
+                    "2023": null
+                },
+                "capital_gains_28_percent_rate_gain": {
+                    "2023": null
+                },
+                "capital_gains_excluded_from_taxable_income": {
+                    "2023": null
+                },
+                "capital_gains_tax": {
+                    "2023": null
+                },
+                "capped_advanced_main_air_circulating_fan_credit": {
+                    "2023": null
+                },
+                "capped_electric_heat_pump_clothes_dryer_rebate": {
+                    "2023": null
+                },
+                "capped_electric_load_service_center_upgrade_rebate": {
+                    "2023": null
+                },
+                "capped_electric_stove_cooktop_range_or_oven_rebate": {
+                    "2023": null
+                },
+                "capped_electric_wiring_rebate": {
+                    "2023": null
+                },
+                "capped_energy_efficient_central_air_conditioner_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_door_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_insulation_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_roof_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_window_credit": {
+                    "2023": null
+                },
+                "capped_heat_pump_heat_pump_water_heater_biomass_stove_boiler_credit": {
+                    "2023": null
+                },
+                "capped_heat_pump_rebate": {
+                    "2023": null
+                },
+                "capped_heat_pump_water_heater_rebate": {
+                    "2023": null
+                },
+                "capped_home_energy_audit_credit": {
+                    "2023": null
+                },
+                "capped_insulation_air_sealing_ventilation_rebate": {
+                    "2023": null
+                },
+                "capped_qualified_furnace_or_hot_water_boiler_credit": {
+                    "2023": null
+                },
+                "care_deduction": {
+                    "2023": 0
+                },
+                "casualty_loss_deduction": {
+                    "2023": null
+                },
+                "cdcc": {
+                    "2023": null
+                },
+                "cdcc_rate": {
+                    "2023": null
+                },
+                "cdcc_relevant_expenses": {
+                    "2023": null
+                },
+                "charitable_deduction": {
+                    "2023": null
+                },
+                "charity_credit": {
+                    "2023": 0
+                },
+                "co_eitc": {
+                    "2023": null
+                },
+                "cohabitating_spouses": {
+                    "2023": false
+                },
+                "combined": {
+                    "2023": null
+                },
+                "count_cdcc_eligible": {
+                    "2023": null
+                },
+                "ctc": {
+                    "2023": null
+                },
+                "ctc_arpa_addition": {
+                    "2023": null
+                },
+                "ctc_arpa_max_addition": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out_cap": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out_threshold": {
+                    "2023": null
+                },
+                "ctc_arpa_uncapped_phase_out": {
+                    "2023": null
+                },
+                "ctc_limiting_tax_liability": {
+                    "2023": null
+                },
+                "ctc_maximum": {
+                    "2023": null
+                },
+                "ctc_maximum_with_arpa_addition": {
+                    "2023": null
+                },
+                "ctc_new": {
+                    "2023": 0
+                },
+                "ctc_phase_out": {
+                    "2023": null
+                },
+                "ctc_phase_out_threshold": {
+                    "2023": null
+                },
+                "ctc_qualifying_children": {
+                    "2023": null
+                },
+                "ctc_refundable_maximum": {
+                    "2023": null
+                },
+                "ctc_value": {
+                    "2023": null
+                },
+                "data_source": {
+                    "2023": false
+                },
+                "dc_eitc": {
+                    "2023": null
+                },
+                "dc_eitc_with_qualifying_child": {
+                    "2023": null
+                },
+                "dc_eitc_without_qualifying_child": {
+                    "2023": null
+                },
+                "dc_standard_deduction": {
+                    "2023": null
+                },
+                "disabled_head": {
+                    "2023": null
+                },
+                "disabled_spouse": {
+                    "2023": null
+                },
+                "domestic_production_ald": {
+                    "2023": 0
+                },
+                "dsi": {
+                    "2023": null
+                },
+                "dsi_spouse": {
+                    "2023": null
+                },
+                "dwks10": {
+                    "2023": null
+                },
+                "dwks13": {
+                    "2023": null
+                },
+                "dwks14": {
+                    "2023": null
+                },
+                "dwks19": {
+                    "2023": null
+                },
+                "dwks6": {
+                    "2023": null
+                },
+                "dwks9": {
+                    "2023": null
+                },
+                "e07240": {
+                    "2023": 0
+                },
+                "e07400": {
+                    "2023": 0
+                },
+                "e07600": {
+                    "2023": 0
+                },
+                "earned_income_tax_credit": {
+                    "2023": null
+                },
+                "ecpa_adult_dependent_credit": {
+                    "2023": null
+                },
+                "ecpa_filer_credit": {
+                    "2023": null
+                },
+                "education_credit_phase_out": {
+                    "2023": null
+                },
+                "education_tax_credits": {
+                    "2023": null
+                },
+                "eitc": {
+                    "2023": null
+                },
+                "eitc_agi_limit": {
+                    "2023": null
+                },
+                "eitc_child_count": {
+                    "2023": null
+                },
+                "eitc_eligible": {
+                    "2023": null
+                },
+                "eitc_maximum": {
+                    "2023": null
+                },
+                "eitc_phase_in_rate": {
+                    "2023": null
+                },
+                "eitc_phase_out_rate": {
+                    "2023": null
+                },
+                "eitc_phase_out_start": {
+                    "2023": null
+                },
+                "eitc_phased_in": {
+                    "2023": null
+                },
+                "eitc_reduction": {
+                    "2023": null
+                },
+                "eitc_relevant_investment_income": {
+                    "2023": null
+                },
+                "elderly_dependents": {
+                    "2023": 0
+                },
+                "elderly_disabled_credit": {
+                    "2023": null
+                },
+                "electric_heat_pump_clothes_dryer_expenditures": {
+                    "2023": 0
+                },
+                "electric_load_service_center_upgrade_expenditures": {
+                    "2023": 0
+                },
+                "electric_stove_cooktop_range_or_oven_expenditures": {
+                    "2023": 0
+                },
+                "electric_wiring_expenditures": {
+                    "2023": 0
+                },
+                "employee_payroll_tax": {
+                    "2023": null
+                },
+                "energy_efficient_central_air_conditioner_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_door_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_home_improvement_credit": {
+                    "2023": null
+                },
+                "energy_efficient_insulation_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_roof_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_window_expenditures": {
+                    "2023": 0
+                },
+                "excess_payroll_tax_withheld": {
+                    "2023": 0
+                },
+                "exemption_phase_out_start": {
+                    "2023": null
+                },
+                "exemptions": {
+                    "2023": null
+                },
+                "f2441": {
+                    "2023": null
+                },
+                "f6251": {
+                    "2023": false
+                },
+                "federal_eitc_without_age_minimum": {
+                    "2023": null
+                },
+                "federal_state_income_tax": {
+                    "2023": null
+                },
+                "ffpos": {
+                    "2023": 0
+                },
+                "filer_cmbtp": {
+                    "2023": null
+                },
+                "filer_e00200": {
+                    "2023": null
+                },
+                "filer_e00300": {
+                    "2023": null
+                },
+                "filer_e02300": {
+                    "2023": null
+                },
+                "filer_e18400": {
+                    "2023": null
+                },
+                "filer_earned": {
+                    "2023": null
+                },
+                "filer_k1bx14": {
+                    "2023": null
+                },
+                "filer_pencon": {
+                    "2023": null
+                },
+                "filer_sey": {
+                    "2023": null
+                },
+                "filing_status": {
+                    "2023": null
+                },
+                "flat_tax": {
+                    "2023": null
+                },
+                "foreign_earned_income_exclusion": {
+                    "2023": 0
+                },
+                "foreign_tax_credit": {
+                    "2023": 0
+                },
+                "fstax": {
+                    "2023": 0
+                },
+                "fuel_cell_property_capacity": {
+                    "2023": 0
+                },
+                "fuel_cell_property_expenditures": {
+                    "2023": 0
+                },
+                "geothermal_heat_pump_property_expenditures": {
+                    "2023": 0
+                },
+                "h_seq": {
+                    "2023": 0
+                },
+                "hasqdivltcg": {
+                    "2023": null
+                },
+                "head_earned": {
+                    "2023": null
+                },
+                "head_is_disabled": {
+                    "2023": null
+                },
+                "head_spouse_count": {
+                    "2023": null
+                },
+                "health_savings_account_ald": {
+                    "2023": 0
+                },
+                "heat_pump_expenditures": {
+                    "2023": 0
+                },
+                "heat_pump_water_heater_expenditures": {
+                    "2023": 0
+                },
+                "hi_agi": {
+                    "2023": 0
+                },
+                "hi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "hi_standard_deduction": {
+                    "2023": null
+                },
+                "hi_taxable_income": {
+                    "2023": 0
+                },
+                "high_efficiency_electric_home_rebate": {
+                    "2023": null
+                },
+                "high_efficiency_electric_home_rebate_percent_covered": {
+                    "2023": null
+                },
+                "home_energy_audit_expenditures": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_unit": {
+                    "2023": null
+                },
+                "ia_cdcc": {
+                    "2023": null
+                },
+                "ia_eitc": {
+                    "2023": null
+                },
+                "ia_exemption_credit": {
+                    "2023": null
+                },
+                "ia_files_separately": {
+                    "2023": null
+                },
+                "ia_income_tax": {
+                    "2023": null
+                },
+                "ia_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ia_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ia_income_tax_indiv": {
+                    "2023": null
+                },
+                "ia_income_tax_joint": {
+                    "2023": null
+                },
+                "ia_is_tax_exempt": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_unit": {
+                    "2023": null
+                },
+                "ia_modified_income": {
+                    "2023": null
+                },
+                "ia_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ia_reduced_tax": {
+                    "2023": null
+                },
+                "ia_refundable_credits": {
+                    "2023": null
+                },
+                "ia_reportable_social_security": {
+                    "2023": null
+                },
+                "iitax": {
+                    "2023": null
+                },
+                "il_aged_blind_exemption": {
+                    "2023": null
+                },
+                "il_base_income": {
+                    "2023": null
+                },
+                "il_base_income_additions": {
+                    "2023": null
+                },
+                "il_base_income_subtractions": {
+                    "2023": null
+                },
+                "il_dependent_exemption": {
+                    "2023": null
+                },
+                "il_eitc": {
+                    "2023": null
+                },
+                "il_income_tax": {
+                    "2023": null
+                },
+                "il_income_tax_before_nonrefundable_credits": {
+                    "2023": null
+                },
+                "il_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "il_is_exemption_eligible": {
+                    "2023": null
+                },
+                "il_k12_education_expense_credit": {
+                    "2023": null
+                },
+                "il_nonrefundable_credits": {
+                    "2023": null
+                },
+                "il_pass_through_entity_tax_credit": {
+                    "2023": 0
+                },
+                "il_pass_through_withholding": {
+                    "2023": 0
+                },
+                "il_personal_exemption": {
+                    "2023": null
+                },
+                "il_personal_exemption_eligibility_status": {
+                    "2023": null
+                },
+                "il_property_tax_credit": {
+                    "2023": null
+                },
+                "il_refundable_credits": {
+                    "2023": null
+                },
+                "il_schedule_m_additions": {
+                    "2023": 0
+                },
+                "il_schedule_m_subtractions": {
+                    "2023": 0
+                },
+                "il_taxable_income": {
+                    "2023": null
+                },
+                "il_total_exemptions": {
+                    "2023": null
+                },
+                "il_total_tax": {
+                    "2023": null
+                },
+                "il_use_tax": {
+                    "2023": null
+                },
+                "in_add_backs": {
+                    "2023": null
+                },
+                "in_additional_exemptions": {
+                    "2023": null
+                },
+                "in_aged_blind_exemptions": {
+                    "2023": null
+                },
+                "in_aged_low_agi_exemptions": {
+                    "2023": null
+                },
+                "in_agi": {
+                    "2023": null
+                },
+                "in_agi_tax": {
+                    "2023": null
+                },
+                "in_base_exemptions": {
+                    "2023": null
+                },
+                "in_bonus_depreciation_add_back": {
+                    "2023": 0
+                },
+                "in_deductions": {
+                    "2023": null
+                },
+                "in_exemptions": {
+                    "2023": null
+                },
+                "in_homeowners_property_tax": {
+                    "2023": 0
+                },
+                "in_homeowners_property_tax_deduction": {
+                    "2023": null
+                },
+                "in_military_service_deduction": {
+                    "2023": null
+                },
+                "in_nol": {
+                    "2023": 0
+                },
+                "in_nol_add_back": {
+                    "2023": 0
+                },
+                "in_nonpublic_school_deduction": {
+                    "2023": null
+                },
+                "in_oos_municipal_obligation_interest_add_back": {
+                    "2023": 0
+                },
+                "in_other_add_backs": {
+                    "2023": 0
+                },
+                "in_other_deductions": {
+                    "2023": 0
+                },
+                "in_other_taxes": {
+                    "2023": 0
+                },
+                "in_qualifying_child_count": {
+                    "2023": null
+                },
+                "in_renters_deduction": {
+                    "2023": null
+                },
+                "in_section_179_expense_add_back": {
+                    "2023": 0
+                },
+                "in_tax_add_back": {
+                    "2023": 0
+                },
+                "in_unemployment_compensation_deduction": {
+                    "2023": null
+                },
+                "income_tax": {
+                    "2023": null
+                },
+                "income_tax_before_credits": {
+                    "2023": null
+                },
+                "income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_capped_non_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_main_rates": {
+                    "2023": null
+                },
+                "income_tax_non_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_unavailable_non_refundable_credits": {
+                    "2023": null
+                },
+                "interest_deduction": {
+                    "2023": null
+                },
+                "investment_in_529_plan": {
+                    "2023": 0
+                },
+                "investment_income_form_4952": {
+                    "2023": 0
+                },
+                "is_eligible_md_poverty_line_credit": {
+                    "2023": null
+                },
+                "is_ma_income_tax_exempt": {
+                    "2023": null
+                },
+                "is_ptc_eligible": {
+                    "2023": null
+                },
+                "itemized_taxable_income_deductions": {
+                    "2023": null
+                },
+                "k12_tuition_and_fees": {
+                    "2023": 0
+                },
+                "ks_agi": {
+                    "2023": null
+                },
+                "ks_agi_additions": {
+                    "2023": 0
+                },
+                "ks_agi_subtractions": {
+                    "2023": null
+                },
+                "ks_cdcc": {
+                    "2023": null
+                },
+                "ks_count_exemptions": {
+                    "2023": null
+                },
+                "ks_exemptions": {
+                    "2023": null
+                },
+                "ks_fstc": {
+                    "2023": null
+                },
+                "ks_income_tax": {
+                    "2023": null
+                },
+                "ks_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ks_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ks_itemized_deductions": {
+                    "2023": null
+                },
+                "ks_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ks_nonrefundable_eitc": {
+                    "2023": null
+                },
+                "ks_refundable_credits": {
+                    "2023": null
+                },
+                "ks_refundable_eitc": {
+                    "2023": null
+                },
+                "ks_standard_deduction": {
+                    "2023": null
+                },
+                "ks_taxable_income": {
+                    "2023": null
+                },
+                "ks_total_eitc": {
+                    "2023": null
+                },
+                "ky_income_tax": {
+                    "2023": null
+                },
+                "ky_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ky_refundable_credits": {
+                    "2023": 0
+                },
+                "ky_taxable_income": {
+                    "2023": 0
+                },
+                "lifetime_learning_credit": {
+                    "2023": null
+                },
+                "local_income_tax": {
+                    "2023": null
+                },
+                "local_sales_tax": {
+                    "2023": 0
+                },
+                "loss_ald": {
+                    "2023": null
+                },
+                "ma_agi": {
+                    "2023": null
+                },
+                "ma_dependent_care_credit": {
+                    "2023": null
+                },
+                "ma_dependent_credit": {
+                    "2023": null
+                },
+                "ma_dependent_or_dependent_care_credit": {
+                    "2023": null
+                },
+                "ma_eitc": {
+                    "2023": null
+                },
+                "ma_gross_income": {
+                    "2023": null
+                },
+                "ma_income_tax": {
+                    "2023": null
+                },
+                "ma_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ma_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ma_income_tax_exemption_threshold": {
+                    "2023": null
+                },
+                "ma_limited_income_tax_credit": {
+                    "2023": null
+                },
+                "ma_non_refundable_credits": {
+                    "2023": null
+                },
+                "ma_part_a_agi": {
+                    "2023": null
+                },
+                "ma_part_a_cg_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_a_div_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_a_gross_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_capital_gains_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_dividend_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_income": {
+                    "2023": null
+                },
+                "ma_part_b_agi": {
+                    "2023": null
+                },
+                "ma_part_b_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_b_gross_income": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_before_exemption": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_deductions": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_exemption": {
+                    "2023": null
+                },
+                "ma_part_c_agi": {
+                    "2023": null
+                },
+                "ma_part_c_gross_income": {
+                    "2023": null
+                },
+                "ma_part_c_taxable_income": {
+                    "2023": null
+                },
+                "ma_refundable_credits": {
+                    "2023": null
+                },
+                "ma_scb_total_income": {
+                    "2023": null
+                },
+                "ma_senior_circuit_breaker": {
+                    "2023": null
+                },
+                "mars": {
+                    "2023": null
+                },
+                "maximum_capital_loss": {
+                    "2023": null
+                },
+                "md_aged_blind_exemptions": {
+                    "2023": null
+                },
+                "md_aged_dependent_exemption": {
+                    "2023": null
+                },
+                "md_aged_exemption": {
+                    "2023": null
+                },
+                "md_agi": {
+                    "2023": null
+                },
+                "md_blind_exemption": {
+                    "2023": null
+                },
+                "md_cdcc": {
+                    "2023": null
+                },
+                "md_ctc": {
+                    "2023": null
+                },
+                "md_deductions": {
+                    "2023": null
+                },
+                "md_dependent_care_subtraction": {
+                    "2023": null
+                },
+                "md_eitc": {
+                    "2023": null
+                },
+                "md_exemptions": {
+                    "2023": null
+                },
+                "md_income_tax": {
+                    "2023": null
+                },
+                "md_income_tax_before_credits": {
+                    "2023": null
+                },
+                "md_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "md_local_income_tax_before_credits": {
+                    "2023": null
+                },
+                "md_non_refundable_credits": {
+                    "2023": null
+                },
+                "md_non_refundable_eitc": {
+                    "2023": null
+                },
+                "md_non_single_childless_non_refundable_eitc": {
+                    "2023": null
+                },
+                "md_non_single_childless_refundable_eitc": {
+                    "2023": null
+                },
+                "md_pension_subtraction": {
+                    "2023": null
+                },
+                "md_personal_exemption": {
+                    "2023": null
+                },
+                "md_poverty_line_credit": {
+                    "2023": null
+                },
+                "md_qualifies_for_single_childless_eitc": {
+                    "2023": null
+                },
+                "md_refundable_cdcc": {
+                    "2023": null
+                },
+                "md_refundable_credits": {
+                    "2023": null
+                },
+                "md_refundable_eitc": {
+                    "2023": null
+                },
+                "md_single_childless_eitc": {
+                    "2023": null
+                },
+                "md_socsec_subtraction": {
+                    "2023": null
+                },
+                "md_standard_deduction": {
+                    "2023": null
+                },
+                "md_tax_unit_earned_income": {
+                    "2023": null
+                },
+                "md_taxable_income": {
+                    "2023": null
+                },
+                "md_total_additions": {
+                    "2023": 0
+                },
+                "md_total_personal_exemptions": {
+                    "2023": null
+                },
+                "md_total_subtractions": {
+                    "2023": null
+                },
+                "md_two_income_subtraction": {
+                    "2023": null
+                },
+                "me_agi": {
+                    "2023": null
+                },
+                "me_agi_additions": {
+                    "2023": 0
+                },
+                "me_agi_subtractions": {
+                    "2023": null
+                },
+                "me_child_care_credit": {
+                    "2023": null
+                },
+                "me_deduction": {
+                    "2023": null
+                },
+                "me_deductions": {
+                    "2023": 0
+                },
+                "me_dependent_exemption": {
+                    "2023": null
+                },
+                "me_eitc": {
+                    "2023": null
+                },
+                "me_exemptions": {
+                    "2023": null
+                },
+                "me_income_tax_before_credits": {
+                    "2023": null
+                },
+                "me_itemized_deductions": {
+                    "2023": 0
+                },
+                "me_non_refundable_child_care_credit": {
+                    "2023": null
+                },
+                "me_pension_income_deduction": {
+                    "2023": null
+                },
+                "me_personal_exemption_deduction": {
+                    "2023": null
+                },
+                "me_refundable_child_care_credit": {
+                    "2023": null
+                },
+                "me_standard_deduction": {
+                    "2023": null
+                },
+                "me_step_4_share_of_child_care_expenses": {
+                    "2023": 0
+                },
+                "me_taxable_income": {
+                    "2023": null
+                },
+                "medicaid_income": {
+                    "2023": null
+                },
+                "medical_expense_deduction": {
+                    "2023": null
+                },
+                "mi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mi_taxable_income": {
+                    "2023": 0
+                },
+                "military_disabled_head": {
+                    "2023": null
+                },
+                "military_disabled_spouse": {
+                    "2023": null
+                },
+                "min_head_spouse_earned": {
+                    "2023": null
+                },
+                "misc_deduction": {
+                    "2023": 0
+                },
+                "mn_additions": {
+                    "2023": null
+                },
+                "mn_amt": {
+                    "2023": null
+                },
+                "mn_amt_taxable_income": {
+                    "2023": null
+                },
+                "mn_basic_tax": {
+                    "2023": null
+                },
+                "mn_cdcc": {
+                    "2023": null
+                },
+                "mn_charity_subtraction": {
+                    "2023": null
+                },
+                "mn_deductions": {
+                    "2023": null
+                },
+                "mn_elderly_disabled_subtraction": {
+                    "2023": null
+                },
+                "mn_exemptions": {
+                    "2023": null
+                },
+                "mn_income_tax": {
+                    "2023": null
+                },
+                "mn_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mn_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mn_itemized_deductions": {
+                    "2023": null
+                },
+                "mn_itemizing": {
+                    "2023": null
+                },
+                "mn_marriage_credit": {
+                    "2023": null
+                },
+                "mn_nonrefundable_credits": {
+                    "2023": null
+                },
+                "mn_refundable_credits": {
+                    "2023": null
+                },
+                "mn_social_security_subtraction": {
+                    "2023": null
+                },
+                "mn_standard_deduction": {
+                    "2023": null
+                },
+                "mn_subtractions": {
+                    "2023": null
+                },
+                "mn_taxable_income": {
+                    "2023": null
+                },
+                "mn_wfc": {
+                    "2023": null
+                },
+                "mn_wfc_eligible": {
+                    "2023": null
+                },
+                "mo_federal_income_tax_deduction": {
+                    "2023": null
+                },
+                "mo_income_tax": {
+                    "2023": null
+                },
+                "mo_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mo_itemized_deductions": {
+                    "2023": null
+                },
+                "mo_net_state_income_taxes": {
+                    "2023": null
+                },
+                "mo_non_refundable_credits": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction": {
+                    "2023": null
+                },
+                "mo_property_tax_credit": {
+                    "2023": null
+                },
+                "mo_ptc_gross_income": {
+                    "2023": null
+                },
+                "mo_ptc_income_offset": {
+                    "2023": null
+                },
+                "mo_ptc_net_income": {
+                    "2023": null
+                },
+                "mo_ptc_taxunit_eligible": {
+                    "2023": null
+                },
+                "mo_refundable_credits": {
+                    "2023": null
+                },
+                "mo_wftc": {
+                    "2023": null
+                },
+                "ms_dependents_exemption": {
+                    "2023": null
+                },
+                "ms_regular_exemption": {
+                    "2023": null
+                },
+                "mt_income_tax": {
+                    "2023": null
+                },
+                "mt_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mt_refundable_credits": {
+                    "2023": 0
+                },
+                "mt_taxable_income": {
+                    "2023": 0
+                },
+                "n1820": {
+                    "2023": 0
+                },
+                "n21": {
+                    "2023": 0
+                },
+                "n24": {
+                    "2023": 0
+                },
+                "nc_income_tax": {
+                    "2023": null
+                },
+                "nc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nc_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nc_taxable_income": {
+                    "2023": 0
+                },
+                "nd_additions": {
+                    "2023": null
+                },
+                "nd_income_tax": {
+                    "2023": null
+                },
+                "nd_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nd_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nd_ltcg_subtraction": {
+                    "2023": null
+                },
+                "nd_mpc": {
+                    "2023": null
+                },
+                "nd_nonrefundable_credits": {
+                    "2023": null
+                },
+                "nd_qdiv_subtraction": {
+                    "2023": null
+                },
+                "nd_refundable_credits": {
+                    "2023": 0
+                },
+                "nd_rtrc": {
+                    "2023": null
+                },
+                "nd_subtractions": {
+                    "2023": null
+                },
+                "nd_taxable_income": {
+                    "2023": null
+                },
+                "ne_agi": {
+                    "2023": null
+                },
+                "ne_agi_additions": {
+                    "2023": 0
+                },
+                "ne_agi_subtractions": {
+                    "2023": null
+                },
+                "ne_cdcc_nonrefundable": {
+                    "2023": null
+                },
+                "ne_cdcc_refundable": {
+                    "2023": null
+                },
+                "ne_eitc": {
+                    "2023": null
+                },
+                "ne_elderly_disabled_credit": {
+                    "2023": null
+                },
+                "ne_exemptions": {
+                    "2023": null
+                },
+                "ne_income_tax": {
+                    "2023": null
+                },
+                "ne_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ne_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ne_itemized_deductions": {
+                    "2023": null
+                },
+                "ne_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ne_refundable_credits": {
+                    "2023": null
+                },
+                "ne_standard_deduction": {
+                    "2023": null
+                },
+                "ne_taxable_income": {
+                    "2023": null
+                },
+                "net_capital_gain": {
+                    "2023": null
+                },
+                "net_investment_income": {
+                    "2023": null
+                },
+                "net_investment_income_tax": {
+                    "2023": null
+                },
+                "net_long_term_capital_gain": {
+                    "2023": null
+                },
+                "net_long_term_capital_loss": {
+                    "2023": null
+                },
+                "net_short_term_capital_gain": {
+                    "2023": null
+                },
+                "net_short_term_capital_loss": {
+                    "2023": null
+                },
+                "new_clean_vehicle_battery_capacity": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_battery_components_made_in_north_america": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_battery_critical_minerals_extracted_in_trading_partner_country": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_classification": {
+                    "2023": "OTHER"
+                },
+                "new_clean_vehicle_credit": {
+                    "2023": null
+                },
+                "new_clean_vehicle_credit_eligible": {
+                    "2023": null
+                },
+                "new_clean_vehicle_msrp": {
+                    "2023": 0
+                },
+                "nh_income_tax": {
+                    "2023": null
+                },
+                "nh_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nh_refundable_credits": {
+                    "2023": 0
+                },
+                "nh_taxable_income": {
+                    "2023": null
+                },
+                "nj_agi": {
+                    "2023": null
+                },
+                "nj_agi_additions": {
+                    "2023": 0
+                },
+                "nj_agi_subtractions": {
+                    "2023": 0
+                },
+                "nj_blind_or_disabled_exemption": {
+                    "2023": null
+                },
+                "nj_cdcc": {
+                    "2023": null
+                },
+                "nj_child_tax_credit": {
+                    "2023": null
+                },
+                "nj_childless_eitc_age_eligible": {
+                    "2023": null
+                },
+                "nj_dependents_attending_college_exemption": {
+                    "2023": null
+                },
+                "nj_dependents_exemption": {
+                    "2023": null
+                },
+                "nj_eitc": {
+                    "2023": null
+                },
+                "nj_eitc_income_eligible": {
+                    "2023": null
+                },
+                "nj_homeowners_property_tax": {
+                    "2023": null
+                },
+                "nj_income_tax": {
+                    "2023": null
+                },
+                "nj_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nj_main_income_tax": {
+                    "2023": null
+                },
+                "nj_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nj_potential_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_property_tax_credit": {
+                    "2023": null
+                },
+                "nj_property_tax_credit_eligible": {
+                    "2023": null
+                },
+                "nj_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_property_tax_deduction_eligible": {
+                    "2023": null
+                },
+                "nj_refundable_credits": {
+                    "2023": null
+                },
+                "nj_regular_exemption": {
+                    "2023": null
+                },
+                "nj_senior_exemption": {
+                    "2023": null
+                },
+                "nj_taking_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_taxable_income": {
+                    "2023": null
+                },
+                "nj_taxable_income_before_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_total_deductions": {
+                    "2023": 0
+                },
+                "nj_total_exemptions": {
+                    "2023": null
+                },
+                "no_salt_income_tax": {
+                    "2023": null
+                },
+                "non_refundable_american_opportunity_credit": {
+                    "2023": null
+                },
+                "non_refundable_ctc": {
+                    "2023": null
+                },
+                "nu06": {
+                    "2023": 0
+                },
+                "nu13": {
+                    "2023": 0
+                },
+                "nu18": {
+                    "2023": 0
+                },
+                "num": {
+                    "2023": null
+                },
+                "ny_agi": {
+                    "2023": null
+                },
+                "ny_agi_additions": {
+                    "2023": 0
+                },
+                "ny_agi_subtractions": {
+                    "2023": null
+                },
+                "ny_cdcc": {
+                    "2023": null
+                },
+                "ny_cdcc_max": {
+                    "2023": null
+                },
+                "ny_cdcc_rate": {
+                    "2023": null
+                },
+                "ny_college_tuition_credit": {
+                    "2023": null
+                },
+                "ny_ctc": {
+                    "2023": null
+                },
+                "ny_deductions": {
+                    "2023": null
+                },
+                "ny_eitc": {
+                    "2023": null
+                },
+                "ny_exemptions": {
+                    "2023": null
+                },
+                "ny_household_credit": {
+                    "2023": null
+                },
+                "ny_income_tax": {
+                    "2023": null
+                },
+                "ny_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ny_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ny_itemized_deductions": {
+                    "2023": null
+                },
+                "ny_itemized_deductions_max": {
+                    "2023": null
+                },
+                "ny_itemized_deductions_reduction": {
+                    "2023": 0
+                },
+                "ny_itemizes": {
+                    "2023": null
+                },
+                "ny_main_income_tax": {
+                    "2023": null
+                },
+                "ny_non_refundable_credits": {
+                    "2023": null
+                },
+                "ny_real_property_tax_credit": {
+                    "2023": null
+                },
+                "ny_refundable_credits": {
+                    "2023": null
+                },
+                "ny_standard_deduction": {
+                    "2023": null
+                },
+                "ny_supplemental_eitc": {
+                    "2023": null
+                },
+                "ny_supplemental_tax": {
+                    "2023": null
+                },
+                "ny_taxable_income": {
+                    "2023": null
+                },
+                "nyc_cdcc": {
+                    "2023": null
+                },
+                "nyc_cdcc_age_restricted_expenses": {
+                    "2023": null
+                },
+                "nyc_cdcc_applicable_percentage": {
+                    "2023": null
+                },
+                "nyc_cdcc_eligible": {
+                    "2023": null
+                },
+                "nyc_cdcc_share_qualifying_childcare_expenses": {
+                    "2023": null
+                },
+                "nyc_eitc": {
+                    "2023": null
+                },
+                "nyc_household_credit": {
+                    "2023": null
+                },
+                "nyc_income_tax": {
+                    "2023": null
+                },
+                "nyc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nyc_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_non_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_school_credit_income": {
+                    "2023": null
+                },
+                "nyc_school_tax_credit_fixed_amount": {
+                    "2023": null
+                },
+                "nyc_school_tax_credit_rate_reduction_amount": {
+                    "2023": null
+                },
+                "nyc_taxable_income": {
+                    "2023": null
+                },
+                "nyc_unincorporated_business_credit": {
+                    "2023": 0
+                },
+                "oh_agi": {
+                    "2023": null
+                },
+                "oh_bonus_depreciation_add_back": {
+                    "2023": 0
+                },
+                "oh_federal_conformity_deductions": {
+                    "2023": 0
+                },
+                "oh_income_tax_before_credits": {
+                    "2023": null
+                },
+                "oh_income_tax_exempt": {
+                    "2023": null
+                },
+                "oh_other_add_backs": {
+                    "2023": 0
+                },
+                "oh_section_179_expense_add_back": {
+                    "2023": 0
+                },
+                "oh_taxable_income": {
+                    "2023": 0
+                },
+                "oh_uniformed_services_retirement_income_deduction": {
+                    "2023": 0
+                },
+                "ok_adjustments": {
+                    "2023": 0
+                },
+                "ok_agi": {
+                    "2023": null
+                },
+                "ok_agi_additions": {
+                    "2023": 0
+                },
+                "ok_agi_subtractions": {
+                    "2023": null
+                },
+                "ok_child_care_child_tax_credit": {
+                    "2023": null
+                },
+                "ok_count_exemptions": {
+                    "2023": null
+                },
+                "ok_eitc": {
+                    "2023": null
+                },
+                "ok_exemptions": {
+                    "2023": null
+                },
+                "ok_gross_income": {
+                    "2023": null
+                },
+                "ok_income_tax": {
+                    "2023": null
+                },
+                "ok_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ok_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ok_itemized_deductions": {
+                    "2023": null
+                },
+                "ok_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ok_ptc": {
+                    "2023": null
+                },
+                "ok_refundable_credits": {
+                    "2023": null
+                },
+                "ok_standard_deduction": {
+                    "2023": null
+                },
+                "ok_stc": {
+                    "2023": null
+                },
+                "ok_taxable_income": {
+                    "2023": null
+                },
+                "ok_use_tax": {
+                    "2023": null
+                },
+                "or_deductions": {
+                    "2023": null
+                },
+                "or_disabled_child_dependent_exemptions": {
+                    "2023": null
+                },
+                "or_eitc": {
+                    "2023": null
+                },
+                "or_exemption_credit": {
+                    "2023": null
+                },
+                "or_federal_tax_liability_subtraction": {
+                    "2023": null
+                },
+                "or_income_additions": {
+                    "2023": 0
+                },
+                "or_income_after_additions": {
+                    "2023": null
+                },
+                "or_income_after_subtractions": {
+                    "2023": null
+                },
+                "or_income_subtractions": {
+                    "2023": null
+                },
+                "or_income_tax": {
+                    "2023": null
+                },
+                "or_income_tax_before_credits": {
+                    "2023": null
+                },
+                "or_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "or_itemized_deductions": {
+                    "2023": null
+                },
+                "or_kicker": {
+                    "2023": null
+                },
+                "or_non_refundable_credits": {
+                    "2023": null
+                },
+                "or_refundable_credits": {
+                    "2023": null
+                },
+                "or_regular_exemptions": {
+                    "2023": null
+                },
+                "or_severely_disabled_exemptions": {
+                    "2023": null
+                },
+                "or_standard_deduction": {
+                    "2023": null
+                },
+                "or_tax_before_credits_in_prior_year": {
+                    "2023": 0
+                },
+                "or_taxable_income": {
+                    "2023": null
+                },
+                "other_net_gain": {
+                    "2023": 0
+                },
+                "othertaxes": {
+                    "2023": 0
+                },
+                "pa_adjusted_taxable_income": {
+                    "2023": null
+                },
+                "pa_eligibility_income": {
+                    "2023": null
+                },
+                "pa_income_tax": {
+                    "2023": null
+                },
+                "pa_income_tax_after_forgiveness": {
+                    "2023": null
+                },
+                "pa_income_tax_before_forgiveness": {
+                    "2023": null
+                },
+                "pa_tax_deductions": {
+                    "2023": 0
+                },
+                "pa_tax_forgiveness_amount": {
+                    "2023": null
+                },
+                "pa_tax_forgiveness_rate": {
+                    "2023": null
+                },
+                "pa_total_taxable_income": {
+                    "2023": null
+                },
+                "pa_use_tax": {
+                    "2023": null
+                },
+                "positive_agi": {
+                    "2023": null
+                },
+                "pre_c04600": {
+                    "2023": null
+                },
+                "premium_tax_credit": {
+                    "2023": null
+                },
+                "prior_energy_efficient_home_improvement_credits": {
+                    "2023": 0
+                },
+                "prior_energy_efficient_window_credits": {
+                    "2023": 0
+                },
+                "property_tax_primary_residence": {
+                    "2023": null
+                },
+                "ptc_phase_out_rate": {
+                    "2023": null
+                },
+                "puerto_rico_income": {
+                    "2023": 0
+                },
+                "purchased_qualifying_new_clean_vehicle": {
+                    "2023": false
+                },
+                "purchased_qualifying_used_clean_vehicle": {
+                    "2023": false
+                },
+                "qualified_battery_storage_technology_expenditures": {
+                    "2023": 0
+                },
+                "qualified_business_income_deduction": {
+                    "2023": null
+                },
+                "qualified_furnace_or_hot_water_boiler_expenditures": {
+                    "2023": 0
+                },
+                "qualified_retirement_penalty": {
+                    "2023": 0
+                },
+                "recapture_of_investment_credit": {
+                    "2023": 0
+                },
+                "recovery_rebate_credit": {
+                    "2023": null
+                },
+                "refundable_american_opportunity_credit": {
+                    "2023": null
+                },
+                "refundable_ctc": {
+                    "2023": null
+                },
+                "refundable_payroll_tax_credit": {
+                    "2023": 0
+                },
+                "regular_tax_before_credits": {
+                    "2023": null
+                },
+                "rents": {
+                    "2023": null
+                },
+                "reported_slspc": {
+                    "2023": 0
+                },
+                "residential_clean_energy_credit": {
+                    "2023": null
+                },
+                "residential_efficiency_electrification_rebate": {
+                    "2023": null
+                },
+                "residential_efficiency_electrification_retrofit_energy_savings": {
+                    "2023": 0
+                },
+                "residential_efficiency_electrification_retrofit_expenditures": {
+                    "2023": 0
+                },
+                "retirement_savings_credit": {
+                    "2023": null
+                },
+                "ri_income_tax": {
+                    "2023": null
+                },
+                "ri_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ri_refundable_credits": {
+                    "2023": 0
+                },
+                "ri_standard_deduction": {
+                    "2023": null
+                },
+                "ri_taxable_income": {
+                    "2023": 0
+                },
+                "rptc": {
+                    "2023": null
+                },
+                "rrc_arpa": {
+                    "2023": null
+                },
+                "rrc_caa": {
+                    "2023": null
+                },
+                "rrc_cares": {
+                    "2023": null
+                },
+                "salt_deduction": {
+                    "2023": null
+                },
+                "salt_refund_last_year": {
+                    "2023": 0
+                },
+                "sc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "sc_taxable_income": {
+                    "2023": 0
+                },
+                "sc_young_child_exemption": {
+                    "2023": null
+                },
+                "second_lowest_silver_plan_cost": {
+                    "2023": null
+                },
+                "section_22_income": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_ald": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald": {
+                    "2023": null
+                },
+                "self_employment_tax_ald": {
+                    "2023": null
+                },
+                "sep": {
+                    "2023": 1
+                },
+                "separate_filer_itemizes": {
+                    "2023": false
+                },
+                "small_wind_energy_property_expenditures": {
+                    "2023": 0
+                },
+                "solar_electric_property_expenditures": {
+                    "2023": 0
+                },
+                "solar_water_heating_property_expenditures": {
+                    "2023": 0
+                },
+                "specified_possession_income": {
+                    "2023": 0
+                },
+                "spouse_earned": {
+                    "2023": null
+                },
+                "spouse_is_disabled": {
+                    "2023": null
+                },
+                "spouse_separate_adjusted_gross_income": {
+                    "2023": null
+                },
+                "spouse_separate_tax_unit_size": {
+                    "2023": null
+                },
+                "standard": {
+                    "2023": null
+                },
+                "standard_deduction": {
+                    "2023": null
+                },
+                "state_and_local_sales_or_income_tax": {
+                    "2023": null
+                },
+                "state_income_tax": {
+                    "2023": null
+                },
+                "state_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "state_sales_tax": {
+                    "2023": 0
+                },
+                "surtax": {
+                    "2023": 0
+                },
+                "tax": {
+                    "2023": null
+                },
+                "tax_exempt_social_security": {
+                    "2023": null
+                },
+                "tax_liability_if_itemizing": {
+                    "2023": null
+                },
+                "tax_liability_if_not_itemizing": {
+                    "2023": null
+                },
+                "tax_unit_capital_loss": {
+                    "2023": null
+                },
+                "tax_unit_childcare_expenses": {
+                    "2023": null
+                },
+                "tax_unit_children": {
+                    "2023": null
+                },
+                "tax_unit_count_dependents": {
+                    "2023": null
+                },
+                "tax_unit_dependent_elsewhere": {
+                    "2023": false
+                },
+                "tax_unit_dependents": {
+                    "2023": null
+                },
+                "tax_unit_earned_income": {
+                    "2023": null
+                },
+                "tax_unit_fpg": {
+                    "2023": null
+                },
+                "tax_unit_id": {
+                    "2023": 0
+                },
+                "tax_unit_income_ami_ratio": {
+                    "2023": 0
+                },
+                "tax_unit_is_joint": {
+                    "2023": null
+                },
+                "tax_unit_itemizes": {
+                    "2023": null
+                },
+                "tax_unit_medicaid_income_level": {
+                    "2023": null
+                },
+                "tax_unit_net_capital_gains": {
+                    "2023": null
+                },
+                "tax_unit_partnership_s_corp_income": {
+                    "2023": null
+                },
+                "tax_unit_rental_income": {
+                    "2023": null
+                },
+                "tax_unit_size": {
+                    "2023": null
+                },
+                "tax_unit_social_security": {
+                    "2023": null
+                },
+                "tax_unit_spouse_dependent_elsewhere": {
+                    "2023": false
+                },
+                "tax_unit_ss": {
+                    "2023": null
+                },
+                "tax_unit_ssi": {
+                    "2023": null
+                },
+                "tax_unit_state": {
+                    "2023": null
+                },
+                "tax_unit_taxable_social_security": {
+                    "2023": null
+                },
+                "tax_unit_taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "tax_unit_unemployment_compensation": {
+                    "2023": null
+                },
+                "tax_unit_weight": {
+                    "2023": 0
+                },
+                "taxable_income": {
+                    "2023": null
+                },
+                "taxable_income_deductions": {
+                    "2023": null
+                },
+                "taxable_income_deductions_if_itemizing": {
+                    "2023": null
+                },
+                "taxable_income_deductions_if_not_itemizing": {
+                    "2023": null
+                },
+                "taxable_income_less_qbid": {
+                    "2023": null
+                },
+                "taxable_ss_magi": {
+                    "2023": null
+                },
+                "taxable_uc_agi": {
+                    "2023": null
+                },
+                "taxbc": {
+                    "2023": null
+                },
+                "taxcalc_c04470": {
+                    "2023": null
+                },
+                "taxcalc_c09200": {
+                    "2023": null
+                },
+                "taxcalc_c17000": {
+                    "2023": null
+                },
+                "taxcalc_c18300": {
+                    "2023": null
+                },
+                "taxcalc_c19200": {
+                    "2023": null
+                },
+                "taxcalc_c19700": {
+                    "2023": null
+                },
+                "taxcalc_c20500": {
+                    "2023": null
+                },
+                "taxcalc_cmbtp": {
+                    "2023": null
+                },
+                "taxcalc_dsi": {
+                    "2023": null
+                },
+                "taxcalc_e00200": {
+                    "2023": null
+                },
+                "taxcalc_e00300": {
+                    "2023": null
+                },
+                "taxcalc_e00400": {
+                    "2023": null
+                },
+                "taxcalc_e00600": {
+                    "2023": null
+                },
+                "taxcalc_e00650": {
+                    "2023": null
+                },
+                "taxcalc_e00700": {
+                    "2023": null
+                },
+                "taxcalc_e00800": {
+                    "2023": null
+                },
+                "taxcalc_e00900": {
+                    "2023": null
+                },
+                "taxcalc_e01100": {
+                    "2023": null
+                },
+                "taxcalc_e01200": {
+                    "2023": null
+                },
+                "taxcalc_e01500": {
+                    "2023": null
+                },
+                "taxcalc_e01700": {
+                    "2023": null
+                },
+                "taxcalc_e02000": {
+                    "2023": null
+                },
+                "taxcalc_e02100": {
+                    "2023": null
+                },
+                "taxcalc_e02300": {
+                    "2023": null
+                },
+                "taxcalc_e02400": {
+                    "2023": null
+                },
+                "taxcalc_e03150": {
+                    "2023": null
+                },
+                "taxcalc_e03210": {
+                    "2023": null
+                },
+                "taxcalc_e03220": {
+                    "2023": null
+                },
+                "taxcalc_e03230": {
+                    "2023": null
+                },
+                "taxcalc_e03240": {
+                    "2023": null
+                },
+                "taxcalc_e03270": {
+                    "2023": null
+                },
+                "taxcalc_e03290": {
+                    "2023": null
+                },
+                "taxcalc_e03300": {
+                    "2023": null
+                },
+                "taxcalc_e03400": {
+                    "2023": null
+                },
+                "taxcalc_e03500": {
+                    "2023": null
+                },
+                "taxcalc_e09700": {
+                    "2023": null
+                },
+                "taxcalc_e09800": {
+                    "2023": null
+                },
+                "taxcalc_e09900": {
+                    "2023": null
+                },
+                "taxcalc_e11200": {
+                    "2023": null
+                },
+                "taxcalc_e17500": {
+                    "2023": null
+                },
+                "taxcalc_e18500": {
+                    "2023": null
+                },
+                "taxcalc_e19200": {
+                    "2023": null
+                },
+                "taxcalc_e19800": {
+                    "2023": null
+                },
+                "taxcalc_e20100": {
+                    "2023": null
+                },
+                "taxcalc_e20400": {
+                    "2023": null
+                },
+                "taxcalc_e24515": {
+                    "2023": null
+                },
+                "taxcalc_e24518": {
+                    "2023": null
+                },
+                "taxcalc_e26270": {
+                    "2023": null
+                },
+                "taxcalc_e27200": {
+                    "2023": null
+                },
+                "taxcalc_e32800": {
+                    "2023": null
+                },
+                "taxcalc_e58990": {
+                    "2023": null
+                },
+                "taxcalc_e62900": {
+                    "2023": null
+                },
+                "taxcalc_e87530": {
+                    "2023": null
+                },
+                "taxcalc_f2441": {
+                    "2023": null
+                },
+                "taxcalc_f6251": {
+                    "2023": null
+                },
+                "taxcalc_fips": {
+                    "2023": null
+                },
+                "taxcalc_g20500": {
+                    "2023": null
+                },
+                "taxcalc_hasqdivltcg": {
+                    "2023": null
+                },
+                "taxcalc_midr": {
+                    "2023": null
+                },
+                "taxcalc_niit": {
+                    "2023": null
+                },
+                "taxcalc_p22250": {
+                    "2023": null
+                },
+                "taxcalc_p23250": {
+                    "2023": null
+                },
+                "taxcalc_pencon": {
+                    "2023": null
+                },
+                "taxcalc_pt_binc_w2_wages": {
+                    "2023": null
+                },
+                "taxcalc_pt_sstb_income": {
+                    "2023": null
+                },
+                "taxcalc_pt_ubia_property": {
+                    "2023": null
+                },
+                "taxcalc_s006": {
+                    "2023": null
+                },
+                "taxsim_age1": {
+                    "2023": null
+                },
+                "taxsim_age2": {
+                    "2023": null
+                },
+                "taxsim_age3": {
+                    "2023": null
+                },
+                "taxsim_childcare": {
+                    "2023": null
+                },
+                "taxsim_dep13": {
+                    "2023": null
+                },
+                "taxsim_dep17": {
+                    "2023": null
+                },
+                "taxsim_dep18": {
+                    "2023": null
+                },
+                "taxsim_depx": {
+                    "2023": null
+                },
+                "taxsim_dividends": {
+                    "2023": null
+                },
+                "taxsim_fiitax": {
+                    "2023": null
+                },
+                "taxsim_gssi": {
+                    "2023": null
+                },
+                "taxsim_intrec": {
+                    "2023": null
+                },
+                "taxsim_ltcg": {
+                    "2023": null
+                },
+                "taxsim_mstat": {
+                    "2023": null
+                },
+                "taxsim_page": {
+                    "2023": null
+                },
+                "taxsim_pbusinc": {
+                    "2023": null
+                },
+                "taxsim_pensions": {
+                    "2023": null
+                },
+                "taxsim_pprofinc": {
+                    "2023": 0
+                },
+                "taxsim_psemp": {
+                    "2023": null
+                },
+                "taxsim_pui": {
+                    "2023": null
+                },
+                "taxsim_pwages": {
+                    "2023": null
+                },
+                "taxsim_sage": {
+                    "2023": null
+                },
+                "taxsim_sbusinc": {
+                    "2023": null
+                },
+                "taxsim_scorp": {
+                    "2023": null
+                },
+                "taxsim_siitax": {
+                    "2023": null
+                },
+                "taxsim_sprofinc": {
+                    "2023": 0
+                },
+                "taxsim_ssemp": {
+                    "2023": null
+                },
+                "taxsim_state": {
+                    "2023": null
+                },
+                "taxsim_stcg": {
+                    "2023": null
+                },
+                "taxsim_swages": {
+                    "2023": null
+                },
+                "taxsim_taxsimid": {
+                    "2023": null
+                },
+                "taxsim_tfica": {
+                    "2023": null
+                },
+                "taxsim_ui": {
+                    "2023": null
+                },
+                "taxsim_v10": {
+                    "2023": null
+                },
+                "taxsim_v11": {
+                    "2023": null
+                },
+                "taxsim_v12": {
+                    "2023": null
+                },
+                "taxsim_v18": {
+                    "2023": null
+                },
+                "taxsim_v25": {
+                    "2023": null
+                },
+                "taxsim_year": {
+                    "2023": null
+                },
+                "tuition_and_fees": {
+                    "2023": 0
+                },
+                "unrecaptured_section_1250_gain": {
+                    "2023": 0
+                },
+                "unreported_payroll_tax": {
+                    "2023": 0
+                },
+                "us_govt_interest": {
+                    "2023": 0
+                },
+                "used_clean_vehicle_credit": {
+                    "2023": null
+                },
+                "used_clean_vehicle_credit_eligible": {
+                    "2023": null
+                },
+                "used_clean_vehicle_sale_price": {
+                    "2023": 0
+                },
+                "ut_additions_to_income": {
+                    "2023": 0
+                },
+                "ut_at_home_parent_credit": {
+                    "2023": null
+                },
+                "ut_claims_retirement_credit": {
+                    "2023": null
+                },
+                "ut_eitc": {
+                    "2023": null
+                },
+                "ut_federal_deductions_for_taxpayer_credit": {
+                    "2023": null
+                },
+                "ut_income_tax": {
+                    "2023": null
+                },
+                "ut_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ut_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ut_income_tax_exempt": {
+                    "2023": null
+                },
+                "ut_personal_exemption": {
+                    "2023": null
+                },
+                "ut_refundable_credits": {
+                    "2023": 0
+                },
+                "ut_retirement_credit": {
+                    "2023": null
+                },
+                "ut_retirement_credit_max": {
+                    "2023": null
+                },
+                "ut_ss_benefits_credit": {
+                    "2023": null
+                },
+                "ut_ss_benefits_credit_max": {
+                    "2023": null
+                },
+                "ut_state_tax_refund": {
+                    "2023": null
+                },
+                "ut_subtractions_from_income": {
+                    "2023": 0
+                },
+                "ut_taxable_income": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_max": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_phase_out_income": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_reduction": {
+                    "2023": null
+                },
+                "ut_total_dependents": {
+                    "2023": null
+                },
+                "ut_total_income": {
+                    "2023": null
+                },
+                "va_aged_blind_exemption": {
+                    "2023": null
+                },
+                "va_disability_income_subtraction": {
+                    "2023": null
+                },
+                "va_federal_state_employees_subtraction": {
+                    "2023": null
+                },
+                "va_income_tax_before_credits": {
+                    "2023": null
+                },
+                "va_military_basic_pay_subtraction": {
+                    "2023": null
+                },
+                "va_personal_exemption": {
+                    "2023": null
+                },
+                "va_standard_deduction": {
+                    "2023": null
+                },
+                "va_taxable_income": {
+                    "2023": 0
+                },
+                "wa_capital_gains_tax": {
+                    "2023": null
+                },
+                "wa_income_tax": {
+                    "2023": null
+                },
+                "wa_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "wa_refundable_credits": {
+                    "2023": null
+                },
+                "wa_working_families_tax_credit": {
+                    "2023": null
+                },
+                "xtot": {
+                    "2023": null
+                }
+            }
+        },
+        "spm_units": {
+            "your household": {
+                "members": [
+                    "you"
+                ],
+                "acp": {
+                    "2023": null
+                },
+                "ami": {
+                    "2023": 0
+                },
+                "broadband_cost": {
+                    "2023": 0
+                },
+                "broadband_cost_after_lifeline": {
+                    "2023": null
+                },
+                "ccdf_income": {
+                    "2023": null
+                },
+                "ccdf_income_to_smi_ratio": {
+                    "2023": null
+                },
+                "childcare_expenses": {
+                    "2023": 0
+                },
+                "co_tanf": {
+                    "2023": null
+                },
+                "co_tanf_count_children": {
+                    "2023": null
+                },
+                "co_tanf_countable_earned_income_grant_standard": {
+                    "2023": null
+                },
+                "co_tanf_countable_earned_income_need": {
+                    "2023": null
+                },
+                "co_tanf_countable_gross_earned_income": {
+                    "2023": null
+                },
+                "co_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "co_tanf_eligible": {
+                    "2023": null
+                },
+                "co_tanf_grant_standard": {
+                    "2023": null
+                },
+                "co_tanf_income_eligible": {
+                    "2023": null
+                },
+                "co_tanf_need_standard": {
+                    "2023": null
+                },
+                "count_distinct_utility_expenses": {
+                    "2023": null
+                },
+                "dc_tanf": {
+                    "2023": null
+                },
+                "dc_tanf_countable_earned_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "dc_tanf_eligible": {
+                    "2023": null
+                },
+                "dc_tanf_grant_standard": {
+                    "2023": null
+                },
+                "dc_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "dc_tanf_income_eligible": {
+                    "2023": null
+                },
+                "dc_tanf_need_standard": {
+                    "2023": null
+                },
+                "dc_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "deep_poverty_gap": {
+                    "2023": null
+                },
+                "deep_poverty_line": {
+                    "2023": null
+                },
+                "ebb": {
+                    "2023": null
+                },
+                "electricity_expense": {
+                    "2023": 0
+                },
+                "enrolled_in_ebb": {
+                    "2023": false
+                },
+                "experienced_covid_income_loss": {
+                    "2023": false
+                },
+                "fcc_fpg_ratio": {
+                    "2023": null
+                },
+                "fdpir": {
+                    "2023": 0
+                },
+                "free_school_meals": {
+                    "2023": null
+                },
+                "free_school_meals_reported": {
+                    "2023": 0
+                },
+                "gas_expense": {
+                    "2023": 0
+                },
+                "has_all_usda_elderly_disabled": {
+                    "2023": null
+                },
+                "has_heating_cooling_expense": {
+                    "2023": null
+                },
+                "has_phone_expense": {
+                    "2023": null
+                },
+                "has_usda_elderly_disabled": {
+                    "2023": null
+                },
+                "heating_cooling_expense": {
+                    "2023": 0
+                },
+                "hhs_smi": {
+                    "2023": null
+                },
+                "housing_assistance": {
+                    "2023": null
+                },
+                "housing_cost": {
+                    "2023": null
+                },
+                "housing_designated_welfare": {
+                    "2023": 0
+                },
+                "hud_adjusted_income": {
+                    "2023": null
+                },
+                "hud_annual_income": {
+                    "2023": null
+                },
+                "hud_gross_rent": {
+                    "2023": null
+                },
+                "hud_hap": {
+                    "2023": null
+                },
+                "hud_income_level": {
+                    "2023": null
+                },
+                "hud_max_subsidy": {
+                    "2023": null
+                },
+                "hud_minimum_rent": {
+                    "2023": 0
+                },
+                "hud_ttp": {
+                    "2023": null
+                },
+                "hud_ttp_adjusted_income_share": {
+                    "2023": null
+                },
+                "hud_ttp_income_share": {
+                    "2023": null
+                },
+                "hud_utility_allowance": {
+                    "2023": 0
+                },
+                "in_deep_poverty": {
+                    "2023": null
+                },
+                "in_poverty": {
+                    "2023": null
+                },
+                "is_acp_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_asset_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_continuous_income_eligible": {
+                    "2023": false
+                },
+                "is_ccdf_income_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_initial_income_eligible": {
+                    "2023": false
+                },
+                "is_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_ebb_eligible": {
+                    "2023": null
+                },
+                "is_eligible_for_housing_assistance": {
+                    "2023": null
+                },
+                "is_hud_elderly_disabled_family": {
+                    "2023": null
+                },
+                "is_lifeline_eligible": {
+                    "2023": null
+                },
+                "is_snap_eligible": {
+                    "2023": null
+                },
+                "is_tanf_continuous_eligible": {
+                    "2023": null
+                },
+                "is_tanf_eligible": {
+                    "2023": null
+                },
+                "is_tanf_enrolled": {
+                    "2023": false
+                },
+                "is_tanf_initial_eligible": {
+                    "2023": null
+                },
+                "is_tanf_non_cash_eligible": {
+                    "2023": null
+                },
+                "is_tanf_non_cash_hheod": {
+                    "2023": null
+                },
+                "lifeline": {
+                    "2023": null
+                },
+                "md_tanf_count_children": {
+                    "2023": null
+                },
+                "md_tanf_eligible": {
+                    "2023": false
+                },
+                "md_tanf_gross_earned_income_deduction": {
+                    "2023": null
+                },
+                "md_tanf_maximum_benefit": {
+                    "2023": null
+                },
+                "meets_ccdf_activity_test": {
+                    "2023": false
+                },
+                "meets_school_meal_categorical_eligibility": {
+                    "2023": null
+                },
+                "meets_snap_asset_test": {
+                    "2023": null
+                },
+                "meets_snap_categorical_eligibility": {
+                    "2023": null
+                },
+                "meets_snap_gross_income_test": {
+                    "2023": null
+                },
+                "meets_snap_net_income_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_asset_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_gross_income_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_net_income_test": {
+                    "2023": null
+                },
+                "meets_wic_income_test": {
+                    "2023": null
+                },
+                "mo_tanf_income_limit": {
+                    "2023": null
+                },
+                "nj_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "nj_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "nj_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "nj_tanf_maximum_allowable_income": {
+                    "2023": null
+                },
+                "nj_tanf_maximum_benefit": {
+                    "2023": null
+                },
+                "nj_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "ny_tanf": {
+                    "2023": null
+                },
+                "ny_tanf_countable_earned_income": {
+                    "2023": null
+                },
+                "ny_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "ny_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "ny_tanf_eligible": {
+                    "2023": null
+                },
+                "ny_tanf_grant_standard": {
+                    "2023": null
+                },
+                "ny_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "ny_tanf_income_eligible": {
+                    "2023": null
+                },
+                "ny_tanf_need_standard": {
+                    "2023": null
+                },
+                "ny_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "ok_tanf": {
+                    "2023": 0
+                },
+                "pell_grant": {
+                    "2023": 0
+                },
+                "pha_payment_standard": {
+                    "2023": 0
+                },
+                "phone_cost": {
+                    "2023": 0
+                },
+                "phone_expense": {
+                    "2023": null
+                },
+                "poverty_gap": {
+                    "2023": null
+                },
+                "poverty_line": {
+                    "2023": null
+                },
+                "receives_housing_assistance": {
+                    "2023": false
+                },
+                "reduced_price_school_meals": {
+                    "2023": null
+                },
+                "school_meal_countable_income": {
+                    "2023": null
+                },
+                "school_meal_daily_subsidy": {
+                    "2023": null
+                },
+                "school_meal_fpg_ratio": {
+                    "2023": null
+                },
+                "school_meal_net_subsidy": {
+                    "2023": null
+                },
+                "school_meal_paid_daily_subsidy": {
+                    "2023": null
+                },
+                "school_meal_tier": {
+                    "2023": null
+                },
+                "sewage_expense": {
+                    "2023": 0
+                },
+                "snap": {
+                    "2023": null
+                },
+                "snap_assets": {
+                    "2023": 0
+                },
+                "snap_child_support_deduction": {
+                    "2023": null
+                },
+                "snap_deductions": {
+                    "2023": null
+                },
+                "snap_dependent_care_deduction": {
+                    "2023": null
+                },
+                "snap_earned_income": {
+                    "2023": null
+                },
+                "snap_earned_income_deduction": {
+                    "2023": null
+                },
+                "snap_emergency_allotment": {
+                    "2023": null
+                },
+                "snap_excess_medical_expense_deduction": {
+                    "2023": null
+                },
+                "snap_excess_shelter_expense_deduction": {
+                    "2023": null
+                },
+                "snap_expected_contribution": {
+                    "2023": null
+                },
+                "snap_gross_income": {
+                    "2023": null
+                },
+                "snap_gross_income_fpg_ratio": {
+                    "2023": null
+                },
+                "snap_max_allotment": {
+                    "2023": null
+                },
+                "snap_min_allotment": {
+                    "2023": null
+                },
+                "snap_net_income": {
+                    "2023": null
+                },
+                "snap_net_income_fpg_ratio": {
+                    "2023": null
+                },
+                "snap_net_income_pre_shelter": {
+                    "2023": null
+                },
+                "snap_normal_allotment": {
+                    "2023": null
+                },
+                "snap_reported": {
+                    "2023": 0
+                },
+                "snap_standard_deduction": {
+                    "2023": null
+                },
+                "snap_unearned_income": {
+                    "2023": null
+                },
+                "snap_utility_allowance": {
+                    "2023": null
+                },
+                "snap_utility_allowance_type": {
+                    "2023": null
+                },
+                "spm_unit_assets": {
+                    "2023": 0
+                },
+                "spm_unit_benefits": {
+                    "2023": null
+                },
+                "spm_unit_capped_housing_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_capped_housing_subsidy_reported": {
+                    "2023": 0
+                },
+                "spm_unit_capped_work_childcare_expenses": {
+                    "2023": 0
+                },
+                "spm_unit_ccdf_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_count_adults": {
+                    "2023": null
+                },
+                "spm_unit_count_children": {
+                    "2023": null
+                },
+                "spm_unit_energy_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_energy_subsidy_reported": {
+                    "2023": 0
+                },
+                "spm_unit_federal_tax": {
+                    "2023": null
+                },
+                "spm_unit_federal_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_fpg": {
+                    "2023": null
+                },
+                "spm_unit_id": {
+                    "2023": 0
+                },
+                "spm_unit_income_decile": {
+                    "2023": null
+                },
+                "spm_unit_is_in_deep_spm_poverty": {
+                    "2023": null
+                },
+                "spm_unit_is_in_spm_poverty": {
+                    "2023": null
+                },
+                "spm_unit_market_income": {
+                    "2023": null
+                },
+                "spm_unit_medical_expenses": {
+                    "2023": null
+                },
+                "spm_unit_net_income": {
+                    "2023": null
+                },
+                "spm_unit_net_income_reported": {
+                    "2023": 0
+                },
+                "spm_unit_oecd_equiv_net_income": {
+                    "2023": null
+                },
+                "spm_unit_payroll_tax": {
+                    "2023": null
+                },
+                "spm_unit_payroll_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_school_lunch_subsidy": {
+                    "2023": 0
+                },
+                "spm_unit_self_employment_tax": {
+                    "2023": null
+                },
+                "spm_unit_size": {
+                    "2023": null
+                },
+                "spm_unit_snap": {
+                    "2023": 0
+                },
+                "spm_unit_spm_threshold": {
+                    "2023": 0
+                },
+                "spm_unit_state_fips": {
+                    "2023": null
+                },
+                "spm_unit_state_tax": {
+                    "2023": null
+                },
+                "spm_unit_state_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_taxes": {
+                    "2023": null
+                },
+                "spm_unit_total_ccdf_copay": {
+                    "2023": null
+                },
+                "spm_unit_total_income_reported": {
+                    "2023": 0
+                },
+                "spm_unit_weight": {
+                    "2023": null
+                },
+                "spm_unit_wic": {
+                    "2023": null
+                },
+                "spm_unit_wic_reported": {
+                    "2023": 0
+                },
+                "tanf": {
+                    "2023": null
+                },
+                "tanf_amount_if_eligible": {
+                    "2023": null
+                },
+                "tanf_countable_income": {
+                    "2023": null
+                },
+                "tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "tanf_gross_unearned_income": {
+                    "2023": null
+                },
+                "tanf_initial_employment_deduction": {
+                    "2023": null
+                },
+                "tanf_max_amount": {
+                    "2023": null
+                },
+                "trash_expense": {
+                    "2023": 0
+                },
+                "tx_tanf_income_limit": {
+                    "2023": null
+                },
+                "utility_expense": {
+                    "2023": null
+                },
+                "wa_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "wa_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "water_expense": {
+                    "2023": 0
+                },
+                "wic_fpg": {
+                    "2023": null
+                }
+            }
+        },
+        "households": {
+            "your household": {
+                "members": [
+                    "you"
+                ],
+                "AK": {
+                    "2023": null
+                },
+                "AL": {
+                    "2023": null
+                },
+                "AR": {
+                    "2023": null
+                },
+                "AZ": {
+                    "2023": null
+                },
+                "CA": {
+                    "2023": null
+                },
+                "CO": {
+                    "2023": null
+                },
+                "CT": {
+                    "2023": null
+                },
+                "DC": {
+                    "2023": null
+                },
+                "DE": {
+                    "2023": null
+                },
+                "FL": {
+                    "2023": null
+                },
+                "GA": {
+                    "2023": null
+                },
+                "HI": {
+                    "2023": null
+                },
+                "IA": {
+                    "2023": null
+                },
+                "ID": {
+                    "2023": null
+                },
+                "IL": {
+                    "2023": null
+                },
+                "IN": {
+                    "2023": null
+                },
+                "KS": {
+                    "2023": null
+                },
+                "KY": {
+                    "2023": null
+                },
+                "LA": {
+                    "2023": null
+                },
+                "MA": {
+                    "2023": null
+                },
+                "MD": {
+                    "2023": null
+                },
+                "ME": {
+                    "2023": null
+                },
+                "MI": {
+                    "2023": null
+                },
+                "MN": {
+                    "2023": null
+                },
+                "MO": {
+                    "2023": null
+                },
+                "MS": {
+                    "2023": null
+                },
+                "MT": {
+                    "2023": null
+                },
+                "NC": {
+                    "2023": null
+                },
+                "ND": {
+                    "2023": null
+                },
+                "NE": {
+                    "2023": null
+                },
+                "NH": {
+                    "2023": null
+                },
+                "NJ": {
+                    "2023": null
+                },
+                "NM": {
+                    "2023": null
+                },
+                "NV": {
+                    "2023": null
+                },
+                "NY": {
+                    "2023": null
+                },
+                "OH": {
+                    "2023": null
+                },
+                "OK": {
+                    "2023": null
+                },
+                "OR": {
+                    "2023": null
+                },
+                "PA": {
+                    "2023": null
+                },
+                "RI": {
+                    "2023": null
+                },
+                "SC": {
+                    "2023": null
+                },
+                "SD": {
+                    "2023": null
+                },
+                "TN": {
+                    "2023": null
+                },
+                "TX": {
+                    "2023": null
+                },
+                "UT": {
+                    "2023": null
+                },
+                "VA": {
+                    "2023": null
+                },
+                "VT": {
+                    "2023": null
+                },
+                "WA": {
+                    "2023": null
+                },
+                "WI": {
+                    "2023": null
+                },
+                "WV": {
+                    "2023": null
+                },
+                "WY": {
+                    "2023": null
+                },
+                "average_home_energy_use_in_state": {
+                    "2023": 0
+                },
+                "ca_care": {
+                    "2023": null
+                },
+                "ca_care_amount_if_eligible": {
+                    "2023": null
+                },
+                "ca_care_categorically_eligible": {
+                    "2023": null
+                },
+                "ca_care_eligible": {
+                    "2023": null
+                },
+                "ca_care_income_eligible": {
+                    "2023": null
+                },
+                "ca_care_poverty_line": {
+                    "2023": null
+                },
+                "ca_fera": {
+                    "2023": null
+                },
+                "ca_fera_amount_if_eligible": {
+                    "2023": null
+                },
+                "ca_fera_eligible": {
+                    "2023": null
+                },
+                "ccdf_county_cluster": {
+                    "2023": null
+                },
+                "county": {
+                    "2023": null
+                },
+                "county_fips": {
+                    "2023": 0
+                },
+                "county_str": {
+                    "2023": null
+                },
+                "current_home_energy_use": {
+                    "2023": 0
+                },
+                "equiv_household_net_income": {
+                    "2023": null
+                },
+                "fips": {
+                    "2023": 6
+                },
+                "household_benefits": {
+                    "2023": null
+                },
+                "household_count_people": {
+                    "2023": null
+                },
+                "household_id": {
+                    "2023": 0
+                },
+                "household_income_ami_ratio": {
+                    "2023": 0
+                },
+                "household_income_decile": {
+                    "2023": null
+                },
+                "household_market_income": {
+                    "2023": null
+                },
+                "household_net_income": {
+                    "2023": null
+                },
+                "household_refundable_tax_credits": {
+                    "2023": null
+                },
+                "household_size": {
+                    "2023": null
+                },
+                "household_tax": {
+                    "2023": null
+                },
+                "household_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "household_vehicles_owned": {
+                    "2023": 0
+                },
+                "household_weight": {
+                    "2023": 0
+                },
+                "in_nyc": {
+                    "2023": false
+                },
+                "is_homeless": {
+                    "2023": false
+                },
+                "is_on_tribal_land": {
+                    "2023": false
+                },
+                "is_rural": {
+                    "2023": false
+                },
+                "medicaid_rating_area": {
+                    "2023": null
+                },
+                "snap_region": {
+                    "2023": null
+                },
+                "snap_region_str": {
+                    "2023": null
+                },
+                "snap_utility_region": {
+                    "2023": null
+                },
+                "snap_utility_region_str": {
+                    "2023": null
+                },
+                "state_code": {
+                    "2023": null
+                },
+                "state_code_str": {
+                    "2023": null
+                },
+                "state_fips": {
+                    "2023": 6
+                },
+                "state_group": {
+                    "2023": null
+                },
+                "state_group_str": {
+                    "2023": null
+                },
+                "state_living_arrangement": {
+                    "2023": "FULL_COST"
+                },
+                "state_name": {
+                    "2023": null
+                },
+                "three_digit_zip_code": {
+                    "2023": null
+                },
+                "zip_code": {
+                    "2023": null
+                }
+            }
+        },
+        "axes": [
+            [
+                {
+                    "name": "employment_income",
+                    "period": "2023",
+                    "min": 0,
+                    "max": 200000,
+                    "count": 401
+                }
+            ]
+        ]
+    },
+    "policy": {
+        "gov.irs.income.exemption.amount": {
+            "2023-01-01.2028-12-31": "100"
+        }
+    }
+}

--- a/tests/python/data/calculate_us_2_data.json
+++ b/tests/python/data/calculate_us_2_data.json
@@ -1,0 +1,4613 @@
+{
+    "household": {
+        "people": {
+            "you": {
+                "age": {
+                    "2023": 40
+                },
+                "adult_index": {
+                    "2023": null
+                },
+                "age_group": {
+                    "2023": null
+                },
+                "alimony_expense": {
+                    "2023": 0
+                },
+                "alimony_income": {
+                    "2023": 0
+                },
+                "assessed_property_value": {
+                    "2023": 0
+                },
+                "business_is_qualified": {
+                    "2023": false
+                },
+                "business_is_sstb": {
+                    "2023": false
+                },
+                "ca_cvrp": {
+                    "2023": null
+                },
+                "ca_cvrp_vehicle_rebate_amount": {
+                    "2023": 0
+                },
+                "ca_is_qualifying_child_for_caleitc": {
+                    "2023": null
+                },
+                "capital_gains": {
+                    "2023": null
+                },
+                "capital_loss": {
+                    "2023": null
+                },
+                "casualty_loss": {
+                    "2023": 0
+                },
+                "ccdf_age_group": {
+                    "2023": null
+                },
+                "ccdf_duration_of_care": {
+                    "2023": null
+                },
+                "ccdf_market_rate": {
+                    "2023": null
+                },
+                "cdcc_qualified_dependent": {
+                    "2023": null
+                },
+                "charitable_cash_donations": {
+                    "2023": 0
+                },
+                "charitable_non_cash_donations": {
+                    "2023": 0
+                },
+                "child_support_expense": {
+                    "2023": 0
+                },
+                "child_support_received": {
+                    "2023": 0
+                },
+                "childcare_days_per_week": {
+                    "2023": 0
+                },
+                "childcare_hours_per_day": {
+                    "2023": 0
+                },
+                "childcare_hours_per_week": {
+                    "2023": null
+                },
+                "childcare_provider_type_group": {
+                    "2023": "DCC_SACC"
+                },
+                "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+                    "2023": false
+                },
+                "cliff_evaluated": {
+                    "2023": null
+                },
+                "cliff_gap": {
+                    "2023": null
+                },
+                "cmbtp": {
+                    "2023": 0
+                },
+                "co_oap": {
+                    "2023": null
+                },
+                "co_oap_eligible": {
+                    "2023": null
+                },
+                "co_state_supplement": {
+                    "2023": null
+                },
+                "co_state_supplement_eligible": {
+                    "2023": null
+                },
+                "count_days_postpartum": {
+                    "2023": null
+                },
+                "cps_race": {
+                    "2023": 0
+                },
+                "ctc_adult_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum_arpa": {
+                    "2023": null
+                },
+                "ctc_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_qualifying_child": {
+                    "2023": null
+                },
+                "debt_relief": {
+                    "2023": 0
+                },
+                "disability_benefits": {
+                    "2023": 0
+                },
+                "dividend_income": {
+                    "2023": null
+                },
+                "e00200": {
+                    "2023": null
+                },
+                "e00300": {
+                    "2023": null
+                },
+                "e02300": {
+                    "2023": 0
+                },
+                "e02400": {
+                    "2023": null
+                },
+                "e87530": {
+                    "2023": 0
+                },
+                "early_withdrawal_penalty": {
+                    "2023": 0
+                },
+                "earned": {
+                    "2023": null
+                },
+                "earned_income": {
+                    "2023": null
+                },
+                "educator_expense": {
+                    "2023": 0
+                },
+                "employee_medicare_tax": {
+                    "2023": null
+                },
+                "employee_social_security_tax": {
+                    "2023": null
+                },
+                "employment_income": {
+                    "2023": null
+                },
+                "farm_income": {
+                    "2023": 0
+                },
+                "farm_rent_income": {
+                    "2023": 0
+                },
+                "general_assistance": {
+                    "2023": 0
+                },
+                "gi_cash_assistance": {
+                    "2023": 0
+                },
+                "has_disabled_spouse": {
+                    "2023": null
+                },
+                "has_marketplace_health_coverage": {
+                    "2023": true
+                },
+                "health_insurance_premiums": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_indiv": {
+                    "2023": null
+                },
+                "ia_alternate_tax_joint": {
+                    "2023": null
+                },
+                "ia_amt_indiv": {
+                    "2023": null
+                },
+                "ia_amt_joint": {
+                    "2023": null
+                },
+                "ia_base_tax_indiv": {
+                    "2023": null
+                },
+                "ia_base_tax_joint": {
+                    "2023": null
+                },
+                "ia_basic_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_basic_deduction_joint": {
+                    "2023": null
+                },
+                "ia_fedtax_deduction": {
+                    "2023": null
+                },
+                "ia_gross_income": {
+                    "2023": null
+                },
+                "ia_income_adjustments": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_indiv": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_joint": {
+                    "2023": null
+                },
+                "ia_net_income": {
+                    "2023": null
+                },
+                "ia_pension_exclusion": {
+                    "2023": null
+                },
+                "ia_prorate_fraction": {
+                    "2023": null
+                },
+                "ia_qbi_deduction": {
+                    "2023": null
+                },
+                "ia_regular_tax_indiv": {
+                    "2023": null
+                },
+                "ia_regular_tax_joint": {
+                    "2023": null
+                },
+                "ia_standard_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_standard_deduction_joint": {
+                    "2023": null
+                },
+                "ia_taxable_income_indiv": {
+                    "2023": null
+                },
+                "ia_taxable_income_joint": {
+                    "2023": null
+                },
+                "illicit_income": {
+                    "2023": 0
+                },
+                "in_is_qualifying_dependent_child": {
+                    "2023": null
+                },
+                "incapable_of_self_care": {
+                    "2023": false
+                },
+                "income_decile": {
+                    "2023": null
+                },
+                "interest_expense": {
+                    "2023": 0
+                },
+                "interest_income": {
+                    "2023": null
+                },
+                "ira_contributions": {
+                    "2023": 0
+                },
+                "irs_gross_income": {
+                    "2023": null
+                },
+                "is_adult": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_blind": {
+                    "2023": false
+                },
+                "is_breastfeeding": {
+                    "2023": false
+                },
+                "is_ca_cvrp_increased_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ca_cvrp_normal_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_age_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_home_based": {
+                    "2023": null
+                },
+                "is_ccdf_reason_for_care_eligible": {
+                    "2023": null
+                },
+                "is_cdcc_eligible": {
+                    "2023": null
+                },
+                "is_child": {
+                    "2023": null
+                },
+                "is_child_of_tax_head": {
+                    "2023": null
+                },
+                "is_citizen": {
+                    "2023": false
+                },
+                "is_disabled": {
+                    "2023": false
+                },
+                "is_eitc_qualifying_child": {
+                    "2023": null
+                },
+                "is_eligible_for_american_opportunity_credit": {
+                    "2023": false
+                },
+                "is_enrolled_in_ccdf": {
+                    "2023": false
+                },
+                "is_father": {
+                    "2023": null
+                },
+                "is_female": {
+                    "2023": false
+                },
+                "is_full_time_college_student": {
+                    "2023": false
+                },
+                "is_full_time_student": {
+                    "2023": null
+                },
+                "is_fully_disabled_service_connected_veteran": {
+                    "2023": false
+                },
+                "is_hispanic": {
+                    "2023": false
+                },
+                "is_in_k12_nonpublic_school": {
+                    "2023": false
+                },
+                "is_in_k12_school": {
+                    "2023": null
+                },
+                "is_in_medicaid_medically_needy_category": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_male": {
+                    "2023": null
+                },
+                "is_medicaid_eligible": {
+                    "2023": null
+                },
+                "is_medically_needy_for_medicaid": {
+                    "2023": null
+                },
+                "is_mother": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_on_cliff": {
+                    "2023": null
+                },
+                "is_optional_senior_or_disabled_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_permanently_and_totally_disabled": {
+                    "2023": false
+                },
+                "is_permanently_disabled_veteran": {
+                    "2023": false
+                },
+                "is_person_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_pregnant": {
+                    "2023": false
+                },
+                "is_pregnant_for_medicaid": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_retired": {
+                    "2023": null
+                },
+                "is_self_employed": {
+                    "2023": false
+                },
+                "is_senior": {
+                    "2023": null
+                },
+                "is_severely_disabled": {
+                    "2023": false
+                },
+                "is_ssi_aged": {
+                    "2023": null
+                },
+                "is_ssi_aged_blind_disabled": {
+                    "2023": null
+                },
+                "is_ssi_disabled": {
+                    "2023": null
+                },
+                "is_ssi_eligible_individual": {
+                    "2023": null
+                },
+                "is_ssi_eligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_child": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_parent": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_recipient_for_medicaid": {
+                    "2023": null
+                },
+                "is_surviving_child_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_surviving_spouse_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_tax_unit_dependent": {
+                    "2023": null
+                },
+                "is_tax_unit_head": {
+                    "2023": null
+                },
+                "is_tax_unit_spouse": {
+                    "2023": null
+                },
+                "is_usda_disabled": {
+                    "2023": null
+                },
+                "is_usda_elderly": {
+                    "2023": null
+                },
+                "is_wa_adult": {
+                    "2023": null
+                },
+                "is_wic_at_nutritional_risk": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "k1bx14": {
+                    "2023": 0
+                },
+                "long_term_capital_gains": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_collectibles": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_small_business_stock": {
+                    "2023": 0
+                },
+                "long_term_capital_losses": {
+                    "2023": 0
+                },
+                "ma_covid_19_essential_employee_premium_pay_program": {
+                    "2023": null
+                },
+                "marginal_tax_rate": {
+                    "2023": null
+                },
+                "market_income": {
+                    "2023": null
+                },
+                "maximum_state_supplement": {
+                    "2023": null
+                },
+                "md_pension_subtraction_amount": {
+                    "2023": null
+                },
+                "md_socsec_subtraction_amount": {
+                    "2023": null
+                },
+                "medicaid": {
+                    "2023": null
+                },
+                "medicaid_benefit_value": {
+                    "2023": null
+                },
+                "medicaid_category": {
+                    "2023": null
+                },
+                "medicaid_income_level": {
+                    "2023": null
+                },
+                "medical_expense": {
+                    "2023": null
+                },
+                "medical_out_of_pocket_expenses": {
+                    "2023": 0
+                },
+                "meets_ssi_resource_test": {
+                    "2023": null
+                },
+                "meets_wic_categorical_eligibility": {
+                    "2023": null
+                },
+                "military_basic_pay": {
+                    "2023": 0
+                },
+                "military_retirement_pay": {
+                    "2023": 0
+                },
+                "military_service_income": {
+                    "2023": 0
+                },
+                "miscellaneous_income": {
+                    "2023": 0
+                },
+                "mo_adjusted_gross_income": {
+                    "2023": null
+                },
+                "mo_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mo_income_tax_exempt": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_a": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_b": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_c": {
+                    "2023": null
+                },
+                "mo_qualified_health_insurance_premiums": {
+                    "2023": null
+                },
+                "mo_taxable_income": {
+                    "2023": null
+                },
+                "net_income": {
+                    "2023": 0
+                },
+                "non_qualified_dividend_income": {
+                    "2023": 0
+                },
+                "non_sch_d_capital_gains": {
+                    "2023": 0
+                },
+                "oh_has_not_taken_oh_lump_sum_credits": {
+                    "2023": false
+                },
+                "own_children_in_household": {
+                    "2023": 0
+                },
+                "pa_nontaxable_pension_income": {
+                    "2023": null
+                },
+                "partnership_s_corp_income": {
+                    "2023": 0
+                },
+                "payroll_tax_gross_wages": {
+                    "2023": null
+                },
+                "pencon": {
+                    "2023": 0
+                },
+                "pension_contributions": {
+                    "2023": null
+                },
+                "pension_income": {
+                    "2023": null
+                },
+                "people": {
+                    "2023": 1
+                },
+                "per_vehicle_payment": {
+                    "2023": null
+                },
+                "person_family_id": {
+                    "2023": 0
+                },
+                "person_household_id": {
+                    "2023": 0
+                },
+                "person_id": {
+                    "2023": null
+                },
+                "person_in_poverty": {
+                    "2023": null
+                },
+                "person_marital_unit_id": {
+                    "2023": 0
+                },
+                "person_spm_unit_id": {
+                    "2023": 0
+                },
+                "person_tax_unit_id": {
+                    "2023": 0
+                },
+                "person_weight": {
+                    "2023": null
+                },
+                "private_pension_income": {
+                    "2023": null
+                },
+                "public_pension_income": {
+                    "2023": null
+                },
+                "qbid_amount": {
+                    "2023": null
+                },
+                "qualified_adoption_assistance_expense": {
+                    "2023": 0
+                },
+                "qualified_business_income": {
+                    "2023": null
+                },
+                "qualified_dividend_income": {
+                    "2023": 0
+                },
+                "qualified_tuition_expenses": {
+                    "2023": 0
+                },
+                "qualifies_for_elderly_or_disabled_credit": {
+                    "2023": null
+                },
+                "race": {
+                    "2023": null
+                },
+                "real_estate_taxes": {
+                    "2023": 0
+                },
+                "receives_or_needs_protective_services": {
+                    "2023": false
+                },
+                "receives_wic": {
+                    "2023": false
+                },
+                "rent": {
+                    "2023": 0
+                },
+                "rental_income": {
+                    "2023": 0
+                },
+                "retired_on_total_disability": {
+                    "2023": false
+                },
+                "salt_refund_income": {
+                    "2023": 0
+                },
+                "self_employed_health_insurance_ald_person": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_premiums": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald_person": {
+                    "2023": null
+                },
+                "self_employed_pension_contributions": {
+                    "2023": 0
+                },
+                "self_employment_income": {
+                    "2023": 0
+                },
+                "self_employment_medicare_tax": {
+                    "2023": null
+                },
+                "self_employment_social_security_tax": {
+                    "2023": null
+                },
+                "self_employment_tax": {
+                    "2023": null
+                },
+                "self_employment_tax_ald_person": {
+                    "2023": null
+                },
+                "sep_simple_qualified_plan_contributions": {
+                    "2023": 0
+                },
+                "sey": {
+                    "2023": null
+                },
+                "short_term_capital_gains": {
+                    "2023": 0
+                },
+                "short_term_capital_losses": {
+                    "2023": 0
+                },
+                "social_security": {
+                    "2023": null
+                },
+                "social_security_dependents": {
+                    "2023": 0
+                },
+                "social_security_disability": {
+                    "2023": 0
+                },
+                "social_security_retirement": {
+                    "2023": 0
+                },
+                "social_security_survivors": {
+                    "2023": 0
+                },
+                "social_security_taxable_self_employment_income": {
+                    "2023": null
+                },
+                "ssi": {
+                    "2023": null
+                },
+                "ssi_amount_if_eligible": {
+                    "2023": null
+                },
+                "ssi_category": {
+                    "2023": "NONE"
+                },
+                "ssi_claim_is_joint": {
+                    "2023": null
+                },
+                "ssi_countable_income": {
+                    "2023": null
+                },
+                "ssi_countable_resources": {
+                    "2023": 0
+                },
+                "ssi_earned_income": {
+                    "2023": null
+                },
+                "ssi_earned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_ineligible_child_allocation": {
+                    "2023": null
+                },
+                "ssi_ineligible_parent_allocation": {
+                    "2023": null
+                },
+                "ssi_reported": {
+                    "2023": 0
+                },
+                "ssi_unearned_income": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_parent": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "state_or_federal_salary": {
+                    "2023": 0
+                },
+                "state_supplement": {
+                    "2023": null
+                },
+                "strike_benefits": {
+                    "2023": 0
+                },
+                "student_loan_interest": {
+                    "2023": 0
+                },
+                "tanf_person": {
+                    "2023": null
+                },
+                "tanf_reported": {
+                    "2023": 0
+                },
+                "tax_exempt_interest_income": {
+                    "2023": 0
+                },
+                "tax_exempt_pension_income": {
+                    "2023": null
+                },
+                "tax_exempt_private_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_public_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_unemployment_compensation": {
+                    "2023": null
+                },
+                "taxable_earnings_for_social_security": {
+                    "2023": null
+                },
+                "taxable_interest_income": {
+                    "2023": 0
+                },
+                "taxable_pension_income": {
+                    "2023": null
+                },
+                "taxable_private_pension_income": {
+                    "2023": 0
+                },
+                "taxable_public_pension_income": {
+                    "2023": 0
+                },
+                "taxable_self_employment_income": {
+                    "2023": null
+                },
+                "taxable_social_security": {
+                    "2023": null
+                },
+                "taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "total_disability_payments": {
+                    "2023": 0
+                },
+                "total_income": {
+                    "2023": 0
+                },
+                "unadjusted_basis_qualified_property": {
+                    "2023": 0
+                },
+                "uncapped_ssi": {
+                    "2023": null
+                },
+                "under_12_months_postpartum": {
+                    "2023": false
+                },
+                "under_60_days_postpartum": {
+                    "2023": false
+                },
+                "unemployment_compensation": {
+                    "2023": 0
+                },
+                "us_bonds_for_higher_ed": {
+                    "2023": 0
+                },
+                "vehicles_owned": {
+                    "2023": null
+                },
+                "veterans_benefits": {
+                    "2023": 0
+                },
+                "w2_wages_from_qualified_business": {
+                    "2023": 0
+                },
+                "wic": {
+                    "2023": null
+                },
+                "wic_category": {
+                    "2023": null
+                },
+                "wic_category_str": {
+                    "2023": null
+                },
+                "workers_compensation": {
+                    "2023": 0
+                },
+                "would_claim_wic": {
+                    "2023": null
+                }
+            }
+        },
+        "families": {
+            "your family": {
+                "members": [
+                    "you"
+                ],
+                "family_id": {
+                    "2023": 0
+                },
+                "family_weight": {
+                    "2023": 0
+                },
+                "is_married": {
+                    "2023": null
+                }
+            }
+        },
+        "marital_units": {
+            "your marital unit": {
+                "members": [
+                    "you"
+                ],
+                "marital_unit_id": {
+                    "2023": 0
+                },
+                "marital_unit_weight": {
+                    "2023": null
+                }
+            }
+        },
+        "tax_units": {
+            "your tax unit": {
+                "members": [
+                    "you"
+                ],
+                "a_lineno": {
+                    "2023": 0
+                },
+                "above_the_line_deductions": {
+                    "2023": null
+                },
+                "additional_medicare_tax": {
+                    "2023": null
+                },
+                "additional_standard_deduction": {
+                    "2023": null
+                },
+                "adjusted_gross_income": {
+                    "2023": null
+                },
+                "adjusted_net_capital_gain": {
+                    "2023": null
+                },
+                "advanced_main_air_circulating_fan_expenditures": {
+                    "2023": 0
+                },
+                "age_head": {
+                    "2023": null
+                },
+                "age_spouse": {
+                    "2023": null
+                },
+                "aged_blind_count": {
+                    "2023": null
+                },
+                "aged_blind_extra_standard_deduction": {
+                    "2023": null
+                },
+                "aged_head": {
+                    "2023": null
+                },
+                "aged_spouse": {
+                    "2023": null
+                },
+                "air_sealing_ventilation_expenditures": {
+                    "2023": 0
+                },
+                "al_agi": {
+                    "2023": 0
+                },
+                "al_dependent_exemption": {
+                    "2023": null
+                },
+                "al_income_tax_before_credits": {
+                    "2023": null
+                },
+                "al_personal_exemption": {
+                    "2023": null
+                },
+                "al_standard_deduction": {
+                    "2023": null
+                },
+                "al_taxable_income": {
+                    "2023": 0
+                },
+                "alternative_minimum_tax": {
+                    "2023": null
+                },
+                "american_opportunity_credit": {
+                    "2023": null
+                },
+                "amt_form_completed": {
+                    "2023": false
+                },
+                "amt_income": {
+                    "2023": null
+                },
+                "amt_non_agi_income": {
+                    "2023": 0
+                },
+                "az_standard_deduction": {
+                    "2023": null
+                },
+                "basic_income": {
+                    "2023": null
+                },
+                "basic_income_before_phase_out": {
+                    "2023": null
+                },
+                "basic_income_eligible": {
+                    "2023": null
+                },
+                "basic_income_phase_out": {
+                    "2023": null
+                },
+                "basic_standard_deduction": {
+                    "2023": null
+                },
+                "benefit_value_total": {
+                    "2023": 0
+                },
+                "biomass_stove_boiler_expenditures": {
+                    "2023": 0
+                },
+                "blind_head": {
+                    "2023": null
+                },
+                "blind_spouse": {
+                    "2023": null
+                },
+                "c01000": {
+                    "2023": null
+                },
+                "c04600": {
+                    "2023": null
+                },
+                "c05700": {
+                    "2023": 0
+                },
+                "c07100": {
+                    "2023": null
+                },
+                "c07200": {
+                    "2023": null
+                },
+                "c07230": {
+                    "2023": null
+                },
+                "c07240": {
+                    "2023": 0
+                },
+                "c07260": {
+                    "2023": 0
+                },
+                "c07300": {
+                    "2023": 0
+                },
+                "c07400": {
+                    "2023": 0
+                },
+                "c07600": {
+                    "2023": 0
+                },
+                "c08000": {
+                    "2023": 0
+                },
+                "c09600": {
+                    "2023": null
+                },
+                "c10960": {
+                    "2023": null
+                },
+                "c11070": {
+                    "2023": null
+                },
+                "c23650": {
+                    "2023": null
+                },
+                "c59660": {
+                    "2023": null
+                },
+                "c62100": {
+                    "2023": null
+                },
+                "c87668": {
+                    "2023": null
+                },
+                "ca_agi": {
+                    "2023": null
+                },
+                "ca_agi_additions": {
+                    "2023": 0
+                },
+                "ca_agi_subtractions": {
+                    "2023": null
+                },
+                "ca_cdcc": {
+                    "2023": null
+                },
+                "ca_eitc": {
+                    "2023": null
+                },
+                "ca_eitc_eligible": {
+                    "2023": null
+                },
+                "ca_exemptions": {
+                    "2023": null
+                },
+                "ca_income_tax": {
+                    "2023": null
+                },
+                "ca_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ca_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ca_itemized_deductions": {
+                    "2023": null
+                },
+                "ca_mental_health_services_tax": {
+                    "2023": null
+                },
+                "ca_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ca_refundable_credits": {
+                    "2023": null
+                },
+                "ca_renter_credit": {
+                    "2023": null
+                },
+                "ca_standard_deduction": {
+                    "2023": null
+                },
+                "ca_taxable_income": {
+                    "2023": null
+                },
+                "ca_use_tax": {
+                    "2023": null
+                },
+                "ca_yctc": {
+                    "2023": null
+                },
+                "capital_gains_28_percent_rate_gain": {
+                    "2023": null
+                },
+                "capital_gains_excluded_from_taxable_income": {
+                    "2023": null
+                },
+                "capital_gains_tax": {
+                    "2023": null
+                },
+                "capped_advanced_main_air_circulating_fan_credit": {
+                    "2023": null
+                },
+                "capped_electric_heat_pump_clothes_dryer_rebate": {
+                    "2023": null
+                },
+                "capped_electric_load_service_center_upgrade_rebate": {
+                    "2023": null
+                },
+                "capped_electric_stove_cooktop_range_or_oven_rebate": {
+                    "2023": null
+                },
+                "capped_electric_wiring_rebate": {
+                    "2023": null
+                },
+                "capped_energy_efficient_central_air_conditioner_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_door_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_insulation_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_roof_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_window_credit": {
+                    "2023": null
+                },
+                "capped_heat_pump_heat_pump_water_heater_biomass_stove_boiler_credit": {
+                    "2023": null
+                },
+                "capped_heat_pump_rebate": {
+                    "2023": null
+                },
+                "capped_heat_pump_water_heater_rebate": {
+                    "2023": null
+                },
+                "capped_home_energy_audit_credit": {
+                    "2023": null
+                },
+                "capped_insulation_air_sealing_ventilation_rebate": {
+                    "2023": null
+                },
+                "capped_qualified_furnace_or_hot_water_boiler_credit": {
+                    "2023": null
+                },
+                "care_deduction": {
+                    "2023": 0
+                },
+                "casualty_loss_deduction": {
+                    "2023": null
+                },
+                "cdcc": {
+                    "2023": null
+                },
+                "cdcc_rate": {
+                    "2023": null
+                },
+                "cdcc_relevant_expenses": {
+                    "2023": null
+                },
+                "charitable_deduction": {
+                    "2023": null
+                },
+                "charity_credit": {
+                    "2023": 0
+                },
+                "co_eitc": {
+                    "2023": null
+                },
+                "cohabitating_spouses": {
+                    "2023": false
+                },
+                "combined": {
+                    "2023": null
+                },
+                "count_cdcc_eligible": {
+                    "2023": null
+                },
+                "ctc": {
+                    "2023": null
+                },
+                "ctc_arpa_addition": {
+                    "2023": null
+                },
+                "ctc_arpa_max_addition": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out_cap": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out_threshold": {
+                    "2023": null
+                },
+                "ctc_arpa_uncapped_phase_out": {
+                    "2023": null
+                },
+                "ctc_limiting_tax_liability": {
+                    "2023": null
+                },
+                "ctc_maximum": {
+                    "2023": null
+                },
+                "ctc_maximum_with_arpa_addition": {
+                    "2023": null
+                },
+                "ctc_new": {
+                    "2023": 0
+                },
+                "ctc_phase_out": {
+                    "2023": null
+                },
+                "ctc_phase_out_threshold": {
+                    "2023": null
+                },
+                "ctc_qualifying_children": {
+                    "2023": null
+                },
+                "ctc_refundable_maximum": {
+                    "2023": null
+                },
+                "ctc_value": {
+                    "2023": null
+                },
+                "data_source": {
+                    "2023": false
+                },
+                "dc_eitc": {
+                    "2023": null
+                },
+                "dc_eitc_with_qualifying_child": {
+                    "2023": null
+                },
+                "dc_eitc_without_qualifying_child": {
+                    "2023": null
+                },
+                "dc_standard_deduction": {
+                    "2023": null
+                },
+                "disabled_head": {
+                    "2023": null
+                },
+                "disabled_spouse": {
+                    "2023": null
+                },
+                "domestic_production_ald": {
+                    "2023": 0
+                },
+                "dsi": {
+                    "2023": null
+                },
+                "dsi_spouse": {
+                    "2023": null
+                },
+                "dwks10": {
+                    "2023": null
+                },
+                "dwks13": {
+                    "2023": null
+                },
+                "dwks14": {
+                    "2023": null
+                },
+                "dwks19": {
+                    "2023": null
+                },
+                "dwks6": {
+                    "2023": null
+                },
+                "dwks9": {
+                    "2023": null
+                },
+                "e07240": {
+                    "2023": 0
+                },
+                "e07400": {
+                    "2023": 0
+                },
+                "e07600": {
+                    "2023": 0
+                },
+                "earned_income_tax_credit": {
+                    "2023": null
+                },
+                "ecpa_adult_dependent_credit": {
+                    "2023": null
+                },
+                "ecpa_filer_credit": {
+                    "2023": null
+                },
+                "education_credit_phase_out": {
+                    "2023": null
+                },
+                "education_tax_credits": {
+                    "2023": null
+                },
+                "eitc": {
+                    "2023": null
+                },
+                "eitc_agi_limit": {
+                    "2023": null
+                },
+                "eitc_child_count": {
+                    "2023": null
+                },
+                "eitc_eligible": {
+                    "2023": null
+                },
+                "eitc_maximum": {
+                    "2023": null
+                },
+                "eitc_phase_in_rate": {
+                    "2023": null
+                },
+                "eitc_phase_out_rate": {
+                    "2023": null
+                },
+                "eitc_phase_out_start": {
+                    "2023": null
+                },
+                "eitc_phased_in": {
+                    "2023": null
+                },
+                "eitc_reduction": {
+                    "2023": null
+                },
+                "eitc_relevant_investment_income": {
+                    "2023": null
+                },
+                "elderly_dependents": {
+                    "2023": 0
+                },
+                "elderly_disabled_credit": {
+                    "2023": null
+                },
+                "electric_heat_pump_clothes_dryer_expenditures": {
+                    "2023": 0
+                },
+                "electric_load_service_center_upgrade_expenditures": {
+                    "2023": 0
+                },
+                "electric_stove_cooktop_range_or_oven_expenditures": {
+                    "2023": 0
+                },
+                "electric_wiring_expenditures": {
+                    "2023": 0
+                },
+                "employee_payroll_tax": {
+                    "2023": null
+                },
+                "energy_efficient_central_air_conditioner_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_door_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_home_improvement_credit": {
+                    "2023": null
+                },
+                "energy_efficient_insulation_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_roof_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_window_expenditures": {
+                    "2023": 0
+                },
+                "excess_payroll_tax_withheld": {
+                    "2023": 0
+                },
+                "exemption_phase_out_start": {
+                    "2023": null
+                },
+                "exemptions": {
+                    "2023": null
+                },
+                "f2441": {
+                    "2023": null
+                },
+                "f6251": {
+                    "2023": false
+                },
+                "federal_eitc_without_age_minimum": {
+                    "2023": null
+                },
+                "federal_state_income_tax": {
+                    "2023": null
+                },
+                "ffpos": {
+                    "2023": 0
+                },
+                "filer_cmbtp": {
+                    "2023": null
+                },
+                "filer_e00200": {
+                    "2023": null
+                },
+                "filer_e00300": {
+                    "2023": null
+                },
+                "filer_e02300": {
+                    "2023": null
+                },
+                "filer_e18400": {
+                    "2023": null
+                },
+                "filer_earned": {
+                    "2023": null
+                },
+                "filer_k1bx14": {
+                    "2023": null
+                },
+                "filer_pencon": {
+                    "2023": null
+                },
+                "filer_sey": {
+                    "2023": null
+                },
+                "filing_status": {
+                    "2023": null
+                },
+                "flat_tax": {
+                    "2023": null
+                },
+                "foreign_earned_income_exclusion": {
+                    "2023": 0
+                },
+                "foreign_tax_credit": {
+                    "2023": 0
+                },
+                "fstax": {
+                    "2023": 0
+                },
+                "fuel_cell_property_capacity": {
+                    "2023": 0
+                },
+                "fuel_cell_property_expenditures": {
+                    "2023": 0
+                },
+                "geothermal_heat_pump_property_expenditures": {
+                    "2023": 0
+                },
+                "h_seq": {
+                    "2023": 0
+                },
+                "hasqdivltcg": {
+                    "2023": null
+                },
+                "head_earned": {
+                    "2023": null
+                },
+                "head_is_disabled": {
+                    "2023": null
+                },
+                "head_spouse_count": {
+                    "2023": null
+                },
+                "health_savings_account_ald": {
+                    "2023": 0
+                },
+                "heat_pump_expenditures": {
+                    "2023": 0
+                },
+                "heat_pump_water_heater_expenditures": {
+                    "2023": 0
+                },
+                "hi_agi": {
+                    "2023": 0
+                },
+                "hi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "hi_standard_deduction": {
+                    "2023": null
+                },
+                "hi_taxable_income": {
+                    "2023": 0
+                },
+                "high_efficiency_electric_home_rebate": {
+                    "2023": null
+                },
+                "high_efficiency_electric_home_rebate_percent_covered": {
+                    "2023": null
+                },
+                "home_energy_audit_expenditures": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_unit": {
+                    "2023": null
+                },
+                "ia_cdcc": {
+                    "2023": null
+                },
+                "ia_eitc": {
+                    "2023": null
+                },
+                "ia_exemption_credit": {
+                    "2023": null
+                },
+                "ia_files_separately": {
+                    "2023": null
+                },
+                "ia_income_tax": {
+                    "2023": null
+                },
+                "ia_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ia_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ia_income_tax_indiv": {
+                    "2023": null
+                },
+                "ia_income_tax_joint": {
+                    "2023": null
+                },
+                "ia_is_tax_exempt": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_unit": {
+                    "2023": null
+                },
+                "ia_modified_income": {
+                    "2023": null
+                },
+                "ia_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ia_reduced_tax": {
+                    "2023": null
+                },
+                "ia_refundable_credits": {
+                    "2023": null
+                },
+                "ia_reportable_social_security": {
+                    "2023": null
+                },
+                "iitax": {
+                    "2023": null
+                },
+                "il_aged_blind_exemption": {
+                    "2023": null
+                },
+                "il_base_income": {
+                    "2023": null
+                },
+                "il_base_income_additions": {
+                    "2023": null
+                },
+                "il_base_income_subtractions": {
+                    "2023": null
+                },
+                "il_dependent_exemption": {
+                    "2023": null
+                },
+                "il_eitc": {
+                    "2023": null
+                },
+                "il_income_tax": {
+                    "2023": null
+                },
+                "il_income_tax_before_nonrefundable_credits": {
+                    "2023": null
+                },
+                "il_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "il_is_exemption_eligible": {
+                    "2023": null
+                },
+                "il_k12_education_expense_credit": {
+                    "2023": null
+                },
+                "il_nonrefundable_credits": {
+                    "2023": null
+                },
+                "il_pass_through_entity_tax_credit": {
+                    "2023": 0
+                },
+                "il_pass_through_withholding": {
+                    "2023": 0
+                },
+                "il_personal_exemption": {
+                    "2023": null
+                },
+                "il_personal_exemption_eligibility_status": {
+                    "2023": null
+                },
+                "il_property_tax_credit": {
+                    "2023": null
+                },
+                "il_refundable_credits": {
+                    "2023": null
+                },
+                "il_schedule_m_additions": {
+                    "2023": 0
+                },
+                "il_schedule_m_subtractions": {
+                    "2023": 0
+                },
+                "il_taxable_income": {
+                    "2023": null
+                },
+                "il_total_exemptions": {
+                    "2023": null
+                },
+                "il_total_tax": {
+                    "2023": null
+                },
+                "il_use_tax": {
+                    "2023": null
+                },
+                "in_add_backs": {
+                    "2023": null
+                },
+                "in_additional_exemptions": {
+                    "2023": null
+                },
+                "in_aged_blind_exemptions": {
+                    "2023": null
+                },
+                "in_aged_low_agi_exemptions": {
+                    "2023": null
+                },
+                "in_agi": {
+                    "2023": null
+                },
+                "in_agi_tax": {
+                    "2023": null
+                },
+                "in_base_exemptions": {
+                    "2023": null
+                },
+                "in_bonus_depreciation_add_back": {
+                    "2023": 0
+                },
+                "in_deductions": {
+                    "2023": null
+                },
+                "in_exemptions": {
+                    "2023": null
+                },
+                "in_homeowners_property_tax": {
+                    "2023": 0
+                },
+                "in_homeowners_property_tax_deduction": {
+                    "2023": null
+                },
+                "in_military_service_deduction": {
+                    "2023": null
+                },
+                "in_nol": {
+                    "2023": 0
+                },
+                "in_nol_add_back": {
+                    "2023": 0
+                },
+                "in_nonpublic_school_deduction": {
+                    "2023": null
+                },
+                "in_oos_municipal_obligation_interest_add_back": {
+                    "2023": 0
+                },
+                "in_other_add_backs": {
+                    "2023": 0
+                },
+                "in_other_deductions": {
+                    "2023": 0
+                },
+                "in_other_taxes": {
+                    "2023": 0
+                },
+                "in_qualifying_child_count": {
+                    "2023": null
+                },
+                "in_renters_deduction": {
+                    "2023": null
+                },
+                "in_section_179_expense_add_back": {
+                    "2023": 0
+                },
+                "in_tax_add_back": {
+                    "2023": 0
+                },
+                "in_unemployment_compensation_deduction": {
+                    "2023": null
+                },
+                "income_tax": {
+                    "2023": null
+                },
+                "income_tax_before_credits": {
+                    "2023": null
+                },
+                "income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_capped_non_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_main_rates": {
+                    "2023": null
+                },
+                "income_tax_non_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_unavailable_non_refundable_credits": {
+                    "2023": null
+                },
+                "interest_deduction": {
+                    "2023": null
+                },
+                "investment_in_529_plan": {
+                    "2023": 0
+                },
+                "investment_income_form_4952": {
+                    "2023": 0
+                },
+                "is_eligible_md_poverty_line_credit": {
+                    "2023": null
+                },
+                "is_ma_income_tax_exempt": {
+                    "2023": null
+                },
+                "is_ptc_eligible": {
+                    "2023": null
+                },
+                "itemized_taxable_income_deductions": {
+                    "2023": null
+                },
+                "k12_tuition_and_fees": {
+                    "2023": 0
+                },
+                "ks_agi": {
+                    "2023": null
+                },
+                "ks_agi_additions": {
+                    "2023": 0
+                },
+                "ks_agi_subtractions": {
+                    "2023": null
+                },
+                "ks_cdcc": {
+                    "2023": null
+                },
+                "ks_count_exemptions": {
+                    "2023": null
+                },
+                "ks_exemptions": {
+                    "2023": null
+                },
+                "ks_fstc": {
+                    "2023": null
+                },
+                "ks_income_tax": {
+                    "2023": null
+                },
+                "ks_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ks_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ks_itemized_deductions": {
+                    "2023": null
+                },
+                "ks_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ks_nonrefundable_eitc": {
+                    "2023": null
+                },
+                "ks_refundable_credits": {
+                    "2023": null
+                },
+                "ks_refundable_eitc": {
+                    "2023": null
+                },
+                "ks_standard_deduction": {
+                    "2023": null
+                },
+                "ks_taxable_income": {
+                    "2023": null
+                },
+                "ks_total_eitc": {
+                    "2023": null
+                },
+                "ky_income_tax": {
+                    "2023": null
+                },
+                "ky_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ky_refundable_credits": {
+                    "2023": 0
+                },
+                "ky_taxable_income": {
+                    "2023": 0
+                },
+                "lifetime_learning_credit": {
+                    "2023": null
+                },
+                "local_income_tax": {
+                    "2023": null
+                },
+                "local_sales_tax": {
+                    "2023": 0
+                },
+                "loss_ald": {
+                    "2023": null
+                },
+                "ma_agi": {
+                    "2023": null
+                },
+                "ma_dependent_care_credit": {
+                    "2023": null
+                },
+                "ma_dependent_credit": {
+                    "2023": null
+                },
+                "ma_dependent_or_dependent_care_credit": {
+                    "2023": null
+                },
+                "ma_eitc": {
+                    "2023": null
+                },
+                "ma_gross_income": {
+                    "2023": null
+                },
+                "ma_income_tax": {
+                    "2023": null
+                },
+                "ma_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ma_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ma_income_tax_exemption_threshold": {
+                    "2023": null
+                },
+                "ma_limited_income_tax_credit": {
+                    "2023": null
+                },
+                "ma_non_refundable_credits": {
+                    "2023": null
+                },
+                "ma_part_a_agi": {
+                    "2023": null
+                },
+                "ma_part_a_cg_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_a_div_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_a_gross_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_capital_gains_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_dividend_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_income": {
+                    "2023": null
+                },
+                "ma_part_b_agi": {
+                    "2023": null
+                },
+                "ma_part_b_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_b_gross_income": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_before_exemption": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_deductions": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_exemption": {
+                    "2023": null
+                },
+                "ma_part_c_agi": {
+                    "2023": null
+                },
+                "ma_part_c_gross_income": {
+                    "2023": null
+                },
+                "ma_part_c_taxable_income": {
+                    "2023": null
+                },
+                "ma_refundable_credits": {
+                    "2023": null
+                },
+                "ma_scb_total_income": {
+                    "2023": null
+                },
+                "ma_senior_circuit_breaker": {
+                    "2023": null
+                },
+                "mars": {
+                    "2023": null
+                },
+                "maximum_capital_loss": {
+                    "2023": null
+                },
+                "md_aged_blind_exemptions": {
+                    "2023": null
+                },
+                "md_aged_dependent_exemption": {
+                    "2023": null
+                },
+                "md_aged_exemption": {
+                    "2023": null
+                },
+                "md_agi": {
+                    "2023": null
+                },
+                "md_blind_exemption": {
+                    "2023": null
+                },
+                "md_cdcc": {
+                    "2023": null
+                },
+                "md_ctc": {
+                    "2023": null
+                },
+                "md_deductions": {
+                    "2023": null
+                },
+                "md_dependent_care_subtraction": {
+                    "2023": null
+                },
+                "md_eitc": {
+                    "2023": null
+                },
+                "md_exemptions": {
+                    "2023": null
+                },
+                "md_income_tax": {
+                    "2023": null
+                },
+                "md_income_tax_before_credits": {
+                    "2023": null
+                },
+                "md_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "md_local_income_tax_before_credits": {
+                    "2023": null
+                },
+                "md_non_refundable_credits": {
+                    "2023": null
+                },
+                "md_non_refundable_eitc": {
+                    "2023": null
+                },
+                "md_non_single_childless_non_refundable_eitc": {
+                    "2023": null
+                },
+                "md_non_single_childless_refundable_eitc": {
+                    "2023": null
+                },
+                "md_pension_subtraction": {
+                    "2023": null
+                },
+                "md_personal_exemption": {
+                    "2023": null
+                },
+                "md_poverty_line_credit": {
+                    "2023": null
+                },
+                "md_qualifies_for_single_childless_eitc": {
+                    "2023": null
+                },
+                "md_refundable_cdcc": {
+                    "2023": null
+                },
+                "md_refundable_credits": {
+                    "2023": null
+                },
+                "md_refundable_eitc": {
+                    "2023": null
+                },
+                "md_single_childless_eitc": {
+                    "2023": null
+                },
+                "md_socsec_subtraction": {
+                    "2023": null
+                },
+                "md_standard_deduction": {
+                    "2023": null
+                },
+                "md_tax_unit_earned_income": {
+                    "2023": null
+                },
+                "md_taxable_income": {
+                    "2023": null
+                },
+                "md_total_additions": {
+                    "2023": 0
+                },
+                "md_total_personal_exemptions": {
+                    "2023": null
+                },
+                "md_total_subtractions": {
+                    "2023": null
+                },
+                "md_two_income_subtraction": {
+                    "2023": null
+                },
+                "me_agi": {
+                    "2023": null
+                },
+                "me_agi_additions": {
+                    "2023": 0
+                },
+                "me_agi_subtractions": {
+                    "2023": null
+                },
+                "me_child_care_credit": {
+                    "2023": null
+                },
+                "me_deduction": {
+                    "2023": null
+                },
+                "me_deductions": {
+                    "2023": 0
+                },
+                "me_dependent_exemption": {
+                    "2023": null
+                },
+                "me_eitc": {
+                    "2023": null
+                },
+                "me_exemptions": {
+                    "2023": null
+                },
+                "me_income_tax_before_credits": {
+                    "2023": null
+                },
+                "me_itemized_deductions": {
+                    "2023": 0
+                },
+                "me_non_refundable_child_care_credit": {
+                    "2023": null
+                },
+                "me_pension_income_deduction": {
+                    "2023": null
+                },
+                "me_personal_exemption_deduction": {
+                    "2023": null
+                },
+                "me_refundable_child_care_credit": {
+                    "2023": null
+                },
+                "me_standard_deduction": {
+                    "2023": null
+                },
+                "me_step_4_share_of_child_care_expenses": {
+                    "2023": 0
+                },
+                "me_taxable_income": {
+                    "2023": null
+                },
+                "medicaid_income": {
+                    "2023": null
+                },
+                "medical_expense_deduction": {
+                    "2023": null
+                },
+                "mi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mi_taxable_income": {
+                    "2023": 0
+                },
+                "military_disabled_head": {
+                    "2023": null
+                },
+                "military_disabled_spouse": {
+                    "2023": null
+                },
+                "min_head_spouse_earned": {
+                    "2023": null
+                },
+                "misc_deduction": {
+                    "2023": 0
+                },
+                "mn_additions": {
+                    "2023": null
+                },
+                "mn_amt": {
+                    "2023": null
+                },
+                "mn_amt_taxable_income": {
+                    "2023": null
+                },
+                "mn_basic_tax": {
+                    "2023": null
+                },
+                "mn_cdcc": {
+                    "2023": null
+                },
+                "mn_charity_subtraction": {
+                    "2023": null
+                },
+                "mn_deductions": {
+                    "2023": null
+                },
+                "mn_elderly_disabled_subtraction": {
+                    "2023": null
+                },
+                "mn_exemptions": {
+                    "2023": null
+                },
+                "mn_income_tax": {
+                    "2023": null
+                },
+                "mn_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mn_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mn_itemized_deductions": {
+                    "2023": null
+                },
+                "mn_itemizing": {
+                    "2023": null
+                },
+                "mn_marriage_credit": {
+                    "2023": null
+                },
+                "mn_nonrefundable_credits": {
+                    "2023": null
+                },
+                "mn_refundable_credits": {
+                    "2023": null
+                },
+                "mn_social_security_subtraction": {
+                    "2023": null
+                },
+                "mn_standard_deduction": {
+                    "2023": null
+                },
+                "mn_subtractions": {
+                    "2023": null
+                },
+                "mn_taxable_income": {
+                    "2023": null
+                },
+                "mn_wfc": {
+                    "2023": null
+                },
+                "mn_wfc_eligible": {
+                    "2023": null
+                },
+                "mo_federal_income_tax_deduction": {
+                    "2023": null
+                },
+                "mo_income_tax": {
+                    "2023": null
+                },
+                "mo_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mo_itemized_deductions": {
+                    "2023": null
+                },
+                "mo_net_state_income_taxes": {
+                    "2023": null
+                },
+                "mo_non_refundable_credits": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction": {
+                    "2023": null
+                },
+                "mo_property_tax_credit": {
+                    "2023": null
+                },
+                "mo_ptc_gross_income": {
+                    "2023": null
+                },
+                "mo_ptc_income_offset": {
+                    "2023": null
+                },
+                "mo_ptc_net_income": {
+                    "2023": null
+                },
+                "mo_ptc_taxunit_eligible": {
+                    "2023": null
+                },
+                "mo_refundable_credits": {
+                    "2023": null
+                },
+                "mo_wftc": {
+                    "2023": null
+                },
+                "ms_dependents_exemption": {
+                    "2023": null
+                },
+                "ms_regular_exemption": {
+                    "2023": null
+                },
+                "mt_income_tax": {
+                    "2023": null
+                },
+                "mt_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mt_refundable_credits": {
+                    "2023": 0
+                },
+                "mt_taxable_income": {
+                    "2023": 0
+                },
+                "n1820": {
+                    "2023": 0
+                },
+                "n21": {
+                    "2023": 0
+                },
+                "n24": {
+                    "2023": 0
+                },
+                "nc_income_tax": {
+                    "2023": null
+                },
+                "nc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nc_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nc_taxable_income": {
+                    "2023": 0
+                },
+                "nd_additions": {
+                    "2023": null
+                },
+                "nd_income_tax": {
+                    "2023": null
+                },
+                "nd_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nd_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nd_ltcg_subtraction": {
+                    "2023": null
+                },
+                "nd_mpc": {
+                    "2023": null
+                },
+                "nd_nonrefundable_credits": {
+                    "2023": null
+                },
+                "nd_qdiv_subtraction": {
+                    "2023": null
+                },
+                "nd_refundable_credits": {
+                    "2023": 0
+                },
+                "nd_rtrc": {
+                    "2023": null
+                },
+                "nd_subtractions": {
+                    "2023": null
+                },
+                "nd_taxable_income": {
+                    "2023": null
+                },
+                "ne_agi": {
+                    "2023": null
+                },
+                "ne_agi_additions": {
+                    "2023": 0
+                },
+                "ne_agi_subtractions": {
+                    "2023": null
+                },
+                "ne_cdcc_nonrefundable": {
+                    "2023": null
+                },
+                "ne_cdcc_refundable": {
+                    "2023": null
+                },
+                "ne_eitc": {
+                    "2023": null
+                },
+                "ne_elderly_disabled_credit": {
+                    "2023": null
+                },
+                "ne_exemptions": {
+                    "2023": null
+                },
+                "ne_income_tax": {
+                    "2023": null
+                },
+                "ne_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ne_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ne_itemized_deductions": {
+                    "2023": null
+                },
+                "ne_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ne_refundable_credits": {
+                    "2023": null
+                },
+                "ne_standard_deduction": {
+                    "2023": null
+                },
+                "ne_taxable_income": {
+                    "2023": null
+                },
+                "net_capital_gain": {
+                    "2023": null
+                },
+                "net_investment_income": {
+                    "2023": null
+                },
+                "net_investment_income_tax": {
+                    "2023": null
+                },
+                "net_long_term_capital_gain": {
+                    "2023": null
+                },
+                "net_long_term_capital_loss": {
+                    "2023": null
+                },
+                "net_short_term_capital_gain": {
+                    "2023": null
+                },
+                "net_short_term_capital_loss": {
+                    "2023": null
+                },
+                "new_clean_vehicle_battery_capacity": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_battery_components_made_in_north_america": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_battery_critical_minerals_extracted_in_trading_partner_country": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_classification": {
+                    "2023": "OTHER"
+                },
+                "new_clean_vehicle_credit": {
+                    "2023": null
+                },
+                "new_clean_vehicle_credit_eligible": {
+                    "2023": null
+                },
+                "new_clean_vehicle_msrp": {
+                    "2023": 0
+                },
+                "nh_income_tax": {
+                    "2023": null
+                },
+                "nh_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nh_refundable_credits": {
+                    "2023": 0
+                },
+                "nh_taxable_income": {
+                    "2023": null
+                },
+                "nj_agi": {
+                    "2023": null
+                },
+                "nj_agi_additions": {
+                    "2023": 0
+                },
+                "nj_agi_subtractions": {
+                    "2023": 0
+                },
+                "nj_blind_or_disabled_exemption": {
+                    "2023": null
+                },
+                "nj_cdcc": {
+                    "2023": null
+                },
+                "nj_child_tax_credit": {
+                    "2023": null
+                },
+                "nj_childless_eitc_age_eligible": {
+                    "2023": null
+                },
+                "nj_dependents_attending_college_exemption": {
+                    "2023": null
+                },
+                "nj_dependents_exemption": {
+                    "2023": null
+                },
+                "nj_eitc": {
+                    "2023": null
+                },
+                "nj_eitc_income_eligible": {
+                    "2023": null
+                },
+                "nj_homeowners_property_tax": {
+                    "2023": null
+                },
+                "nj_income_tax": {
+                    "2023": null
+                },
+                "nj_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nj_main_income_tax": {
+                    "2023": null
+                },
+                "nj_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nj_potential_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_property_tax_credit": {
+                    "2023": null
+                },
+                "nj_property_tax_credit_eligible": {
+                    "2023": null
+                },
+                "nj_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_property_tax_deduction_eligible": {
+                    "2023": null
+                },
+                "nj_refundable_credits": {
+                    "2023": null
+                },
+                "nj_regular_exemption": {
+                    "2023": null
+                },
+                "nj_senior_exemption": {
+                    "2023": null
+                },
+                "nj_taking_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_taxable_income": {
+                    "2023": null
+                },
+                "nj_taxable_income_before_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_total_deductions": {
+                    "2023": 0
+                },
+                "nj_total_exemptions": {
+                    "2023": null
+                },
+                "no_salt_income_tax": {
+                    "2023": null
+                },
+                "non_refundable_american_opportunity_credit": {
+                    "2023": null
+                },
+                "non_refundable_ctc": {
+                    "2023": null
+                },
+                "nu06": {
+                    "2023": 0
+                },
+                "nu13": {
+                    "2023": 0
+                },
+                "nu18": {
+                    "2023": 0
+                },
+                "num": {
+                    "2023": null
+                },
+                "ny_agi": {
+                    "2023": null
+                },
+                "ny_agi_additions": {
+                    "2023": 0
+                },
+                "ny_agi_subtractions": {
+                    "2023": null
+                },
+                "ny_cdcc": {
+                    "2023": null
+                },
+                "ny_cdcc_max": {
+                    "2023": null
+                },
+                "ny_cdcc_rate": {
+                    "2023": null
+                },
+                "ny_college_tuition_credit": {
+                    "2023": null
+                },
+                "ny_ctc": {
+                    "2023": null
+                },
+                "ny_deductions": {
+                    "2023": null
+                },
+                "ny_eitc": {
+                    "2023": null
+                },
+                "ny_exemptions": {
+                    "2023": null
+                },
+                "ny_household_credit": {
+                    "2023": null
+                },
+                "ny_income_tax": {
+                    "2023": null
+                },
+                "ny_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ny_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ny_itemized_deductions": {
+                    "2023": null
+                },
+                "ny_itemized_deductions_max": {
+                    "2023": null
+                },
+                "ny_itemized_deductions_reduction": {
+                    "2023": 0
+                },
+                "ny_itemizes": {
+                    "2023": null
+                },
+                "ny_main_income_tax": {
+                    "2023": null
+                },
+                "ny_non_refundable_credits": {
+                    "2023": null
+                },
+                "ny_real_property_tax_credit": {
+                    "2023": null
+                },
+                "ny_refundable_credits": {
+                    "2023": null
+                },
+                "ny_standard_deduction": {
+                    "2023": null
+                },
+                "ny_supplemental_eitc": {
+                    "2023": null
+                },
+                "ny_supplemental_tax": {
+                    "2023": null
+                },
+                "ny_taxable_income": {
+                    "2023": null
+                },
+                "nyc_cdcc": {
+                    "2023": null
+                },
+                "nyc_cdcc_age_restricted_expenses": {
+                    "2023": null
+                },
+                "nyc_cdcc_applicable_percentage": {
+                    "2023": null
+                },
+                "nyc_cdcc_eligible": {
+                    "2023": null
+                },
+                "nyc_cdcc_share_qualifying_childcare_expenses": {
+                    "2023": null
+                },
+                "nyc_eitc": {
+                    "2023": null
+                },
+                "nyc_household_credit": {
+                    "2023": null
+                },
+                "nyc_income_tax": {
+                    "2023": null
+                },
+                "nyc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nyc_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_non_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_school_credit_income": {
+                    "2023": null
+                },
+                "nyc_school_tax_credit_fixed_amount": {
+                    "2023": null
+                },
+                "nyc_school_tax_credit_rate_reduction_amount": {
+                    "2023": null
+                },
+                "nyc_taxable_income": {
+                    "2023": null
+                },
+                "nyc_unincorporated_business_credit": {
+                    "2023": 0
+                },
+                "oh_agi": {
+                    "2023": null
+                },
+                "oh_bonus_depreciation_add_back": {
+                    "2023": 0
+                },
+                "oh_federal_conformity_deductions": {
+                    "2023": 0
+                },
+                "oh_income_tax_before_credits": {
+                    "2023": null
+                },
+                "oh_income_tax_exempt": {
+                    "2023": null
+                },
+                "oh_other_add_backs": {
+                    "2023": 0
+                },
+                "oh_section_179_expense_add_back": {
+                    "2023": 0
+                },
+                "oh_taxable_income": {
+                    "2023": 0
+                },
+                "oh_uniformed_services_retirement_income_deduction": {
+                    "2023": 0
+                },
+                "ok_adjustments": {
+                    "2023": 0
+                },
+                "ok_agi": {
+                    "2023": null
+                },
+                "ok_agi_additions": {
+                    "2023": 0
+                },
+                "ok_agi_subtractions": {
+                    "2023": null
+                },
+                "ok_child_care_child_tax_credit": {
+                    "2023": null
+                },
+                "ok_count_exemptions": {
+                    "2023": null
+                },
+                "ok_eitc": {
+                    "2023": null
+                },
+                "ok_exemptions": {
+                    "2023": null
+                },
+                "ok_gross_income": {
+                    "2023": null
+                },
+                "ok_income_tax": {
+                    "2023": null
+                },
+                "ok_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ok_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ok_itemized_deductions": {
+                    "2023": null
+                },
+                "ok_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ok_ptc": {
+                    "2023": null
+                },
+                "ok_refundable_credits": {
+                    "2023": null
+                },
+                "ok_standard_deduction": {
+                    "2023": null
+                },
+                "ok_stc": {
+                    "2023": null
+                },
+                "ok_taxable_income": {
+                    "2023": null
+                },
+                "ok_use_tax": {
+                    "2023": null
+                },
+                "or_deductions": {
+                    "2023": null
+                },
+                "or_disabled_child_dependent_exemptions": {
+                    "2023": null
+                },
+                "or_eitc": {
+                    "2023": null
+                },
+                "or_exemption_credit": {
+                    "2023": null
+                },
+                "or_federal_tax_liability_subtraction": {
+                    "2023": null
+                },
+                "or_income_additions": {
+                    "2023": 0
+                },
+                "or_income_after_additions": {
+                    "2023": null
+                },
+                "or_income_after_subtractions": {
+                    "2023": null
+                },
+                "or_income_subtractions": {
+                    "2023": null
+                },
+                "or_income_tax": {
+                    "2023": null
+                },
+                "or_income_tax_before_credits": {
+                    "2023": null
+                },
+                "or_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "or_itemized_deductions": {
+                    "2023": null
+                },
+                "or_kicker": {
+                    "2023": null
+                },
+                "or_non_refundable_credits": {
+                    "2023": null
+                },
+                "or_refundable_credits": {
+                    "2023": null
+                },
+                "or_regular_exemptions": {
+                    "2023": null
+                },
+                "or_severely_disabled_exemptions": {
+                    "2023": null
+                },
+                "or_standard_deduction": {
+                    "2023": null
+                },
+                "or_tax_before_credits_in_prior_year": {
+                    "2023": 0
+                },
+                "or_taxable_income": {
+                    "2023": null
+                },
+                "other_net_gain": {
+                    "2023": 0
+                },
+                "othertaxes": {
+                    "2023": 0
+                },
+                "pa_adjusted_taxable_income": {
+                    "2023": null
+                },
+                "pa_eligibility_income": {
+                    "2023": null
+                },
+                "pa_income_tax": {
+                    "2023": null
+                },
+                "pa_income_tax_after_forgiveness": {
+                    "2023": null
+                },
+                "pa_income_tax_before_forgiveness": {
+                    "2023": null
+                },
+                "pa_tax_deductions": {
+                    "2023": 0
+                },
+                "pa_tax_forgiveness_amount": {
+                    "2023": null
+                },
+                "pa_tax_forgiveness_rate": {
+                    "2023": null
+                },
+                "pa_total_taxable_income": {
+                    "2023": null
+                },
+                "pa_use_tax": {
+                    "2023": null
+                },
+                "positive_agi": {
+                    "2023": null
+                },
+                "pre_c04600": {
+                    "2023": null
+                },
+                "premium_tax_credit": {
+                    "2023": null
+                },
+                "prior_energy_efficient_home_improvement_credits": {
+                    "2023": 0
+                },
+                "prior_energy_efficient_window_credits": {
+                    "2023": 0
+                },
+                "property_tax_primary_residence": {
+                    "2023": null
+                },
+                "ptc_phase_out_rate": {
+                    "2023": null
+                },
+                "puerto_rico_income": {
+                    "2023": 0
+                },
+                "purchased_qualifying_new_clean_vehicle": {
+                    "2023": false
+                },
+                "purchased_qualifying_used_clean_vehicle": {
+                    "2023": false
+                },
+                "qualified_battery_storage_technology_expenditures": {
+                    "2023": 0
+                },
+                "qualified_business_income_deduction": {
+                    "2023": null
+                },
+                "qualified_furnace_or_hot_water_boiler_expenditures": {
+                    "2023": 0
+                },
+                "qualified_retirement_penalty": {
+                    "2023": 0
+                },
+                "recapture_of_investment_credit": {
+                    "2023": 0
+                },
+                "recovery_rebate_credit": {
+                    "2023": null
+                },
+                "refundable_american_opportunity_credit": {
+                    "2023": null
+                },
+                "refundable_ctc": {
+                    "2023": null
+                },
+                "refundable_payroll_tax_credit": {
+                    "2023": 0
+                },
+                "regular_tax_before_credits": {
+                    "2023": null
+                },
+                "rents": {
+                    "2023": null
+                },
+                "reported_slspc": {
+                    "2023": 0
+                },
+                "residential_clean_energy_credit": {
+                    "2023": null
+                },
+                "residential_efficiency_electrification_rebate": {
+                    "2023": null
+                },
+                "residential_efficiency_electrification_retrofit_energy_savings": {
+                    "2023": 0
+                },
+                "residential_efficiency_electrification_retrofit_expenditures": {
+                    "2023": 0
+                },
+                "retirement_savings_credit": {
+                    "2023": null
+                },
+                "ri_income_tax": {
+                    "2023": null
+                },
+                "ri_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ri_refundable_credits": {
+                    "2023": 0
+                },
+                "ri_standard_deduction": {
+                    "2023": null
+                },
+                "ri_taxable_income": {
+                    "2023": 0
+                },
+                "rptc": {
+                    "2023": null
+                },
+                "rrc_arpa": {
+                    "2023": null
+                },
+                "rrc_caa": {
+                    "2023": null
+                },
+                "rrc_cares": {
+                    "2023": null
+                },
+                "salt_deduction": {
+                    "2023": null
+                },
+                "salt_refund_last_year": {
+                    "2023": 0
+                },
+                "sc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "sc_taxable_income": {
+                    "2023": 0
+                },
+                "sc_young_child_exemption": {
+                    "2023": null
+                },
+                "second_lowest_silver_plan_cost": {
+                    "2023": null
+                },
+                "section_22_income": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_ald": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald": {
+                    "2023": null
+                },
+                "self_employment_tax_ald": {
+                    "2023": null
+                },
+                "sep": {
+                    "2023": 1
+                },
+                "separate_filer_itemizes": {
+                    "2023": false
+                },
+                "small_wind_energy_property_expenditures": {
+                    "2023": 0
+                },
+                "solar_electric_property_expenditures": {
+                    "2023": 0
+                },
+                "solar_water_heating_property_expenditures": {
+                    "2023": 0
+                },
+                "specified_possession_income": {
+                    "2023": 0
+                },
+                "spouse_earned": {
+                    "2023": null
+                },
+                "spouse_is_disabled": {
+                    "2023": null
+                },
+                "spouse_separate_adjusted_gross_income": {
+                    "2023": null
+                },
+                "spouse_separate_tax_unit_size": {
+                    "2023": null
+                },
+                "standard": {
+                    "2023": null
+                },
+                "standard_deduction": {
+                    "2023": null
+                },
+                "state_and_local_sales_or_income_tax": {
+                    "2023": null
+                },
+                "state_income_tax": {
+                    "2023": null
+                },
+                "state_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "state_sales_tax": {
+                    "2023": 0
+                },
+                "surtax": {
+                    "2023": 0
+                },
+                "tax": {
+                    "2023": null
+                },
+                "tax_exempt_social_security": {
+                    "2023": null
+                },
+                "tax_liability_if_itemizing": {
+                    "2023": null
+                },
+                "tax_liability_if_not_itemizing": {
+                    "2023": null
+                },
+                "tax_unit_capital_loss": {
+                    "2023": null
+                },
+                "tax_unit_childcare_expenses": {
+                    "2023": null
+                },
+                "tax_unit_children": {
+                    "2023": null
+                },
+                "tax_unit_count_dependents": {
+                    "2023": null
+                },
+                "tax_unit_dependent_elsewhere": {
+                    "2023": false
+                },
+                "tax_unit_dependents": {
+                    "2023": null
+                },
+                "tax_unit_earned_income": {
+                    "2023": null
+                },
+                "tax_unit_fpg": {
+                    "2023": null
+                },
+                "tax_unit_id": {
+                    "2023": 0
+                },
+                "tax_unit_income_ami_ratio": {
+                    "2023": 0
+                },
+                "tax_unit_is_joint": {
+                    "2023": null
+                },
+                "tax_unit_itemizes": {
+                    "2023": null
+                },
+                "tax_unit_medicaid_income_level": {
+                    "2023": null
+                },
+                "tax_unit_net_capital_gains": {
+                    "2023": null
+                },
+                "tax_unit_partnership_s_corp_income": {
+                    "2023": null
+                },
+                "tax_unit_rental_income": {
+                    "2023": null
+                },
+                "tax_unit_size": {
+                    "2023": null
+                },
+                "tax_unit_social_security": {
+                    "2023": null
+                },
+                "tax_unit_spouse_dependent_elsewhere": {
+                    "2023": false
+                },
+                "tax_unit_ss": {
+                    "2023": null
+                },
+                "tax_unit_ssi": {
+                    "2023": null
+                },
+                "tax_unit_state": {
+                    "2023": null
+                },
+                "tax_unit_taxable_social_security": {
+                    "2023": null
+                },
+                "tax_unit_taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "tax_unit_unemployment_compensation": {
+                    "2023": null
+                },
+                "tax_unit_weight": {
+                    "2023": 0
+                },
+                "taxable_income": {
+                    "2023": null
+                },
+                "taxable_income_deductions": {
+                    "2023": null
+                },
+                "taxable_income_deductions_if_itemizing": {
+                    "2023": null
+                },
+                "taxable_income_deductions_if_not_itemizing": {
+                    "2023": null
+                },
+                "taxable_income_less_qbid": {
+                    "2023": null
+                },
+                "taxable_ss_magi": {
+                    "2023": null
+                },
+                "taxable_uc_agi": {
+                    "2023": null
+                },
+                "taxbc": {
+                    "2023": null
+                },
+                "taxcalc_c04470": {
+                    "2023": null
+                },
+                "taxcalc_c09200": {
+                    "2023": null
+                },
+                "taxcalc_c17000": {
+                    "2023": null
+                },
+                "taxcalc_c18300": {
+                    "2023": null
+                },
+                "taxcalc_c19200": {
+                    "2023": null
+                },
+                "taxcalc_c19700": {
+                    "2023": null
+                },
+                "taxcalc_c20500": {
+                    "2023": null
+                },
+                "taxcalc_cmbtp": {
+                    "2023": null
+                },
+                "taxcalc_dsi": {
+                    "2023": null
+                },
+                "taxcalc_e00200": {
+                    "2023": null
+                },
+                "taxcalc_e00300": {
+                    "2023": null
+                },
+                "taxcalc_e00400": {
+                    "2023": null
+                },
+                "taxcalc_e00600": {
+                    "2023": null
+                },
+                "taxcalc_e00650": {
+                    "2023": null
+                },
+                "taxcalc_e00700": {
+                    "2023": null
+                },
+                "taxcalc_e00800": {
+                    "2023": null
+                },
+                "taxcalc_e00900": {
+                    "2023": null
+                },
+                "taxcalc_e01100": {
+                    "2023": null
+                },
+                "taxcalc_e01200": {
+                    "2023": null
+                },
+                "taxcalc_e01500": {
+                    "2023": null
+                },
+                "taxcalc_e01700": {
+                    "2023": null
+                },
+                "taxcalc_e02000": {
+                    "2023": null
+                },
+                "taxcalc_e02100": {
+                    "2023": null
+                },
+                "taxcalc_e02300": {
+                    "2023": null
+                },
+                "taxcalc_e02400": {
+                    "2023": null
+                },
+                "taxcalc_e03150": {
+                    "2023": null
+                },
+                "taxcalc_e03210": {
+                    "2023": null
+                },
+                "taxcalc_e03220": {
+                    "2023": null
+                },
+                "taxcalc_e03230": {
+                    "2023": null
+                },
+                "taxcalc_e03240": {
+                    "2023": null
+                },
+                "taxcalc_e03270": {
+                    "2023": null
+                },
+                "taxcalc_e03290": {
+                    "2023": null
+                },
+                "taxcalc_e03300": {
+                    "2023": null
+                },
+                "taxcalc_e03400": {
+                    "2023": null
+                },
+                "taxcalc_e03500": {
+                    "2023": null
+                },
+                "taxcalc_e09700": {
+                    "2023": null
+                },
+                "taxcalc_e09800": {
+                    "2023": null
+                },
+                "taxcalc_e09900": {
+                    "2023": null
+                },
+                "taxcalc_e11200": {
+                    "2023": null
+                },
+                "taxcalc_e17500": {
+                    "2023": null
+                },
+                "taxcalc_e18500": {
+                    "2023": null
+                },
+                "taxcalc_e19200": {
+                    "2023": null
+                },
+                "taxcalc_e19800": {
+                    "2023": null
+                },
+                "taxcalc_e20100": {
+                    "2023": null
+                },
+                "taxcalc_e20400": {
+                    "2023": null
+                },
+                "taxcalc_e24515": {
+                    "2023": null
+                },
+                "taxcalc_e24518": {
+                    "2023": null
+                },
+                "taxcalc_e26270": {
+                    "2023": null
+                },
+                "taxcalc_e27200": {
+                    "2023": null
+                },
+                "taxcalc_e32800": {
+                    "2023": null
+                },
+                "taxcalc_e58990": {
+                    "2023": null
+                },
+                "taxcalc_e62900": {
+                    "2023": null
+                },
+                "taxcalc_e87530": {
+                    "2023": null
+                },
+                "taxcalc_f2441": {
+                    "2023": null
+                },
+                "taxcalc_f6251": {
+                    "2023": null
+                },
+                "taxcalc_fips": {
+                    "2023": null
+                },
+                "taxcalc_g20500": {
+                    "2023": null
+                },
+                "taxcalc_hasqdivltcg": {
+                    "2023": null
+                },
+                "taxcalc_midr": {
+                    "2023": null
+                },
+                "taxcalc_niit": {
+                    "2023": null
+                },
+                "taxcalc_p22250": {
+                    "2023": null
+                },
+                "taxcalc_p23250": {
+                    "2023": null
+                },
+                "taxcalc_pencon": {
+                    "2023": null
+                },
+                "taxcalc_pt_binc_w2_wages": {
+                    "2023": null
+                },
+                "taxcalc_pt_sstb_income": {
+                    "2023": null
+                },
+                "taxcalc_pt_ubia_property": {
+                    "2023": null
+                },
+                "taxcalc_s006": {
+                    "2023": null
+                },
+                "taxsim_age1": {
+                    "2023": null
+                },
+                "taxsim_age2": {
+                    "2023": null
+                },
+                "taxsim_age3": {
+                    "2023": null
+                },
+                "taxsim_childcare": {
+                    "2023": null
+                },
+                "taxsim_dep13": {
+                    "2023": null
+                },
+                "taxsim_dep17": {
+                    "2023": null
+                },
+                "taxsim_dep18": {
+                    "2023": null
+                },
+                "taxsim_depx": {
+                    "2023": null
+                },
+                "taxsim_dividends": {
+                    "2023": null
+                },
+                "taxsim_fiitax": {
+                    "2023": null
+                },
+                "taxsim_gssi": {
+                    "2023": null
+                },
+                "taxsim_intrec": {
+                    "2023": null
+                },
+                "taxsim_ltcg": {
+                    "2023": null
+                },
+                "taxsim_mstat": {
+                    "2023": null
+                },
+                "taxsim_page": {
+                    "2023": null
+                },
+                "taxsim_pbusinc": {
+                    "2023": null
+                },
+                "taxsim_pensions": {
+                    "2023": null
+                },
+                "taxsim_pprofinc": {
+                    "2023": 0
+                },
+                "taxsim_psemp": {
+                    "2023": null
+                },
+                "taxsim_pui": {
+                    "2023": null
+                },
+                "taxsim_pwages": {
+                    "2023": null
+                },
+                "taxsim_sage": {
+                    "2023": null
+                },
+                "taxsim_sbusinc": {
+                    "2023": null
+                },
+                "taxsim_scorp": {
+                    "2023": null
+                },
+                "taxsim_siitax": {
+                    "2023": null
+                },
+                "taxsim_sprofinc": {
+                    "2023": 0
+                },
+                "taxsim_ssemp": {
+                    "2023": null
+                },
+                "taxsim_state": {
+                    "2023": null
+                },
+                "taxsim_stcg": {
+                    "2023": null
+                },
+                "taxsim_swages": {
+                    "2023": null
+                },
+                "taxsim_taxsimid": {
+                    "2023": null
+                },
+                "taxsim_tfica": {
+                    "2023": null
+                },
+                "taxsim_ui": {
+                    "2023": null
+                },
+                "taxsim_v10": {
+                    "2023": null
+                },
+                "taxsim_v11": {
+                    "2023": null
+                },
+                "taxsim_v12": {
+                    "2023": null
+                },
+                "taxsim_v18": {
+                    "2023": null
+                },
+                "taxsim_v25": {
+                    "2023": null
+                },
+                "taxsim_year": {
+                    "2023": null
+                },
+                "tuition_and_fees": {
+                    "2023": 0
+                },
+                "unrecaptured_section_1250_gain": {
+                    "2023": 0
+                },
+                "unreported_payroll_tax": {
+                    "2023": 0
+                },
+                "us_govt_interest": {
+                    "2023": 0
+                },
+                "used_clean_vehicle_credit": {
+                    "2023": null
+                },
+                "used_clean_vehicle_credit_eligible": {
+                    "2023": null
+                },
+                "used_clean_vehicle_sale_price": {
+                    "2023": 0
+                },
+                "ut_additions_to_income": {
+                    "2023": 0
+                },
+                "ut_at_home_parent_credit": {
+                    "2023": null
+                },
+                "ut_claims_retirement_credit": {
+                    "2023": null
+                },
+                "ut_eitc": {
+                    "2023": null
+                },
+                "ut_federal_deductions_for_taxpayer_credit": {
+                    "2023": null
+                },
+                "ut_income_tax": {
+                    "2023": null
+                },
+                "ut_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ut_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ut_income_tax_exempt": {
+                    "2023": null
+                },
+                "ut_personal_exemption": {
+                    "2023": null
+                },
+                "ut_refundable_credits": {
+                    "2023": 0
+                },
+                "ut_retirement_credit": {
+                    "2023": null
+                },
+                "ut_retirement_credit_max": {
+                    "2023": null
+                },
+                "ut_ss_benefits_credit": {
+                    "2023": null
+                },
+                "ut_ss_benefits_credit_max": {
+                    "2023": null
+                },
+                "ut_state_tax_refund": {
+                    "2023": null
+                },
+                "ut_subtractions_from_income": {
+                    "2023": 0
+                },
+                "ut_taxable_income": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_max": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_phase_out_income": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_reduction": {
+                    "2023": null
+                },
+                "ut_total_dependents": {
+                    "2023": null
+                },
+                "ut_total_income": {
+                    "2023": null
+                },
+                "va_aged_blind_exemption": {
+                    "2023": null
+                },
+                "va_disability_income_subtraction": {
+                    "2023": null
+                },
+                "va_federal_state_employees_subtraction": {
+                    "2023": null
+                },
+                "va_income_tax_before_credits": {
+                    "2023": null
+                },
+                "va_military_basic_pay_subtraction": {
+                    "2023": null
+                },
+                "va_personal_exemption": {
+                    "2023": null
+                },
+                "va_standard_deduction": {
+                    "2023": null
+                },
+                "va_taxable_income": {
+                    "2023": 0
+                },
+                "wa_capital_gains_tax": {
+                    "2023": null
+                },
+                "wa_income_tax": {
+                    "2023": null
+                },
+                "wa_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "wa_refundable_credits": {
+                    "2023": null
+                },
+                "wa_working_families_tax_credit": {
+                    "2023": null
+                },
+                "xtot": {
+                    "2023": null
+                }
+            }
+        },
+        "spm_units": {
+            "your household": {
+                "members": [
+                    "you"
+                ],
+                "acp": {
+                    "2023": null
+                },
+                "ami": {
+                    "2023": 0
+                },
+                "broadband_cost": {
+                    "2023": 0
+                },
+                "broadband_cost_after_lifeline": {
+                    "2023": null
+                },
+                "ccdf_income": {
+                    "2023": null
+                },
+                "ccdf_income_to_smi_ratio": {
+                    "2023": null
+                },
+                "childcare_expenses": {
+                    "2023": 0
+                },
+                "co_tanf": {
+                    "2023": null
+                },
+                "co_tanf_count_children": {
+                    "2023": null
+                },
+                "co_tanf_countable_earned_income_grant_standard": {
+                    "2023": null
+                },
+                "co_tanf_countable_earned_income_need": {
+                    "2023": null
+                },
+                "co_tanf_countable_gross_earned_income": {
+                    "2023": null
+                },
+                "co_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "co_tanf_eligible": {
+                    "2023": null
+                },
+                "co_tanf_grant_standard": {
+                    "2023": null
+                },
+                "co_tanf_income_eligible": {
+                    "2023": null
+                },
+                "co_tanf_need_standard": {
+                    "2023": null
+                },
+                "count_distinct_utility_expenses": {
+                    "2023": null
+                },
+                "dc_tanf": {
+                    "2023": null
+                },
+                "dc_tanf_countable_earned_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "dc_tanf_eligible": {
+                    "2023": null
+                },
+                "dc_tanf_grant_standard": {
+                    "2023": null
+                },
+                "dc_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "dc_tanf_income_eligible": {
+                    "2023": null
+                },
+                "dc_tanf_need_standard": {
+                    "2023": null
+                },
+                "dc_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "deep_poverty_gap": {
+                    "2023": null
+                },
+                "deep_poverty_line": {
+                    "2023": null
+                },
+                "ebb": {
+                    "2023": null
+                },
+                "electricity_expense": {
+                    "2023": 0
+                },
+                "enrolled_in_ebb": {
+                    "2023": false
+                },
+                "experienced_covid_income_loss": {
+                    "2023": false
+                },
+                "fcc_fpg_ratio": {
+                    "2023": null
+                },
+                "fdpir": {
+                    "2023": 0
+                },
+                "free_school_meals": {
+                    "2023": null
+                },
+                "free_school_meals_reported": {
+                    "2023": 0
+                },
+                "gas_expense": {
+                    "2023": 0
+                },
+                "has_all_usda_elderly_disabled": {
+                    "2023": null
+                },
+                "has_heating_cooling_expense": {
+                    "2023": null
+                },
+                "has_phone_expense": {
+                    "2023": null
+                },
+                "has_usda_elderly_disabled": {
+                    "2023": null
+                },
+                "heating_cooling_expense": {
+                    "2023": 0
+                },
+                "hhs_smi": {
+                    "2023": null
+                },
+                "housing_assistance": {
+                    "2023": null
+                },
+                "housing_cost": {
+                    "2023": null
+                },
+                "housing_designated_welfare": {
+                    "2023": 0
+                },
+                "hud_adjusted_income": {
+                    "2023": null
+                },
+                "hud_annual_income": {
+                    "2023": null
+                },
+                "hud_gross_rent": {
+                    "2023": null
+                },
+                "hud_hap": {
+                    "2023": null
+                },
+                "hud_income_level": {
+                    "2023": null
+                },
+                "hud_max_subsidy": {
+                    "2023": null
+                },
+                "hud_minimum_rent": {
+                    "2023": 0
+                },
+                "hud_ttp": {
+                    "2023": null
+                },
+                "hud_ttp_adjusted_income_share": {
+                    "2023": null
+                },
+                "hud_ttp_income_share": {
+                    "2023": null
+                },
+                "hud_utility_allowance": {
+                    "2023": 0
+                },
+                "in_deep_poverty": {
+                    "2023": null
+                },
+                "in_poverty": {
+                    "2023": null
+                },
+                "is_acp_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_asset_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_continuous_income_eligible": {
+                    "2023": false
+                },
+                "is_ccdf_income_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_initial_income_eligible": {
+                    "2023": false
+                },
+                "is_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_ebb_eligible": {
+                    "2023": null
+                },
+                "is_eligible_for_housing_assistance": {
+                    "2023": null
+                },
+                "is_hud_elderly_disabled_family": {
+                    "2023": null
+                },
+                "is_lifeline_eligible": {
+                    "2023": null
+                },
+                "is_snap_eligible": {
+                    "2023": null
+                },
+                "is_tanf_continuous_eligible": {
+                    "2023": null
+                },
+                "is_tanf_eligible": {
+                    "2023": null
+                },
+                "is_tanf_enrolled": {
+                    "2023": false
+                },
+                "is_tanf_initial_eligible": {
+                    "2023": null
+                },
+                "is_tanf_non_cash_eligible": {
+                    "2023": null
+                },
+                "is_tanf_non_cash_hheod": {
+                    "2023": null
+                },
+                "lifeline": {
+                    "2023": null
+                },
+                "md_tanf_count_children": {
+                    "2023": null
+                },
+                "md_tanf_eligible": {
+                    "2023": false
+                },
+                "md_tanf_gross_earned_income_deduction": {
+                    "2023": null
+                },
+                "md_tanf_maximum_benefit": {
+                    "2023": null
+                },
+                "meets_ccdf_activity_test": {
+                    "2023": false
+                },
+                "meets_school_meal_categorical_eligibility": {
+                    "2023": null
+                },
+                "meets_snap_asset_test": {
+                    "2023": null
+                },
+                "meets_snap_categorical_eligibility": {
+                    "2023": null
+                },
+                "meets_snap_gross_income_test": {
+                    "2023": null
+                },
+                "meets_snap_net_income_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_asset_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_gross_income_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_net_income_test": {
+                    "2023": null
+                },
+                "meets_wic_income_test": {
+                    "2023": null
+                },
+                "mo_tanf_income_limit": {
+                    "2023": null
+                },
+                "nj_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "nj_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "nj_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "nj_tanf_maximum_allowable_income": {
+                    "2023": null
+                },
+                "nj_tanf_maximum_benefit": {
+                    "2023": null
+                },
+                "nj_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "ny_tanf": {
+                    "2023": null
+                },
+                "ny_tanf_countable_earned_income": {
+                    "2023": null
+                },
+                "ny_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "ny_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "ny_tanf_eligible": {
+                    "2023": null
+                },
+                "ny_tanf_grant_standard": {
+                    "2023": null
+                },
+                "ny_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "ny_tanf_income_eligible": {
+                    "2023": null
+                },
+                "ny_tanf_need_standard": {
+                    "2023": null
+                },
+                "ny_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "ok_tanf": {
+                    "2023": 0
+                },
+                "pell_grant": {
+                    "2023": 0
+                },
+                "pha_payment_standard": {
+                    "2023": 0
+                },
+                "phone_cost": {
+                    "2023": 0
+                },
+                "phone_expense": {
+                    "2023": null
+                },
+                "poverty_gap": {
+                    "2023": null
+                },
+                "poverty_line": {
+                    "2023": null
+                },
+                "receives_housing_assistance": {
+                    "2023": false
+                },
+                "reduced_price_school_meals": {
+                    "2023": null
+                },
+                "school_meal_countable_income": {
+                    "2023": null
+                },
+                "school_meal_daily_subsidy": {
+                    "2023": null
+                },
+                "school_meal_fpg_ratio": {
+                    "2023": null
+                },
+                "school_meal_net_subsidy": {
+                    "2023": null
+                },
+                "school_meal_paid_daily_subsidy": {
+                    "2023": null
+                },
+                "school_meal_tier": {
+                    "2023": null
+                },
+                "sewage_expense": {
+                    "2023": 0
+                },
+                "snap": {
+                    "2023": null
+                },
+                "snap_assets": {
+                    "2023": 0
+                },
+                "snap_child_support_deduction": {
+                    "2023": null
+                },
+                "snap_deductions": {
+                    "2023": null
+                },
+                "snap_dependent_care_deduction": {
+                    "2023": null
+                },
+                "snap_earned_income": {
+                    "2023": null
+                },
+                "snap_earned_income_deduction": {
+                    "2023": null
+                },
+                "snap_emergency_allotment": {
+                    "2023": null
+                },
+                "snap_excess_medical_expense_deduction": {
+                    "2023": null
+                },
+                "snap_excess_shelter_expense_deduction": {
+                    "2023": null
+                },
+                "snap_expected_contribution": {
+                    "2023": null
+                },
+                "snap_gross_income": {
+                    "2023": null
+                },
+                "snap_gross_income_fpg_ratio": {
+                    "2023": null
+                },
+                "snap_max_allotment": {
+                    "2023": null
+                },
+                "snap_min_allotment": {
+                    "2023": null
+                },
+                "snap_net_income": {
+                    "2023": null
+                },
+                "snap_net_income_fpg_ratio": {
+                    "2023": null
+                },
+                "snap_net_income_pre_shelter": {
+                    "2023": null
+                },
+                "snap_normal_allotment": {
+                    "2023": null
+                },
+                "snap_reported": {
+                    "2023": 0
+                },
+                "snap_standard_deduction": {
+                    "2023": null
+                },
+                "snap_unearned_income": {
+                    "2023": null
+                },
+                "snap_utility_allowance": {
+                    "2023": null
+                },
+                "snap_utility_allowance_type": {
+                    "2023": null
+                },
+                "spm_unit_assets": {
+                    "2023": 0
+                },
+                "spm_unit_benefits": {
+                    "2023": null
+                },
+                "spm_unit_capped_housing_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_capped_housing_subsidy_reported": {
+                    "2023": 0
+                },
+                "spm_unit_capped_work_childcare_expenses": {
+                    "2023": 0
+                },
+                "spm_unit_ccdf_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_count_adults": {
+                    "2023": null
+                },
+                "spm_unit_count_children": {
+                    "2023": null
+                },
+                "spm_unit_energy_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_energy_subsidy_reported": {
+                    "2023": 0
+                },
+                "spm_unit_federal_tax": {
+                    "2023": null
+                },
+                "spm_unit_federal_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_fpg": {
+                    "2023": null
+                },
+                "spm_unit_id": {
+                    "2023": 0
+                },
+                "spm_unit_income_decile": {
+                    "2023": null
+                },
+                "spm_unit_is_in_deep_spm_poverty": {
+                    "2023": null
+                },
+                "spm_unit_is_in_spm_poverty": {
+                    "2023": null
+                },
+                "spm_unit_market_income": {
+                    "2023": null
+                },
+                "spm_unit_medical_expenses": {
+                    "2023": null
+                },
+                "spm_unit_net_income": {
+                    "2023": null
+                },
+                "spm_unit_net_income_reported": {
+                    "2023": 0
+                },
+                "spm_unit_oecd_equiv_net_income": {
+                    "2023": null
+                },
+                "spm_unit_payroll_tax": {
+                    "2023": null
+                },
+                "spm_unit_payroll_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_school_lunch_subsidy": {
+                    "2023": 0
+                },
+                "spm_unit_self_employment_tax": {
+                    "2023": null
+                },
+                "spm_unit_size": {
+                    "2023": null
+                },
+                "spm_unit_snap": {
+                    "2023": 0
+                },
+                "spm_unit_spm_threshold": {
+                    "2023": 0
+                },
+                "spm_unit_state_fips": {
+                    "2023": null
+                },
+                "spm_unit_state_tax": {
+                    "2023": null
+                },
+                "spm_unit_state_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_taxes": {
+                    "2023": null
+                },
+                "spm_unit_total_ccdf_copay": {
+                    "2023": null
+                },
+                "spm_unit_total_income_reported": {
+                    "2023": 0
+                },
+                "spm_unit_weight": {
+                    "2023": null
+                },
+                "spm_unit_wic": {
+                    "2023": null
+                },
+                "spm_unit_wic_reported": {
+                    "2023": 0
+                },
+                "tanf": {
+                    "2023": null
+                },
+                "tanf_amount_if_eligible": {
+                    "2023": null
+                },
+                "tanf_countable_income": {
+                    "2023": null
+                },
+                "tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "tanf_gross_unearned_income": {
+                    "2023": null
+                },
+                "tanf_initial_employment_deduction": {
+                    "2023": null
+                },
+                "tanf_max_amount": {
+                    "2023": null
+                },
+                "trash_expense": {
+                    "2023": 0
+                },
+                "tx_tanf_income_limit": {
+                    "2023": null
+                },
+                "utility_expense": {
+                    "2023": null
+                },
+                "wa_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "wa_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "water_expense": {
+                    "2023": 0
+                },
+                "wic_fpg": {
+                    "2023": null
+                }
+            }
+        },
+        "households": {
+            "your household": {
+                "members": [
+                    "you"
+                ],
+                "AK": {
+                    "2023": null
+                },
+                "AL": {
+                    "2023": null
+                },
+                "AR": {
+                    "2023": null
+                },
+                "AZ": {
+                    "2023": null
+                },
+                "CA": {
+                    "2023": null
+                },
+                "CO": {
+                    "2023": null
+                },
+                "CT": {
+                    "2023": null
+                },
+                "DC": {
+                    "2023": null
+                },
+                "DE": {
+                    "2023": null
+                },
+                "FL": {
+                    "2023": null
+                },
+                "GA": {
+                    "2023": null
+                },
+                "HI": {
+                    "2023": null
+                },
+                "IA": {
+                    "2023": null
+                },
+                "ID": {
+                    "2023": null
+                },
+                "IL": {
+                    "2023": null
+                },
+                "IN": {
+                    "2023": null
+                },
+                "KS": {
+                    "2023": null
+                },
+                "KY": {
+                    "2023": null
+                },
+                "LA": {
+                    "2023": null
+                },
+                "MA": {
+                    "2023": null
+                },
+                "MD": {
+                    "2023": null
+                },
+                "ME": {
+                    "2023": null
+                },
+                "MI": {
+                    "2023": null
+                },
+                "MN": {
+                    "2023": null
+                },
+                "MO": {
+                    "2023": null
+                },
+                "MS": {
+                    "2023": null
+                },
+                "MT": {
+                    "2023": null
+                },
+                "NC": {
+                    "2023": null
+                },
+                "ND": {
+                    "2023": null
+                },
+                "NE": {
+                    "2023": null
+                },
+                "NH": {
+                    "2023": null
+                },
+                "NJ": {
+                    "2023": null
+                },
+                "NM": {
+                    "2023": null
+                },
+                "NV": {
+                    "2023": null
+                },
+                "NY": {
+                    "2023": null
+                },
+                "OH": {
+                    "2023": null
+                },
+                "OK": {
+                    "2023": null
+                },
+                "OR": {
+                    "2023": null
+                },
+                "PA": {
+                    "2023": null
+                },
+                "RI": {
+                    "2023": null
+                },
+                "SC": {
+                    "2023": null
+                },
+                "SD": {
+                    "2023": null
+                },
+                "TN": {
+                    "2023": null
+                },
+                "TX": {
+                    "2023": null
+                },
+                "UT": {
+                    "2023": null
+                },
+                "VA": {
+                    "2023": null
+                },
+                "VT": {
+                    "2023": null
+                },
+                "WA": {
+                    "2023": null
+                },
+                "WI": {
+                    "2023": null
+                },
+                "WV": {
+                    "2023": null
+                },
+                "WY": {
+                    "2023": null
+                },
+                "average_home_energy_use_in_state": {
+                    "2023": 0
+                },
+                "ca_care": {
+                    "2023": null
+                },
+                "ca_care_amount_if_eligible": {
+                    "2023": null
+                },
+                "ca_care_categorically_eligible": {
+                    "2023": null
+                },
+                "ca_care_eligible": {
+                    "2023": null
+                },
+                "ca_care_income_eligible": {
+                    "2023": null
+                },
+                "ca_care_poverty_line": {
+                    "2023": null
+                },
+                "ca_fera": {
+                    "2023": null
+                },
+                "ca_fera_amount_if_eligible": {
+                    "2023": null
+                },
+                "ca_fera_eligible": {
+                    "2023": null
+                },
+                "ccdf_county_cluster": {
+                    "2023": null
+                },
+                "county": {
+                    "2023": null
+                },
+                "county_fips": {
+                    "2023": 0
+                },
+                "county_str": {
+                    "2023": null
+                },
+                "current_home_energy_use": {
+                    "2023": 0
+                },
+                "equiv_household_net_income": {
+                    "2023": null
+                },
+                "fips": {
+                    "2023": 6
+                },
+                "household_benefits": {
+                    "2023": null
+                },
+                "household_count_people": {
+                    "2023": null
+                },
+                "household_id": {
+                    "2023": 0
+                },
+                "household_income_ami_ratio": {
+                    "2023": 0
+                },
+                "household_income_decile": {
+                    "2023": null
+                },
+                "household_market_income": {
+                    "2023": null
+                },
+                "household_net_income": {
+                    "2023": null
+                },
+                "household_refundable_tax_credits": {
+                    "2023": null
+                },
+                "household_size": {
+                    "2023": null
+                },
+                "household_tax": {
+                    "2023": null
+                },
+                "household_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "household_vehicles_owned": {
+                    "2023": 0
+                },
+                "household_weight": {
+                    "2023": 0
+                },
+                "in_nyc": {
+                    "2023": false
+                },
+                "is_homeless": {
+                    "2023": false
+                },
+                "is_on_tribal_land": {
+                    "2023": false
+                },
+                "is_rural": {
+                    "2023": false
+                },
+                "medicaid_rating_area": {
+                    "2023": null
+                },
+                "snap_region": {
+                    "2023": null
+                },
+                "snap_region_str": {
+                    "2023": null
+                },
+                "snap_utility_region": {
+                    "2023": null
+                },
+                "snap_utility_region_str": {
+                    "2023": null
+                },
+                "state_code": {
+                    "2023": null
+                },
+                "state_code_str": {
+                    "2023": null
+                },
+                "state_fips": {
+                    "2023": 6
+                },
+                "state_group": {
+                    "2023": null
+                },
+                "state_group_str": {
+                    "2023": null
+                },
+                "state_living_arrangement": {
+                    "2023": "FULL_COST"
+                },
+                "state_name": {
+                    "2023": null
+                },
+                "three_digit_zip_code": {
+                    "2023": null
+                },
+                "zip_code": {
+                    "2023": null
+                }
+            }
+        },
+        "axes": [
+            [
+                {
+                    "name": "employment_income",
+                    "period": "2023",
+                    "min": 0,
+                    "max": 200000,
+                    "count": 401
+                }
+            ]
+        ]
+    },
+    "policy": {
+        "gov.irs.income.exemption.amount": {
+            "2023-01-01.2028-12-31": "100"
+        }
+    }
+}

--- a/tests/python/test_calculate_us_1.py
+++ b/tests/python/test_calculate_us_1.py
@@ -1,48 +1,79 @@
+# Test: run a few calls to /calculate, running them with --durations=0 should
+# show that chaching is working (the ones suffixed by _repeat should be hits
+# and run much faster than their equivalent without the _repeat suffix).
 import requests
-import json
-from policyengine_api.api import app
 import pytest
-
+from policyengine_api.api import app
 
 @pytest.fixture
 def client():
+    """run the app for the tests to run against"""
     app.config["TESTING"] = True
-    with app.test_client() as client:
-        yield client
+    with app.test_client() as test_client:
+        yield test_client
 
-# trying to check cache, _1 has exactly the same data as _2 but different order so different cache key
+
 def test_calculate_us_1():
+    """This should be a cache miss as no other requests have been made yet."""
     response = requests.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
-        data=open("./tests/python/data/calculate_us_1_data.json", "r"),
+        data=open(
+            "./tests/python/data/calculate_us_1_data.json",
+            "r",
+            encoding="utf-8",
+        ),
+        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)
+
 
 def test_calculate_us_2():
+    """This should be a miss as the data is different to test_calculate_us_1"""
     response = requests.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
-        data=open("./tests/python/data/calculate_us_2_data.json", "r"),
+        data=open(
+            "./tests/python/data/calculate_us_2_data.json",
+            "r",
+            encoding="utf-8",
+        ),
+        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)
+
 
 def test_calculate_us_1_repeat_1():
+    """This should be a hit as the data is the same as test_calculate_us_1"""
     response = requests.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
-        data=open("./tests/python/data/calculate_us_1_data.json", "r"),
+        data=open(
+            "./tests/python/data/calculate_us_1_data.json",
+            "r",
+            encoding="utf-8",
+        ),
+        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)
 
+
 def test_calculate_us_2_repeat_1():
+    """This should be a cache hit as the data is the same as
+    test_calculate_us_2
+    """
     response = requests.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
-        data=open("./tests/python/data/calculate_us_2_data.json", "r"),
+        data=open(
+            "./tests/python/data/calculate_us_2_data.json",
+            "r",
+            encoding="utf-8",
+        ),
+        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)

--- a/tests/python/test_calculate_us_1.py
+++ b/tests/python/test_calculate_us_1.py
@@ -5,6 +5,7 @@ import requests
 import pytest
 from policyengine_api.api import app
 
+
 @pytest.fixture
 def client():
     """run the app for the tests to run against"""

--- a/tests/python/test_calculate_us_1.py
+++ b/tests/python/test_calculate_us_1.py
@@ -1,12 +1,11 @@
 # Test: run a few calls to /calculate, running them with --durations=0 should
 # show that chaching is working (the ones suffixed by _repeat should be hits
 # and run much faster than their equivalent without the _repeat suffix).
-import requests
 import pytest
 from policyengine_api.api import app
 
 
-@pytest.fixture
+@pytest.fixture(name="rest_client")
 def client():
     """run the app for the tests to run against"""
     app.config["TESTING"] = True
@@ -14,9 +13,9 @@ def client():
         yield test_client
 
 
-def test_calculate_us_1():
+def test_calculate_us_1(rest_client):
     """This should be a cache miss as no other requests have been made yet."""
-    response = requests.post(
+    response = rest_client.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
         data=open(
@@ -24,15 +23,14 @@ def test_calculate_us_1():
             "r",
             encoding="utf-8",
         ),
-        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)
 
 
-def test_calculate_us_2():
+def test_calculate_us_2(rest_client):
     """This should be a miss as the data is different to test_calculate_us_1"""
-    response = requests.post(
+    response = rest_client.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
         data=open(
@@ -40,15 +38,14 @@ def test_calculate_us_2():
             "r",
             encoding="utf-8",
         ),
-        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)
 
 
-def test_calculate_us_1_repeat_1():
+def test_calculate_us_1_repeat_1(rest_client):
     """This should be a hit as the data is the same as test_calculate_us_1"""
-    response = requests.post(
+    response = rest_client.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
         data=open(
@@ -56,17 +53,16 @@ def test_calculate_us_1_repeat_1():
             "r",
             encoding="utf-8",
         ),
-        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)
 
 
-def test_calculate_us_2_repeat_1():
+def test_calculate_us_2_repeat_1(rest_client):
     """This should be a cache hit as the data is the same as
     test_calculate_us_2
     """
-    response = requests.post(
+    response = rest_client.post(
         "http://localhost:5000/us/calculate",
         headers={"Content-Type": "application/json"},
         data=open(
@@ -74,7 +70,6 @@ def test_calculate_us_2_repeat_1():
             "r",
             encoding="utf-8",
         ),
-        timeout=20,
     )
     assert response.status_code == 200
     print(response.text)

--- a/tests/python/test_calculate_us_1.py
+++ b/tests/python/test_calculate_us_1.py
@@ -1,0 +1,48 @@
+import requests
+import json
+from policyengine_api.api import app
+import pytest
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+# trying to check cache, _1 has exactly the same data as _2 but different order so different cache key
+def test_calculate_us_1():
+    response = requests.post(
+        "http://localhost:5000/us/calculate",
+        headers={"Content-Type": "application/json"},
+        data=open("./tests/python/data/calculate_us_1_data.json", "r"),
+    )
+    assert response.status_code == 200
+    print(response.text)
+
+def test_calculate_us_2():
+    response = requests.post(
+        "http://localhost:5000/us/calculate",
+        headers={"Content-Type": "application/json"},
+        data=open("./tests/python/data/calculate_us_2_data.json", "r"),
+    )
+    assert response.status_code == 200
+    print(response.text)
+
+def test_calculate_us_1_repeat_1():
+    response = requests.post(
+        "http://localhost:5000/us/calculate",
+        headers={"Content-Type": "application/json"},
+        data=open("./tests/python/data/calculate_us_1_data.json", "r"),
+    )
+    assert response.status_code == 200
+    print(response.text)
+
+def test_calculate_us_2_repeat_1():
+    response = requests.post(
+        "http://localhost:5000/us/calculate",
+        headers={"Content-Type": "application/json"},
+        data=open("./tests/python/data/calculate_us_2_data.json", "r"),
+    )
+    assert response.status_code == 200
+    print(response.text)


### PR DESCRIPTION
Added Flask-Caching (https://flask-caching.readthedocs.io/en/latest/) experimentally for `/calculate`.
 - ~~To test it you'd need `pip install Flask-Caching`, I didn't see a requirements.txt at first glance, not sure how to add as dep now, I'll fix it.~~
~~Did a few tests (about 3 clicks) and it looks promising. I'll continue to do some tests next week.~~


