### PR TITLE
Rename `nj_child_tax_credit` to `nj_ctc` in tests

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+      - Rename nj_child_tax_credit to nj_ctc in tests, following policyengine-us.

--- a/tests/python/data/calculate_us_1_data.json
+++ b/tests/python/data/calculate_us_1_data.json
@@ -2504,7 +2504,7 @@
                 "nj_cdcc": {
                     "2023": null
                 },
-                "nj_child_tax_credit": {
+                "nj_ctc": {
                     "2023": null
                 },
                 "nj_childless_eitc_age_eligible": {

--- a/tests/python/data/calculate_us_2_data.json
+++ b/tests/python/data/calculate_us_2_data.json
@@ -2504,7 +2504,7 @@
                 "nj_cdcc": {
                     "2023": null
                 },
-                "nj_child_tax_credit": {
+                "nj_ctc": {
                     "2023": null
                 },
                 "nj_childless_eitc_age_eligible": {


### PR DESCRIPTION
Fixes #617