### PR TITLE
[URGENT] Bugfix: remove caching for /economy

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - /economy endpoint was being cached with falsk caching and is breaking functionality, was added by mistake. There was already a different kind of caching for this endpoint that works fine.

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -73,7 +73,7 @@ app.route("/<country_id>/calculate", methods=["POST"])(
 app.route(
     "/<country_id>/economy/<policy_id>/over/<baseline_policy_id>",
     methods=["GET"],
-)(cache.cached(make_cache_key=make_cache_key)(get_economic_impact))
+)(get_economic_impact)
 
 app.route("/<country_id>/analysis", methods=["POST"])(
     app.route("/<country_id>/analysis/<prompt_id>", methods=["GET"])(


### PR DESCRIPTION
PR #495 mistakenly added caching for `/economy`.
There was already a different kind of caching for this endpoint that works fine.
The added cache, caches the "calculating" response and answers that for any future requests thus the calculation results never get answered.
