### PR TITLE
Shift default variable addition from front end to back end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ debug:
 	FLASK_APP=policyengine_api.api FLASK_DEBUG=1 flask run --without-threads
 
 test:
-	pytest tests/api
+	pytest tests
 
 debug-test:
-	FLASK_DEBUG=1 pytest tests/api
+	FLASK_DEBUG=1 pytest tests
 
 format:
 	black . -l 79

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,7 +1,7 @@
 - bump: patch
   changes:
     changed:
-    - Add script to add default variables to houseold situation
+    - Add script to add default variables to household situation
       before enqueuing for calculation
     - Add endpoint for updating existing households
     - Add test US household that contains variables not present

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,9 @@
+- bump: patch
+  changes:
+    changed:
+    - Add script to add default variables to houseold situation
+      before enqueuing for calculation
+    - Add endpoint for updating existing households
+    - Add test US household that contains variables not present
+      in the policyengine-us package
+    - Add various tests for new features

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -18,6 +18,7 @@ from .endpoints import (
     get_metadata,
     get_household,
     post_household,
+    update_household,
     get_policy,
     set_policy,
     get_policy_search,
@@ -54,6 +55,8 @@ app.route("/<country_id>/household/<household_id>", methods=["GET"])(
 )
 
 app.route("/<country_id>/household", methods=["POST"])(post_household)
+
+app.route("/<country_id>/household/<household_id>", methods=["PUT"])(update_household)
 
 app.route("/<country_id>/policy/<policy_id>", methods=["GET"])(get_policy)
 

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -56,7 +56,9 @@ app.route("/<country_id>/household/<household_id>", methods=["GET"])(
 
 app.route("/<country_id>/household", methods=["POST"])(post_household)
 
-app.route("/<country_id>/household/<household_id>", methods=["PUT"])(update_household)
+app.route("/<country_id>/household/<household_id>", methods=["PUT"])(
+    update_household
+)
 
 app.route("/<country_id>/policy/<policy_id>", methods=["GET"])(get_policy)
 

--- a/policyengine_api/data/seed/household/household_15_us.sql
+++ b/policyengine_api/data/seed/household/household_15_us.sql
@@ -1,0 +1,7073 @@
+INSERT OR REPLACE INTO household (id, country_id, label, api_version, household_json, household_hash)
+VALUES (
+	-15,
+	"us",
+	"Sample dataset - duplicate of US household #33010 in live database, plus fake variables to simulate data no longer in US package",
+	"0.403.3",
+	'{
+        "families": {
+            "your family": {
+                "family_id": {
+                    "2023": 0
+                },
+                "family_weight": {
+                    "2023": 0
+                },
+                "is_married": {
+                    "2023": null
+                },
+                "members": [
+                    "you",
+                    "your first dependent",
+                    "your second dependent"
+                ]
+            }
+        },
+        "households": {
+            "your household": {
+                "garbageTruthyValue": {
+                  "2023": 25
+                },
+                "garbageFalsyValue": {
+                  "2023": false
+                },
+                "AK": {
+                    "2023": null
+                },
+                "AL": {
+                    "2023": null
+                },
+                "AR": {
+                    "2023": null
+                },
+                "AZ": {
+                    "2023": null
+                },
+                "CA": {
+                    "2023": null
+                },
+                "CO": {
+                    "2023": null
+                },
+                "CT": {
+                    "2023": null
+                },
+                "DC": {
+                    "2023": null
+                },
+                "DE": {
+                    "2023": null
+                },
+                "FL": {
+                    "2023": null
+                },
+                "GA": {
+                    "2023": null
+                },
+                "HI": {
+                    "2023": null
+                },
+                "IA": {
+                    "2023": null
+                },
+                "ID": {
+                    "2023": null
+                },
+                "IL": {
+                    "2023": null
+                },
+                "IN": {
+                    "2023": null
+                },
+                "KS": {
+                    "2023": null
+                },
+                "KY": {
+                    "2023": null
+                },
+                "LA": {
+                    "2023": null
+                },
+                "MA": {
+                    "2023": null
+                },
+                "MD": {
+                    "2023": null
+                },
+                "ME": {
+                    "2023": null
+                },
+                "MI": {
+                    "2023": null
+                },
+                "MN": {
+                    "2023": null
+                },
+                "MO": {
+                    "2023": null
+                },
+                "MS": {
+                    "2023": null
+                },
+                "MT": {
+                    "2023": null
+                },
+                "NC": {
+                    "2023": null
+                },
+                "ND": {
+                    "2023": null
+                },
+                "NE": {
+                    "2023": null
+                },
+                "NH": {
+                    "2023": null
+                },
+                "NJ": {
+                    "2023": null
+                },
+                "NM": {
+                    "2023": null
+                },
+                "NV": {
+                    "2023": null
+                },
+                "NY": {
+                    "2023": null
+                },
+                "OH": {
+                    "2023": null
+                },
+                "OK": {
+                    "2023": null
+                },
+                "OR": {
+                    "2023": null
+                },
+                "PA": {
+                    "2023": null
+                },
+                "RI": {
+                    "2023": null
+                },
+                "SC": {
+                    "2023": null
+                },
+                "SD": {
+                    "2023": null
+                },
+                "TN": {
+                    "2023": null
+                },
+                "TX": {
+                    "2023": null
+                },
+                "UT": {
+                    "2023": null
+                },
+                "VA": {
+                    "2023": null
+                },
+                "VT": {
+                    "2023": null
+                },
+                "WA": {
+                    "2023": null
+                },
+                "WI": {
+                    "2023": null
+                },
+                "WV": {
+                    "2023": null
+                },
+                "WY": {
+                    "2023": null
+                },
+                "average_home_energy_use_in_state": {
+                    "2023": 0
+                },
+                "ca_care": {
+                    "2023": null
+                },
+                "ca_care_amount_if_eligible": {
+                    "2023": null
+                },
+                "ca_care_categorically_eligible": {
+                    "2023": null
+                },
+                "ca_care_eligible": {
+                    "2023": null
+                },
+                "ca_care_income_eligible": {
+                    "2023": null
+                },
+                "ca_care_poverty_line": {
+                    "2023": null
+                },
+                "ca_fera": {
+                    "2023": null
+                },
+                "ca_fera_amount_if_eligible": {
+                    "2023": null
+                },
+                "ca_fera_eligible": {
+                    "2023": null
+                },
+                "ccdf_county_cluster": {
+                    "2023": null
+                },
+                "county": {
+                    "2023": null
+                },
+                "county_fips": {
+                    "2023": 0
+                },
+                "county_str": {
+                    "2023": null
+                },
+                "current_home_energy_use": {
+                    "2023": 0
+                },
+                "equiv_household_net_income": {
+                    "2023": null
+                },
+                "fips": {
+                    "2023": 6
+                },
+                "household_benefits": {
+                    "2023": null
+                },
+                "household_count_people": {
+                    "2023": null
+                },
+                "household_id": {
+                    "2023": 0
+                },
+                "household_income_ami_ratio": {
+                    "2023": 0
+                },
+                "household_income_decile": {
+                    "2023": null
+                },
+                "household_market_income": {
+                    "2023": null
+                },
+                "household_net_income": {
+                    "2023": null
+                },
+                "household_refundable_tax_credits": {
+                    "2023": null
+                },
+                "household_size": {
+                    "2023": null
+                },
+                "household_tax": {
+                    "2023": null
+                },
+                "household_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "household_vehicles_owned": {
+                    "2023": 0
+                },
+                "household_weight": {
+                    "2023": 0
+                },
+                "in_nyc": {
+                    "2023": false
+                },
+                "is_homeless": {
+                    "2023": false
+                },
+                "is_on_tribal_land": {
+                    "2023": false
+                },
+                "is_rural": {
+                    "2023": false
+                },
+                "medicaid_rating_area": {
+                    "2023": null
+                },
+                "members": [
+                    "you",
+                    "your first dependent",
+                    "your second dependent"
+                ],
+                "snap_region": {
+                    "2023": null
+                },
+                "snap_region_str": {
+                    "2023": null
+                },
+                "snap_utility_region": {
+                    "2023": null
+                },
+                "snap_utility_region_str": {
+                    "2023": null
+                },
+                "state_code": {
+                    "2023": null
+                },
+                "state_code_str": {
+                    "2023": null
+                },
+                "state_fips": {
+                    "2023": 6
+                },
+                "state_group": {
+                    "2023": null
+                },
+                "state_group_str": {
+                    "2023": null
+                },
+                "state_living_arrangement": {
+                    "2023": "FULL_COST"
+                },
+                "state_name": {
+                    "2023": "NM"
+                },
+                "three_digit_zip_code": {
+                    "2023": null
+                },
+                "zip_code": {
+                    "2023": null
+                }
+            }
+        },
+        "marital_units": {
+            "your first dependent''s marital unit": {
+                "marital_unit_id": {
+                    "2023": 2
+                },
+                "marital_unit_weight": {
+                    "2023": null
+                },
+                "members": [
+                    "your first dependent"
+                ]
+            },
+            "your marital unit": {
+                "marital_unit_id": {
+                    "2023": 0
+                },
+                "marital_unit_weight": {
+                    "2023": null
+                },
+                "members": [
+                    "you"
+                ]
+            },
+            "your second dependent''s marital unit": {
+                "marital_unit_id": {
+                    "2023": 3
+                },
+                "marital_unit_weight": {
+                    "2023": null
+                },
+                "members": [
+                    "your second dependent"
+                ]
+            }
+        },
+        "people": {
+            "you": {
+                "adjusted_gross_income_person": {
+                    "2023": null
+                },
+                "adult_index": {
+                    "2023": null
+                },
+                "age": {
+                    "2023": 40
+                },
+                "age_group": {
+                    "2023": null
+                },
+                "alimony_expense": {
+                    "2023": 0
+                },
+                "alimony_income": {
+                    "2023": 0
+                },
+                "assessed_property_value": {
+                    "2023": 0
+                },
+                "business_is_qualified": {
+                    "2023": false
+                },
+                "business_is_sstb": {
+                    "2023": false
+                },
+                "ca_cvrp": {
+                    "2023": null
+                },
+                "ca_cvrp_vehicle_rebate_amount": {
+                    "2023": 0
+                },
+                "ca_is_qualifying_child_for_caleitc": {
+                    "2023": null
+                },
+                "capital_gains": {
+                    "2023": null
+                },
+                "capital_losses": {
+                    "2023": null
+                },
+                "casualty_loss": {
+                    "2023": 0
+                },
+                "ccdf_age_group": {
+                    "2023": null
+                },
+                "ccdf_duration_of_care": {
+                    "2023": null
+                },
+                "ccdf_market_rate": {
+                    "2023": null
+                },
+                "cdcc_qualified_dependent": {
+                    "2023": null
+                },
+                "charitable_cash_donations": {
+                    "2023": 0
+                },
+                "charitable_non_cash_donations": {
+                    "2023": 0
+                },
+                "child_support_expense": {
+                    "2023": 0
+                },
+                "child_support_received": {
+                    "2023": 0
+                },
+                "childcare_days_per_week": {
+                    "2023": 0
+                },
+                "childcare_hours_per_day": {
+                    "2023": 0
+                },
+                "childcare_hours_per_week": {
+                    "2023": null
+                },
+                "childcare_provider_type_group": {
+                    "2023": "DCC_SACC"
+                },
+                "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+                    "2023": false
+                },
+                "cliff_evaluated": {
+                    "2023": null
+                },
+                "cliff_gap": {
+                    "2023": null
+                },
+                "cmbtp": {
+                    "2023": 0
+                },
+                "co_oap": {
+                    "2023": null
+                },
+                "co_oap_eligible": {
+                    "2023": null
+                },
+                "co_state_supplement": {
+                    "2023": null
+                },
+                "co_state_supplement_eligible": {
+                    "2023": null
+                },
+                "count_days_postpartum": {
+                    "2023": null
+                },
+                "cps_race": {
+                    "2023": 0
+                },
+                "ctc_adult_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum_arpa": {
+                    "2023": null
+                },
+                "ctc_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_qualifying_child": {
+                    "2023": null
+                },
+                "dc_agi": {
+                    "2023": null
+                },
+                "dc_deduction_indiv": {
+                    "2023": null
+                },
+                "dc_disabled_exclusion_subtraction": {
+                    "2023": null
+                },
+                "dc_income_additions": {
+                    "2023": null
+                },
+                "dc_income_subtractions": {
+                    "2023": null
+                },
+                "dc_self_employment_loss_addition": {
+                    "2023": null
+                },
+                "dc_taxable_income_indiv": {
+                    "2023": null
+                },
+                "debt_relief": {
+                    "2023": 0
+                },
+                "disability_benefits": {
+                    "2023": 0
+                },
+                "dividend_income": {
+                    "2023": null
+                },
+                "e00200": {
+                    "2023": null
+                },
+                "e00300": {
+                    "2023": null
+                },
+                "e02300": {
+                    "2023": 0
+                },
+                "e02400": {
+                    "2023": null
+                },
+                "e87530": {
+                    "2023": 0
+                },
+                "early_withdrawal_penalty": {
+                    "2023": 0
+                },
+                "earned": {
+                    "2023": null
+                },
+                "earned_income": {
+                    "2023": null
+                },
+                "educator_expense": {
+                    "2023": 0
+                },
+                "employee_medicare_tax": {
+                    "2023": null
+                },
+                "employee_social_security_tax": {
+                    "2023": null
+                },
+                "employment_income": {
+                    "2023": 30000
+                },
+                "farm_income": {
+                    "2023": 0
+                },
+                "farm_rent_income": {
+                    "2023": 0
+                },
+                "general_assistance": {
+                    "2023": 0
+                },
+                "gi_cash_assistance": {
+                    "2023": 0
+                },
+                "has_disabled_spouse": {
+                    "2023": null
+                },
+                "has_marketplace_health_coverage": {
+                    "2023": true
+                },
+                "health_insurance_premiums": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_indiv": {
+                    "2023": null
+                },
+                "ia_alternate_tax_joint": {
+                    "2023": null
+                },
+                "ia_amt_indiv": {
+                    "2023": null
+                },
+                "ia_amt_joint": {
+                    "2023": null
+                },
+                "ia_base_tax_indiv": {
+                    "2023": null
+                },
+                "ia_base_tax_joint": {
+                    "2023": null
+                },
+                "ia_basic_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_basic_deduction_joint": {
+                    "2023": null
+                },
+                "ia_fedtax_deduction": {
+                    "2023": null
+                },
+                "ia_gross_income": {
+                    "2023": null
+                },
+                "ia_income_adjustments": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_indiv": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_joint": {
+                    "2023": null
+                },
+                "ia_net_income": {
+                    "2023": null
+                },
+                "ia_pension_exclusion": {
+                    "2023": null
+                },
+                "ia_prorate_fraction": {
+                    "2023": null
+                },
+                "ia_qbi_deduction": {
+                    "2023": null
+                },
+                "ia_regular_tax_indiv": {
+                    "2023": null
+                },
+                "ia_regular_tax_joint": {
+                    "2023": null
+                },
+                "ia_standard_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_standard_deduction_joint": {
+                    "2023": null
+                },
+                "ia_taxable_income_indiv": {
+                    "2023": null
+                },
+                "ia_taxable_income_joint": {
+                    "2023": null
+                },
+                "illicit_income": {
+                    "2023": 0
+                },
+                "in_is_qualifying_dependent_child": {
+                    "2023": null
+                },
+                "in_unified_elderly_tax_income": {
+                    "2023": null
+                },
+                "incapable_of_self_care": {
+                    "2023": false
+                },
+                "income_decile": {
+                    "2023": null
+                },
+                "interest_expense": {
+                    "2023": 0
+                },
+                "interest_income": {
+                    "2023": null
+                },
+                "ira_contributions": {
+                    "2023": 0
+                },
+                "irs_gross_income": {
+                    "2023": null
+                },
+                "is_adult": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_blind": {
+                    "2023": false
+                },
+                "is_breastfeeding": {
+                    "2023": false
+                },
+                "is_ca_cvrp_increased_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ca_cvrp_normal_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_age_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_home_based": {
+                    "2023": null
+                },
+                "is_ccdf_reason_for_care_eligible": {
+                    "2023": null
+                },
+                "is_cdcc_eligible": {
+                    "2023": null
+                },
+                "is_child": {
+                    "2023": null
+                },
+                "is_child_of_tax_head": {
+                    "2023": null
+                },
+                "is_citizen": {
+                    "2023": false
+                },
+                "is_disabled": {
+                    "2023": false
+                },
+                "is_eitc_qualifying_child": {
+                    "2023": null
+                },
+                "is_eligible_for_american_opportunity_credit": {
+                    "2023": false
+                },
+                "is_enrolled_in_ccdf": {
+                    "2023": false
+                },
+                "is_father": {
+                    "2023": null
+                },
+                "is_female": {
+                    "2023": false
+                },
+                "is_full_time_college_student": {
+                    "2023": false
+                },
+                "is_full_time_student": {
+                    "2023": null
+                },
+                "is_fully_disabled_service_connected_veteran": {
+                    "2023": false
+                },
+                "is_hispanic": {
+                    "2023": false
+                },
+                "is_in_k12_nonpublic_school": {
+                    "2023": false
+                },
+                "is_in_k12_school": {
+                    "2023": null
+                },
+                "is_in_medicaid_medically_needy_category": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_male": {
+                    "2023": null
+                },
+                "is_medicaid_eligible": {
+                    "2023": null
+                },
+                "is_medically_needy_for_medicaid": {
+                    "2023": null
+                },
+                "is_mother": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_on_cliff": {
+                    "2023": null
+                },
+                "is_optional_senior_or_disabled_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_permanently_and_totally_disabled": {
+                    "2023": false
+                },
+                "is_permanently_disabled_veteran": {
+                    "2023": false
+                },
+                "is_person_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_pregnant": {
+                    "2023": false
+                },
+                "is_pregnant_for_medicaid": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_retired": {
+                    "2023": null
+                },
+                "is_self_employed": {
+                    "2023": false
+                },
+                "is_senior": {
+                    "2023": null
+                },
+                "is_severely_disabled": {
+                    "2023": false
+                },
+                "is_ssi_aged": {
+                    "2023": null
+                },
+                "is_ssi_aged_blind_disabled": {
+                    "2023": null
+                },
+                "is_ssi_disabled": {
+                    "2023": null
+                },
+                "is_ssi_eligible_individual": {
+                    "2023": null
+                },
+                "is_ssi_eligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_child": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_parent": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_recipient_for_medicaid": {
+                    "2023": null
+                },
+                "is_surviving_child_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_surviving_spouse_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_tax_unit_dependent": {
+                    "2023": null
+                },
+                "is_tax_unit_head": {
+                    "2023": null
+                },
+                "is_tax_unit_spouse": {
+                    "2023": null
+                },
+                "is_usda_disabled": {
+                    "2023": null
+                },
+                "is_usda_elderly": {
+                    "2023": null
+                },
+                "is_wa_adult": {
+                    "2023": null
+                },
+                "is_wic_at_nutritional_risk": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "k1bx14": {
+                    "2023": 0
+                },
+                "long_term_capital_gains": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_collectibles": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_small_business_stock": {
+                    "2023": 0
+                },
+                "ma_covid_19_essential_employee_premium_pay_program": {
+                    "2023": null
+                },
+                "marginal_tax_rate": {
+                    "2023": null
+                },
+                "market_income": {
+                    "2023": null
+                },
+                "maximum_state_supplement": {
+                    "2023": null
+                },
+                "md_pension_subtraction_amount": {
+                    "2023": null
+                },
+                "md_socsec_subtraction_amount": {
+                    "2023": null
+                },
+                "medicaid": {
+                    "2023": null
+                },
+                "medicaid_benefit_value": {
+                    "2023": null
+                },
+                "medicaid_category": {
+                    "2023": null
+                },
+                "medicaid_income_level": {
+                    "2023": null
+                },
+                "medical_expense": {
+                    "2023": null
+                },
+                "medical_out_of_pocket_expenses": {
+                    "2023": 0
+                },
+                "meets_ssi_resource_test": {
+                    "2023": null
+                },
+                "meets_wic_categorical_eligibility": {
+                    "2023": null
+                },
+                "military_basic_pay": {
+                    "2023": 0
+                },
+                "military_retirement_pay": {
+                    "2023": 0
+                },
+                "military_service_income": {
+                    "2023": 0
+                },
+                "miscellaneous_income": {
+                    "2023": 0
+                },
+                "mo_adjusted_gross_income": {
+                    "2023": null
+                },
+                "mo_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mo_income_tax_exempt": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_a": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_b": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_c": {
+                    "2023": null
+                },
+                "mo_qualified_health_insurance_premiums": {
+                    "2023": null
+                },
+                "mo_taxable_income": {
+                    "2023": null
+                },
+                "net_income": {
+                    "2023": 0
+                },
+                "nm_cdcc_eligible_child": {
+                    "2023": null
+                },
+                "non_public_school_tuition": {
+                    "2023": 0
+                },
+                "non_qualified_dividend_income": {
+                    "2023": 0
+                },
+                "non_sch_d_capital_gains": {
+                    "2023": 0
+                },
+                "oh_has_not_taken_oh_lump_sum_credits": {
+                    "2023": false
+                },
+                "own_children_in_household": {
+                    "2023": 0
+                },
+                "pa_nontaxable_pension_income": {
+                    "2023": null
+                },
+                "partnership_s_corp_income": {
+                    "2023": 0
+                },
+                "payroll_tax_gross_wages": {
+                    "2023": null
+                },
+                "pencon": {
+                    "2023": 0
+                },
+                "pension_contributions": {
+                    "2023": null
+                },
+                "pension_income": {
+                    "2023": null
+                },
+                "people": {
+                    "2023": 1
+                },
+                "per_vehicle_payment": {
+                    "2023": null
+                },
+                "person_family_id": {
+                    "2023": 0
+                },
+                "person_household_id": {
+                    "2023": 0
+                },
+                "person_id": {
+                    "2023": null
+                },
+                "person_in_poverty": {
+                    "2023": null
+                },
+                "person_marital_unit_id": {
+                    "2023": 0
+                },
+                "person_spm_unit_id": {
+                    "2023": 0
+                },
+                "person_tax_unit_id": {
+                    "2023": 0
+                },
+                "person_weight": {
+                    "2023": null
+                },
+                "private_pension_income": {
+                    "2023": null
+                },
+                "public_pension_income": {
+                    "2023": null
+                },
+                "qbid_amount": {
+                    "2023": null
+                },
+                "qualified_adoption_assistance_expense": {
+                    "2023": 0
+                },
+                "qualified_business_income": {
+                    "2023": null
+                },
+                "qualified_dividend_income": {
+                    "2023": 0
+                },
+                "qualified_tuition_expenses": {
+                    "2023": 0
+                },
+                "qualifies_for_elderly_or_disabled_credit": {
+                    "2023": null
+                },
+                "race": {
+                    "2023": null
+                },
+                "real_estate_taxes": {
+                    "2023": 0
+                },
+                "receives_or_needs_protective_services": {
+                    "2023": false
+                },
+                "receives_wic": {
+                    "2023": false
+                },
+                "rent": {
+                    "2023": 12000
+                },
+                "rental_income": {
+                    "2023": 0
+                },
+                "retired_on_total_disability": {
+                    "2023": false
+                },
+                "salt_refund_income": {
+                    "2023": 0
+                },
+                "self_employed_health_insurance_ald_person": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_premiums": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald_person": {
+                    "2023": null
+                },
+                "self_employed_pension_contributions": {
+                    "2023": 0
+                },
+                "self_employment_income": {
+                    "2023": 0
+                },
+                "self_employment_medicare_tax": {
+                    "2023": null
+                },
+                "self_employment_social_security_tax": {
+                    "2023": null
+                },
+                "self_employment_tax": {
+                    "2023": null
+                },
+                "self_employment_tax_ald_person": {
+                    "2023": null
+                },
+                "sep_simple_qualified_plan_contributions": {
+                    "2023": 0
+                },
+                "sey": {
+                    "2023": null
+                },
+                "short_term_capital_gains": {
+                    "2023": 0
+                },
+                "social_security": {
+                    "2023": null
+                },
+                "social_security_dependents": {
+                    "2023": 0
+                },
+                "social_security_disability": {
+                    "2023": 0
+                },
+                "social_security_retirement": {
+                    "2023": 0
+                },
+                "social_security_survivors": {
+                    "2023": 0
+                },
+                "social_security_taxable_self_employment_income": {
+                    "2023": null
+                },
+                "ssi": {
+                    "2023": null
+                },
+                "ssi_amount_if_eligible": {
+                    "2023": null
+                },
+                "ssi_category": {
+                    "2023": "NONE"
+                },
+                "ssi_claim_is_joint": {
+                    "2023": null
+                },
+                "ssi_countable_income": {
+                    "2023": null
+                },
+                "ssi_countable_resources": {
+                    "2023": 0
+                },
+                "ssi_earned_income": {
+                    "2023": null
+                },
+                "ssi_earned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_ineligible_child_allocation": {
+                    "2023": null
+                },
+                "ssi_ineligible_parent_allocation": {
+                    "2023": null
+                },
+                "ssi_reported": {
+                    "2023": 0
+                },
+                "ssi_unearned_income": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_parent": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "state_or_federal_salary": {
+                    "2023": 0
+                },
+                "state_supplement": {
+                    "2023": null
+                },
+                "strike_benefits": {
+                    "2023": 0
+                },
+                "student_loan_interest": {
+                    "2023": 0
+                },
+                "tanf_person": {
+                    "2023": null
+                },
+                "tanf_reported": {
+                    "2023": 0
+                },
+                "tax_exempt_interest_income": {
+                    "2023": 0
+                },
+                "tax_exempt_pension_income": {
+                    "2023": null
+                },
+                "tax_exempt_private_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_public_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_unemployment_compensation": {
+                    "2023": null
+                },
+                "taxable_earnings_for_social_security": {
+                    "2023": null
+                },
+                "taxable_interest_income": {
+                    "2023": 0
+                },
+                "taxable_pension_income": {
+                    "2023": null
+                },
+                "taxable_private_pension_income": {
+                    "2023": 0
+                },
+                "taxable_public_pension_income": {
+                    "2023": 0
+                },
+                "taxable_self_employment_income": {
+                    "2023": null
+                },
+                "taxable_social_security": {
+                    "2023": null
+                },
+                "taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "total_disability_payments": {
+                    "2023": 0
+                },
+                "total_income": {
+                    "2023": 0
+                },
+                "unadjusted_basis_qualified_property": {
+                    "2023": 0
+                },
+                "uncapped_ssi": {
+                    "2023": null
+                },
+                "under_12_months_postpartum": {
+                    "2023": false
+                },
+                "under_60_days_postpartum": {
+                    "2023": false
+                },
+                "unemployment_compensation": {
+                    "2023": 0
+                },
+                "us_bonds_for_higher_ed": {
+                    "2023": 0
+                },
+                "vehicles_owned": {
+                    "2023": null
+                },
+                "veterans_benefits": {
+                    "2023": 0
+                },
+                "w2_wages_from_qualified_business": {
+                    "2023": 0
+                },
+                "wic": {
+                    "2023": null
+                },
+                "wic_category": {
+                    "2023": null
+                },
+                "wic_category_str": {
+                    "2023": null
+                },
+                "workers_compensation": {
+                    "2023": 0
+                },
+                "would_claim_wic": {
+                    "2023": null
+                }
+            },
+            "your first dependent": {
+                "adjusted_gross_income_person": {
+                    "2023": null
+                },
+                "adult_index": {
+                    "2023": null
+                },
+                "age": {
+                    "2023": 5
+                },
+                "age_group": {
+                    "2023": null
+                },
+                "alimony_expense": {
+                    "2023": 0
+                },
+                "alimony_income": {
+                    "2023": 0
+                },
+                "assessed_property_value": {
+                    "2023": 0
+                },
+                "business_is_qualified": {
+                    "2023": false
+                },
+                "business_is_sstb": {
+                    "2023": false
+                },
+                "ca_cvrp": {
+                    "2023": null
+                },
+                "ca_cvrp_vehicle_rebate_amount": {
+                    "2023": 0
+                },
+                "ca_is_qualifying_child_for_caleitc": {
+                    "2023": null
+                },
+                "capital_gains": {
+                    "2023": null
+                },
+                "capital_losses": {
+                    "2023": null
+                },
+                "casualty_loss": {
+                    "2023": 0
+                },
+                "ccdf_age_group": {
+                    "2023": null
+                },
+                "ccdf_duration_of_care": {
+                    "2023": null
+                },
+                "ccdf_market_rate": {
+                    "2023": null
+                },
+                "cdcc_qualified_dependent": {
+                    "2023": null
+                },
+                "charitable_cash_donations": {
+                    "2023": 0
+                },
+                "charitable_non_cash_donations": {
+                    "2023": 0
+                },
+                "child_support_expense": {
+                    "2023": 0
+                },
+                "child_support_received": {
+                    "2023": 0
+                },
+                "childcare_days_per_week": {
+                    "2023": 0
+                },
+                "childcare_hours_per_day": {
+                    "2023": 0
+                },
+                "childcare_hours_per_week": {
+                    "2023": null
+                },
+                "childcare_provider_type_group": {
+                    "2023": "DCC_SACC"
+                },
+                "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+                    "2023": false
+                },
+                "cliff_evaluated": {
+                    "2023": null
+                },
+                "cliff_gap": {
+                    "2023": null
+                },
+                "cmbtp": {
+                    "2023": 0
+                },
+                "co_oap": {
+                    "2023": null
+                },
+                "co_oap_eligible": {
+                    "2023": null
+                },
+                "co_state_supplement": {
+                    "2023": null
+                },
+                "co_state_supplement_eligible": {
+                    "2023": null
+                },
+                "count_days_postpartum": {
+                    "2023": null
+                },
+                "cps_race": {
+                    "2023": 0
+                },
+                "ctc_adult_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum_arpa": {
+                    "2023": null
+                },
+                "ctc_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_qualifying_child": {
+                    "2023": null
+                },
+                "dc_agi": {
+                    "2023": null
+                },
+                "dc_deduction_indiv": {
+                    "2023": null
+                },
+                "dc_disabled_exclusion_subtraction": {
+                    "2023": null
+                },
+                "dc_income_additions": {
+                    "2023": null
+                },
+                "dc_income_subtractions": {
+                    "2023": null
+                },
+                "dc_self_employment_loss_addition": {
+                    "2023": null
+                },
+                "dc_taxable_income_indiv": {
+                    "2023": null
+                },
+                "debt_relief": {
+                    "2023": 0
+                },
+                "disability_benefits": {
+                    "2023": 0
+                },
+                "dividend_income": {
+                    "2023": null
+                },
+                "e00200": {
+                    "2023": null
+                },
+                "e00300": {
+                    "2023": null
+                },
+                "e02300": {
+                    "2023": 0
+                },
+                "e02400": {
+                    "2023": null
+                },
+                "e87530": {
+                    "2023": 0
+                },
+                "early_withdrawal_penalty": {
+                    "2023": 0
+                },
+                "earned": {
+                    "2023": null
+                },
+                "earned_income": {
+                    "2023": null
+                },
+                "educator_expense": {
+                    "2023": 0
+                },
+                "employee_medicare_tax": {
+                    "2023": null
+                },
+                "employee_social_security_tax": {
+                    "2023": null
+                },
+                "employment_income": {
+                    "2023": 0
+                },
+                "farm_income": {
+                    "2023": 0
+                },
+                "farm_rent_income": {
+                    "2023": 0
+                },
+                "general_assistance": {
+                    "2023": 0
+                },
+                "gi_cash_assistance": {
+                    "2023": 0
+                },
+                "has_disabled_spouse": {
+                    "2023": null
+                },
+                "has_marketplace_health_coverage": {
+                    "2023": true
+                },
+                "health_insurance_premiums": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_indiv": {
+                    "2023": null
+                },
+                "ia_alternate_tax_joint": {
+                    "2023": null
+                },
+                "ia_amt_indiv": {
+                    "2023": null
+                },
+                "ia_amt_joint": {
+                    "2023": null
+                },
+                "ia_base_tax_indiv": {
+                    "2023": null
+                },
+                "ia_base_tax_joint": {
+                    "2023": null
+                },
+                "ia_basic_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_basic_deduction_joint": {
+                    "2023": null
+                },
+                "ia_fedtax_deduction": {
+                    "2023": null
+                },
+                "ia_gross_income": {
+                    "2023": null
+                },
+                "ia_income_adjustments": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_indiv": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_joint": {
+                    "2023": null
+                },
+                "ia_net_income": {
+                    "2023": null
+                },
+                "ia_pension_exclusion": {
+                    "2023": null
+                },
+                "ia_prorate_fraction": {
+                    "2023": null
+                },
+                "ia_qbi_deduction": {
+                    "2023": null
+                },
+                "ia_regular_tax_indiv": {
+                    "2023": null
+                },
+                "ia_regular_tax_joint": {
+                    "2023": null
+                },
+                "ia_standard_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_standard_deduction_joint": {
+                    "2023": null
+                },
+                "ia_taxable_income_indiv": {
+                    "2023": null
+                },
+                "ia_taxable_income_joint": {
+                    "2023": null
+                },
+                "illicit_income": {
+                    "2023": 0
+                },
+                "in_is_qualifying_dependent_child": {
+                    "2023": null
+                },
+                "in_unified_elderly_tax_income": {
+                    "2023": null
+                },
+                "incapable_of_self_care": {
+                    "2023": false
+                },
+                "income_decile": {
+                    "2023": null
+                },
+                "interest_expense": {
+                    "2023": 0
+                },
+                "interest_income": {
+                    "2023": null
+                },
+                "ira_contributions": {
+                    "2023": 0
+                },
+                "irs_gross_income": {
+                    "2023": null
+                },
+                "is_adult": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_blind": {
+                    "2023": false
+                },
+                "is_breastfeeding": {
+                    "2023": false
+                },
+                "is_ca_cvrp_increased_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ca_cvrp_normal_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_age_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_home_based": {
+                    "2023": null
+                },
+                "is_ccdf_reason_for_care_eligible": {
+                    "2023": null
+                },
+                "is_cdcc_eligible": {
+                    "2023": null
+                },
+                "is_child": {
+                    "2023": null
+                },
+                "is_child_of_tax_head": {
+                    "2023": null
+                },
+                "is_citizen": {
+                    "2023": false
+                },
+                "is_disabled": {
+                    "2023": false
+                },
+                "is_eitc_qualifying_child": {
+                    "2023": null
+                },
+                "is_eligible_for_american_opportunity_credit": {
+                    "2023": false
+                },
+                "is_enrolled_in_ccdf": {
+                    "2023": false
+                },
+                "is_father": {
+                    "2023": null
+                },
+                "is_female": {
+                    "2023": false
+                },
+                "is_full_time_college_student": {
+                    "2023": false
+                },
+                "is_full_time_student": {
+                    "2023": null
+                },
+                "is_fully_disabled_service_connected_veteran": {
+                    "2023": false
+                },
+                "is_hispanic": {
+                    "2023": false
+                },
+                "is_in_k12_nonpublic_school": {
+                    "2023": false
+                },
+                "is_in_k12_school": {
+                    "2023": null
+                },
+                "is_in_medicaid_medically_needy_category": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_male": {
+                    "2023": null
+                },
+                "is_medicaid_eligible": {
+                    "2023": null
+                },
+                "is_medically_needy_for_medicaid": {
+                    "2023": null
+                },
+                "is_mother": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_on_cliff": {
+                    "2023": null
+                },
+                "is_optional_senior_or_disabled_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_permanently_and_totally_disabled": {
+                    "2023": false
+                },
+                "is_permanently_disabled_veteran": {
+                    "2023": false
+                },
+                "is_person_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_pregnant": {
+                    "2023": false
+                },
+                "is_pregnant_for_medicaid": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_retired": {
+                    "2023": null
+                },
+                "is_self_employed": {
+                    "2023": false
+                },
+                "is_senior": {
+                    "2023": null
+                },
+                "is_severely_disabled": {
+                    "2023": false
+                },
+                "is_ssi_aged": {
+                    "2023": null
+                },
+                "is_ssi_aged_blind_disabled": {
+                    "2023": null
+                },
+                "is_ssi_disabled": {
+                    "2023": null
+                },
+                "is_ssi_eligible_individual": {
+                    "2023": null
+                },
+                "is_ssi_eligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_child": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_parent": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_recipient_for_medicaid": {
+                    "2023": null
+                },
+                "is_surviving_child_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_surviving_spouse_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_tax_unit_dependent": {
+                    "2023": true
+                },
+                "is_tax_unit_head": {
+                    "2023": null
+                },
+                "is_tax_unit_spouse": {
+                    "2023": null
+                },
+                "is_usda_disabled": {
+                    "2023": null
+                },
+                "is_usda_elderly": {
+                    "2023": null
+                },
+                "is_wa_adult": {
+                    "2023": null
+                },
+                "is_wic_at_nutritional_risk": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "k1bx14": {
+                    "2023": 0
+                },
+                "long_term_capital_gains": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_collectibles": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_small_business_stock": {
+                    "2023": 0
+                },
+                "ma_covid_19_essential_employee_premium_pay_program": {
+                    "2023": null
+                },
+                "marginal_tax_rate": {
+                    "2023": null
+                },
+                "market_income": {
+                    "2023": null
+                },
+                "maximum_state_supplement": {
+                    "2023": null
+                },
+                "md_pension_subtraction_amount": {
+                    "2023": null
+                },
+                "md_socsec_subtraction_amount": {
+                    "2023": null
+                },
+                "medicaid": {
+                    "2023": null
+                },
+                "medicaid_benefit_value": {
+                    "2023": null
+                },
+                "medicaid_category": {
+                    "2023": null
+                },
+                "medicaid_income_level": {
+                    "2023": null
+                },
+                "medical_expense": {
+                    "2023": null
+                },
+                "medical_out_of_pocket_expenses": {
+                    "2023": 0
+                },
+                "meets_ssi_resource_test": {
+                    "2023": null
+                },
+                "meets_wic_categorical_eligibility": {
+                    "2023": null
+                },
+                "military_basic_pay": {
+                    "2023": 0
+                },
+                "military_retirement_pay": {
+                    "2023": 0
+                },
+                "military_service_income": {
+                    "2023": 0
+                },
+                "miscellaneous_income": {
+                    "2023": 0
+                },
+                "mo_adjusted_gross_income": {
+                    "2023": null
+                },
+                "mo_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mo_income_tax_exempt": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_a": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_b": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_c": {
+                    "2023": null
+                },
+                "mo_qualified_health_insurance_premiums": {
+                    "2023": null
+                },
+                "mo_taxable_income": {
+                    "2023": null
+                },
+                "net_income": {
+                    "2023": 0
+                },
+                "nm_cdcc_eligible_child": {
+                    "2023": null
+                },
+                "non_public_school_tuition": {
+                    "2023": 0
+                },
+                "non_qualified_dividend_income": {
+                    "2023": 0
+                },
+                "non_sch_d_capital_gains": {
+                    "2023": 0
+                },
+                "oh_has_not_taken_oh_lump_sum_credits": {
+                    "2023": false
+                },
+                "own_children_in_household": {
+                    "2023": 0
+                },
+                "pa_nontaxable_pension_income": {
+                    "2023": null
+                },
+                "partnership_s_corp_income": {
+                    "2023": 0
+                },
+                "payroll_tax_gross_wages": {
+                    "2023": null
+                },
+                "pencon": {
+                    "2023": 0
+                },
+                "pension_contributions": {
+                    "2023": null
+                },
+                "pension_income": {
+                    "2023": null
+                },
+                "people": {
+                    "2023": 1
+                },
+                "per_vehicle_payment": {
+                    "2023": null
+                },
+                "person_family_id": {
+                    "2023": 0
+                },
+                "person_household_id": {
+                    "2023": 0
+                },
+                "person_id": {
+                    "2023": null
+                },
+                "person_in_poverty": {
+                    "2023": null
+                },
+                "person_marital_unit_id": {
+                    "2023": 0
+                },
+                "person_spm_unit_id": {
+                    "2023": 0
+                },
+                "person_tax_unit_id": {
+                    "2023": 0
+                },
+                "person_weight": {
+                    "2023": null
+                },
+                "private_pension_income": {
+                    "2023": null
+                },
+                "public_pension_income": {
+                    "2023": null
+                },
+                "qbid_amount": {
+                    "2023": null
+                },
+                "qualified_adoption_assistance_expense": {
+                    "2023": 0
+                },
+                "qualified_business_income": {
+                    "2023": null
+                },
+                "qualified_dividend_income": {
+                    "2023": 0
+                },
+                "qualified_tuition_expenses": {
+                    "2023": 0
+                },
+                "qualifies_for_elderly_or_disabled_credit": {
+                    "2023": null
+                },
+                "race": {
+                    "2023": null
+                },
+                "real_estate_taxes": {
+                    "2023": 0
+                },
+                "receives_or_needs_protective_services": {
+                    "2023": false
+                },
+                "receives_wic": {
+                    "2023": false
+                },
+                "rent": {
+                    "2023": 0
+                },
+                "rental_income": {
+                    "2023": 0
+                },
+                "retired_on_total_disability": {
+                    "2023": false
+                },
+                "salt_refund_income": {
+                    "2023": 0
+                },
+                "self_employed_health_insurance_ald_person": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_premiums": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald_person": {
+                    "2023": null
+                },
+                "self_employed_pension_contributions": {
+                    "2023": 0
+                },
+                "self_employment_income": {
+                    "2023": 0
+                },
+                "self_employment_medicare_tax": {
+                    "2023": null
+                },
+                "self_employment_social_security_tax": {
+                    "2023": null
+                },
+                "self_employment_tax": {
+                    "2023": null
+                },
+                "self_employment_tax_ald_person": {
+                    "2023": null
+                },
+                "sep_simple_qualified_plan_contributions": {
+                    "2023": 0
+                },
+                "sey": {
+                    "2023": null
+                },
+                "short_term_capital_gains": {
+                    "2023": 0
+                },
+                "social_security": {
+                    "2023": null
+                },
+                "social_security_dependents": {
+                    "2023": 0
+                },
+                "social_security_disability": {
+                    "2023": 0
+                },
+                "social_security_retirement": {
+                    "2023": 0
+                },
+                "social_security_survivors": {
+                    "2023": 0
+                },
+                "social_security_taxable_self_employment_income": {
+                    "2023": null
+                },
+                "ssi": {
+                    "2023": null
+                },
+                "ssi_amount_if_eligible": {
+                    "2023": null
+                },
+                "ssi_category": {
+                    "2023": "NONE"
+                },
+                "ssi_claim_is_joint": {
+                    "2023": null
+                },
+                "ssi_countable_income": {
+                    "2023": null
+                },
+                "ssi_countable_resources": {
+                    "2023": 0
+                },
+                "ssi_earned_income": {
+                    "2023": null
+                },
+                "ssi_earned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_ineligible_child_allocation": {
+                    "2023": null
+                },
+                "ssi_ineligible_parent_allocation": {
+                    "2023": null
+                },
+                "ssi_reported": {
+                    "2023": 0
+                },
+                "ssi_unearned_income": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_parent": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "state_or_federal_salary": {
+                    "2023": 0
+                },
+                "state_supplement": {
+                    "2023": null
+                },
+                "strike_benefits": {
+                    "2023": 0
+                },
+                "student_loan_interest": {
+                    "2023": 0
+                },
+                "tanf_person": {
+                    "2023": null
+                },
+                "tanf_reported": {
+                    "2023": 0
+                },
+                "tax_exempt_interest_income": {
+                    "2023": 0
+                },
+                "tax_exempt_pension_income": {
+                    "2023": null
+                },
+                "tax_exempt_private_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_public_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_unemployment_compensation": {
+                    "2023": null
+                },
+                "taxable_earnings_for_social_security": {
+                    "2023": null
+                },
+                "taxable_interest_income": {
+                    "2023": 0
+                },
+                "taxable_pension_income": {
+                    "2023": null
+                },
+                "taxable_private_pension_income": {
+                    "2023": 0
+                },
+                "taxable_public_pension_income": {
+                    "2023": 0
+                },
+                "taxable_self_employment_income": {
+                    "2023": null
+                },
+                "taxable_social_security": {
+                    "2023": null
+                },
+                "taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "total_disability_payments": {
+                    "2023": 0
+                },
+                "total_income": {
+                    "2023": 0
+                },
+                "unadjusted_basis_qualified_property": {
+                    "2023": 0
+                },
+                "uncapped_ssi": {
+                    "2023": null
+                },
+                "under_12_months_postpartum": {
+                    "2023": false
+                },
+                "under_60_days_postpartum": {
+                    "2023": false
+                },
+                "unemployment_compensation": {
+                    "2023": 0
+                },
+                "us_bonds_for_higher_ed": {
+                    "2023": 0
+                },
+                "vehicles_owned": {
+                    "2023": null
+                },
+                "veterans_benefits": {
+                    "2023": 0
+                },
+                "w2_wages_from_qualified_business": {
+                    "2023": 0
+                },
+                "wic": {
+                    "2023": null
+                },
+                "wic_category": {
+                    "2023": null
+                },
+                "wic_category_str": {
+                    "2023": null
+                },
+                "workers_compensation": {
+                    "2023": 0
+                },
+                "would_claim_wic": {
+                    "2023": null
+                }
+            },
+            "your second dependent": {
+                "adjusted_gross_income_person": {
+                    "2023": null
+                },
+                "adult_index": {
+                    "2023": null
+                },
+                "age": {
+                    "2023": 3
+                },
+                "age_group": {
+                    "2023": null
+                },
+                "alimony_expense": {
+                    "2023": 0
+                },
+                "alimony_income": {
+                    "2023": 0
+                },
+                "assessed_property_value": {
+                    "2023": 0
+                },
+                "business_is_qualified": {
+                    "2023": false
+                },
+                "business_is_sstb": {
+                    "2023": false
+                },
+                "ca_cvrp": {
+                    "2023": null
+                },
+                "ca_cvrp_vehicle_rebate_amount": {
+                    "2023": 0
+                },
+                "ca_is_qualifying_child_for_caleitc": {
+                    "2023": null
+                },
+                "capital_gains": {
+                    "2023": null
+                },
+                "capital_losses": {
+                    "2023": null
+                },
+                "casualty_loss": {
+                    "2023": 0
+                },
+                "ccdf_age_group": {
+                    "2023": null
+                },
+                "ccdf_duration_of_care": {
+                    "2023": null
+                },
+                "ccdf_market_rate": {
+                    "2023": null
+                },
+                "cdcc_qualified_dependent": {
+                    "2023": null
+                },
+                "charitable_cash_donations": {
+                    "2023": 0
+                },
+                "charitable_non_cash_donations": {
+                    "2023": 0
+                },
+                "child_support_expense": {
+                    "2023": 0
+                },
+                "child_support_received": {
+                    "2023": 0
+                },
+                "childcare_days_per_week": {
+                    "2023": 0
+                },
+                "childcare_hours_per_day": {
+                    "2023": 0
+                },
+                "childcare_hours_per_week": {
+                    "2023": null
+                },
+                "childcare_provider_type_group": {
+                    "2023": "DCC_SACC"
+                },
+                "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+                    "2023": false
+                },
+                "cliff_evaluated": {
+                    "2023": null
+                },
+                "cliff_gap": {
+                    "2023": null
+                },
+                "cmbtp": {
+                    "2023": 0
+                },
+                "co_oap": {
+                    "2023": null
+                },
+                "co_oap_eligible": {
+                    "2023": null
+                },
+                "co_state_supplement": {
+                    "2023": null
+                },
+                "co_state_supplement_eligible": {
+                    "2023": null
+                },
+                "count_days_postpartum": {
+                    "2023": null
+                },
+                "cps_race": {
+                    "2023": 0
+                },
+                "ctc_adult_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_child_individual_maximum_arpa": {
+                    "2023": null
+                },
+                "ctc_individual_maximum": {
+                    "2023": null
+                },
+                "ctc_qualifying_child": {
+                    "2023": null
+                },
+                "dc_agi": {
+                    "2023": null
+                },
+                "dc_deduction_indiv": {
+                    "2023": null
+                },
+                "dc_disabled_exclusion_subtraction": {
+                    "2023": null
+                },
+                "dc_income_additions": {
+                    "2023": null
+                },
+                "dc_income_subtractions": {
+                    "2023": null
+                },
+                "dc_self_employment_loss_addition": {
+                    "2023": null
+                },
+                "dc_taxable_income_indiv": {
+                    "2023": null
+                },
+                "debt_relief": {
+                    "2023": 0
+                },
+                "disability_benefits": {
+                    "2023": 0
+                },
+                "dividend_income": {
+                    "2023": null
+                },
+                "e00200": {
+                    "2023": null
+                },
+                "e00300": {
+                    "2023": null
+                },
+                "e02300": {
+                    "2023": 0
+                },
+                "e02400": {
+                    "2023": null
+                },
+                "e87530": {
+                    "2023": 0
+                },
+                "early_withdrawal_penalty": {
+                    "2023": 0
+                },
+                "earned": {
+                    "2023": null
+                },
+                "earned_income": {
+                    "2023": null
+                },
+                "educator_expense": {
+                    "2023": 0
+                },
+                "employee_medicare_tax": {
+                    "2023": null
+                },
+                "employee_social_security_tax": {
+                    "2023": null
+                },
+                "employment_income": {
+                    "2023": 0
+                },
+                "farm_income": {
+                    "2023": 0
+                },
+                "farm_rent_income": {
+                    "2023": 0
+                },
+                "general_assistance": {
+                    "2023": 0
+                },
+                "gi_cash_assistance": {
+                    "2023": 0
+                },
+                "has_disabled_spouse": {
+                    "2023": null
+                },
+                "has_marketplace_health_coverage": {
+                    "2023": true
+                },
+                "health_insurance_premiums": {
+                    "2023": 0
+                },
+                "ia_alternate_tax_indiv": {
+                    "2023": null
+                },
+                "ia_alternate_tax_joint": {
+                    "2023": null
+                },
+                "ia_amt_indiv": {
+                    "2023": null
+                },
+                "ia_amt_joint": {
+                    "2023": null
+                },
+                "ia_base_tax_indiv": {
+                    "2023": null
+                },
+                "ia_base_tax_joint": {
+                    "2023": null
+                },
+                "ia_basic_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_basic_deduction_joint": {
+                    "2023": null
+                },
+                "ia_fedtax_deduction": {
+                    "2023": null
+                },
+                "ia_gross_income": {
+                    "2023": null
+                },
+                "ia_income_adjustments": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_indiv": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_joint": {
+                    "2023": null
+                },
+                "ia_net_income": {
+                    "2023": null
+                },
+                "ia_pension_exclusion": {
+                    "2023": null
+                },
+                "ia_prorate_fraction": {
+                    "2023": null
+                },
+                "ia_qbi_deduction": {
+                    "2023": null
+                },
+                "ia_regular_tax_indiv": {
+                    "2023": null
+                },
+                "ia_regular_tax_joint": {
+                    "2023": null
+                },
+                "ia_standard_deduction_indiv": {
+                    "2023": null
+                },
+                "ia_standard_deduction_joint": {
+                    "2023": null
+                },
+                "ia_taxable_income_indiv": {
+                    "2023": null
+                },
+                "ia_taxable_income_joint": {
+                    "2023": null
+                },
+                "illicit_income": {
+                    "2023": 0
+                },
+                "in_is_qualifying_dependent_child": {
+                    "2023": null
+                },
+                "in_unified_elderly_tax_income": {
+                    "2023": null
+                },
+                "incapable_of_self_care": {
+                    "2023": false
+                },
+                "income_decile": {
+                    "2023": null
+                },
+                "interest_expense": {
+                    "2023": 0
+                },
+                "interest_income": {
+                    "2023": null
+                },
+                "ira_contributions": {
+                    "2023": 0
+                },
+                "irs_gross_income": {
+                    "2023": null
+                },
+                "is_adult": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_blind": {
+                    "2023": false
+                },
+                "is_breastfeeding": {
+                    "2023": false
+                },
+                "is_ca_cvrp_increased_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ca_cvrp_normal_rebate_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_age_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_home_based": {
+                    "2023": null
+                },
+                "is_ccdf_reason_for_care_eligible": {
+                    "2023": null
+                },
+                "is_cdcc_eligible": {
+                    "2023": null
+                },
+                "is_child": {
+                    "2023": null
+                },
+                "is_child_of_tax_head": {
+                    "2023": null
+                },
+                "is_citizen": {
+                    "2023": false
+                },
+                "is_disabled": {
+                    "2023": false
+                },
+                "is_eitc_qualifying_child": {
+                    "2023": null
+                },
+                "is_eligible_for_american_opportunity_credit": {
+                    "2023": false
+                },
+                "is_enrolled_in_ccdf": {
+                    "2023": false
+                },
+                "is_father": {
+                    "2023": null
+                },
+                "is_female": {
+                    "2023": false
+                },
+                "is_full_time_college_student": {
+                    "2023": false
+                },
+                "is_full_time_student": {
+                    "2023": null
+                },
+                "is_fully_disabled_service_connected_veteran": {
+                    "2023": false
+                },
+                "is_hispanic": {
+                    "2023": false
+                },
+                "is_in_k12_nonpublic_school": {
+                    "2023": false
+                },
+                "is_in_k12_school": {
+                    "2023": null
+                },
+                "is_in_medicaid_medically_needy_category": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_infant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_male": {
+                    "2023": null
+                },
+                "is_medicaid_eligible": {
+                    "2023": null
+                },
+                "is_medically_needy_for_medicaid": {
+                    "2023": null
+                },
+                "is_mother": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_older_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_on_cliff": {
+                    "2023": null
+                },
+                "is_optional_senior_or_disabled_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_parent_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_permanently_and_totally_disabled": {
+                    "2023": false
+                },
+                "is_permanently_disabled_veteran": {
+                    "2023": false
+                },
+                "is_person_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_pregnant": {
+                    "2023": false
+                },
+                "is_pregnant_for_medicaid": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_pregnant_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_retired": {
+                    "2023": null
+                },
+                "is_self_employed": {
+                    "2023": false
+                },
+                "is_senior": {
+                    "2023": null
+                },
+                "is_severely_disabled": {
+                    "2023": false
+                },
+                "is_ssi_aged": {
+                    "2023": null
+                },
+                "is_ssi_aged_blind_disabled": {
+                    "2023": null
+                },
+                "is_ssi_disabled": {
+                    "2023": null
+                },
+                "is_ssi_eligible_individual": {
+                    "2023": null
+                },
+                "is_ssi_eligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_child": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_parent": {
+                    "2023": null
+                },
+                "is_ssi_ineligible_spouse": {
+                    "2023": null
+                },
+                "is_ssi_recipient_for_medicaid": {
+                    "2023": null
+                },
+                "is_surviving_child_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_surviving_spouse_of_disabled_veteran": {
+                    "2023": false
+                },
+                "is_tax_unit_dependent": {
+                    "2023": true
+                },
+                "is_tax_unit_head": {
+                    "2023": null
+                },
+                "is_tax_unit_spouse": {
+                    "2023": null
+                },
+                "is_usda_disabled": {
+                    "2023": null
+                },
+                "is_usda_elderly": {
+                    "2023": null
+                },
+                "is_wa_adult": {
+                    "2023": null
+                },
+                "is_wic_at_nutritional_risk": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_adult_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_fc": {
+                    "2023": null
+                },
+                "is_young_child_for_medicaid_nfc": {
+                    "2023": null
+                },
+                "k1bx14": {
+                    "2023": 0
+                },
+                "long_term_capital_gains": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_collectibles": {
+                    "2023": 0
+                },
+                "long_term_capital_gains_on_small_business_stock": {
+                    "2023": 0
+                },
+                "ma_covid_19_essential_employee_premium_pay_program": {
+                    "2023": null
+                },
+                "marginal_tax_rate": {
+                    "2023": null
+                },
+                "market_income": {
+                    "2023": null
+                },
+                "maximum_state_supplement": {
+                    "2023": null
+                },
+                "md_pension_subtraction_amount": {
+                    "2023": null
+                },
+                "md_socsec_subtraction_amount": {
+                    "2023": null
+                },
+                "medicaid": {
+                    "2023": null
+                },
+                "medicaid_benefit_value": {
+                    "2023": null
+                },
+                "medicaid_category": {
+                    "2023": null
+                },
+                "medicaid_income_level": {
+                    "2023": null
+                },
+                "medical_expense": {
+                    "2023": null
+                },
+                "medical_out_of_pocket_expenses": {
+                    "2023": 0
+                },
+                "meets_ssi_resource_test": {
+                    "2023": null
+                },
+                "meets_wic_categorical_eligibility": {
+                    "2023": null
+                },
+                "military_basic_pay": {
+                    "2023": 0
+                },
+                "military_retirement_pay": {
+                    "2023": 0
+                },
+                "military_service_income": {
+                    "2023": 0
+                },
+                "miscellaneous_income": {
+                    "2023": 0
+                },
+                "mo_adjusted_gross_income": {
+                    "2023": null
+                },
+                "mo_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mo_income_tax_exempt": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_a": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_b": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction_section_c": {
+                    "2023": null
+                },
+                "mo_qualified_health_insurance_premiums": {
+                    "2023": null
+                },
+                "mo_taxable_income": {
+                    "2023": null
+                },
+                "net_income": {
+                    "2023": 0
+                },
+                "nm_cdcc_eligible_child": {
+                    "2023": null
+                },
+                "non_public_school_tuition": {
+                    "2023": 0
+                },
+                "non_qualified_dividend_income": {
+                    "2023": 0
+                },
+                "non_sch_d_capital_gains": {
+                    "2023": 0
+                },
+                "oh_has_not_taken_oh_lump_sum_credits": {
+                    "2023": false
+                },
+                "own_children_in_household": {
+                    "2023": 0
+                },
+                "pa_nontaxable_pension_income": {
+                    "2023": null
+                },
+                "partnership_s_corp_income": {
+                    "2023": 0
+                },
+                "payroll_tax_gross_wages": {
+                    "2023": null
+                },
+                "pencon": {
+                    "2023": 0
+                },
+                "pension_contributions": {
+                    "2023": null
+                },
+                "pension_income": {
+                    "2023": null
+                },
+                "people": {
+                    "2023": 1
+                },
+                "per_vehicle_payment": {
+                    "2023": null
+                },
+                "person_family_id": {
+                    "2023": 0
+                },
+                "person_household_id": {
+                    "2023": 0
+                },
+                "person_id": {
+                    "2023": null
+                },
+                "person_in_poverty": {
+                    "2023": null
+                },
+                "person_marital_unit_id": {
+                    "2023": 0
+                },
+                "person_spm_unit_id": {
+                    "2023": 0
+                },
+                "person_tax_unit_id": {
+                    "2023": 0
+                },
+                "person_weight": {
+                    "2023": null
+                },
+                "private_pension_income": {
+                    "2023": null
+                },
+                "public_pension_income": {
+                    "2023": null
+                },
+                "qbid_amount": {
+                    "2023": null
+                },
+                "qualified_adoption_assistance_expense": {
+                    "2023": 0
+                },
+                "qualified_business_income": {
+                    "2023": null
+                },
+                "qualified_dividend_income": {
+                    "2023": 0
+                },
+                "qualified_tuition_expenses": {
+                    "2023": 0
+                },
+                "qualifies_for_elderly_or_disabled_credit": {
+                    "2023": null
+                },
+                "race": {
+                    "2023": null
+                },
+                "real_estate_taxes": {
+                    "2023": 0
+                },
+                "receives_or_needs_protective_services": {
+                    "2023": false
+                },
+                "receives_wic": {
+                    "2023": false
+                },
+                "rent": {
+                    "2023": 0
+                },
+                "rental_income": {
+                    "2023": 0
+                },
+                "retired_on_total_disability": {
+                    "2023": false
+                },
+                "salt_refund_income": {
+                    "2023": 0
+                },
+                "self_employed_health_insurance_ald_person": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_premiums": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald_person": {
+                    "2023": null
+                },
+                "self_employed_pension_contributions": {
+                    "2023": 0
+                },
+                "self_employment_income": {
+                    "2023": 0
+                },
+                "self_employment_medicare_tax": {
+                    "2023": null
+                },
+                "self_employment_social_security_tax": {
+                    "2023": null
+                },
+                "self_employment_tax": {
+                    "2023": null
+                },
+                "self_employment_tax_ald_person": {
+                    "2023": null
+                },
+                "sep_simple_qualified_plan_contributions": {
+                    "2023": 0
+                },
+                "sey": {
+                    "2023": null
+                },
+                "short_term_capital_gains": {
+                    "2023": 0
+                },
+                "social_security": {
+                    "2023": null
+                },
+                "social_security_dependents": {
+                    "2023": 0
+                },
+                "social_security_disability": {
+                    "2023": 0
+                },
+                "social_security_retirement": {
+                    "2023": 0
+                },
+                "social_security_survivors": {
+                    "2023": 0
+                },
+                "social_security_taxable_self_employment_income": {
+                    "2023": null
+                },
+                "ssi": {
+                    "2023": null
+                },
+                "ssi_amount_if_eligible": {
+                    "2023": null
+                },
+                "ssi_category": {
+                    "2023": "NONE"
+                },
+                "ssi_claim_is_joint": {
+                    "2023": null
+                },
+                "ssi_countable_income": {
+                    "2023": null
+                },
+                "ssi_countable_resources": {
+                    "2023": 0
+                },
+                "ssi_earned_income": {
+                    "2023": null
+                },
+                "ssi_earned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "ssi_ineligible_child_allocation": {
+                    "2023": null
+                },
+                "ssi_ineligible_parent_allocation": {
+                    "2023": null
+                },
+                "ssi_reported": {
+                    "2023": 0
+                },
+                "ssi_unearned_income": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_parent": {
+                    "2023": null
+                },
+                "ssi_unearned_income_deemed_from_ineligible_spouse": {
+                    "2023": null
+                },
+                "state_or_federal_salary": {
+                    "2023": 0
+                },
+                "state_supplement": {
+                    "2023": null
+                },
+                "strike_benefits": {
+                    "2023": 0
+                },
+                "student_loan_interest": {
+                    "2023": 0
+                },
+                "tanf_person": {
+                    "2023": null
+                },
+                "tanf_reported": {
+                    "2023": 0
+                },
+                "tax_exempt_interest_income": {
+                    "2023": 0
+                },
+                "tax_exempt_pension_income": {
+                    "2023": null
+                },
+                "tax_exempt_private_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_public_pension_income": {
+                    "2023": 0
+                },
+                "tax_exempt_unemployment_compensation": {
+                    "2023": null
+                },
+                "taxable_earnings_for_social_security": {
+                    "2023": null
+                },
+                "taxable_interest_income": {
+                    "2023": 0
+                },
+                "taxable_pension_income": {
+                    "2023": null
+                },
+                "taxable_private_pension_income": {
+                    "2023": 0
+                },
+                "taxable_public_pension_income": {
+                    "2023": 0
+                },
+                "taxable_self_employment_income": {
+                    "2023": null
+                },
+                "taxable_social_security": {
+                    "2023": null
+                },
+                "taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "total_disability_payments": {
+                    "2023": 0
+                },
+                "total_income": {
+                    "2023": 0
+                },
+                "unadjusted_basis_qualified_property": {
+                    "2023": 0
+                },
+                "uncapped_ssi": {
+                    "2023": null
+                },
+                "under_12_months_postpartum": {
+                    "2023": false
+                },
+                "under_60_days_postpartum": {
+                    "2023": false
+                },
+                "unemployment_compensation": {
+                    "2023": 0
+                },
+                "us_bonds_for_higher_ed": {
+                    "2023": 0
+                },
+                "vehicles_owned": {
+                    "2023": null
+                },
+                "veterans_benefits": {
+                    "2023": 0
+                },
+                "w2_wages_from_qualified_business": {
+                    "2023": 0
+                },
+                "wic": {
+                    "2023": null
+                },
+                "wic_category": {
+                    "2023": null
+                },
+                "wic_category_str": {
+                    "2023": null
+                },
+                "workers_compensation": {
+                    "2023": 0
+                },
+                "would_claim_wic": {
+                    "2023": null
+                }
+            }
+        },
+        "spm_units": {
+            "your household": {
+                "acp": {
+                    "2023": null
+                },
+                "ami": {
+                    "2023": 0
+                },
+                "broadband_cost": {
+                    "2023": 0
+                },
+                "broadband_cost_after_lifeline": {
+                    "2023": null
+                },
+                "ccdf_income": {
+                    "2023": null
+                },
+                "ccdf_income_to_smi_ratio": {
+                    "2023": null
+                },
+                "childcare_expenses": {
+                    "2023": 6000
+                },
+                "co_tanf": {
+                    "2023": null
+                },
+                "co_tanf_count_children": {
+                    "2023": null
+                },
+                "co_tanf_countable_earned_income_grant_standard": {
+                    "2023": null
+                },
+                "co_tanf_countable_earned_income_need": {
+                    "2023": null
+                },
+                "co_tanf_countable_gross_earned_income": {
+                    "2023": null
+                },
+                "co_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "co_tanf_eligible": {
+                    "2023": null
+                },
+                "co_tanf_grant_standard": {
+                    "2023": null
+                },
+                "co_tanf_income_eligible": {
+                    "2023": null
+                },
+                "co_tanf_need_standard": {
+                    "2023": null
+                },
+                "count_distinct_utility_expenses": {
+                    "2023": null
+                },
+                "dc_tanf": {
+                    "2023": null
+                },
+                "dc_tanf_countable_earned_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_income": {
+                    "2023": null
+                },
+                "dc_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "dc_tanf_eligible": {
+                    "2023": null
+                },
+                "dc_tanf_grant_standard": {
+                    "2023": null
+                },
+                "dc_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "dc_tanf_income_eligible": {
+                    "2023": null
+                },
+                "dc_tanf_need_standard": {
+                    "2023": null
+                },
+                "dc_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "deep_poverty_gap": {
+                    "2023": null
+                },
+                "deep_poverty_line": {
+                    "2023": null
+                },
+                "ebb": {
+                    "2023": null
+                },
+                "electricity_expense": {
+                    "2023": 0
+                },
+                "enrolled_in_ebb": {
+                    "2023": false
+                },
+                "experienced_covid_income_loss": {
+                    "2023": false
+                },
+                "fcc_fpg_ratio": {
+                    "2023": null
+                },
+                "fdpir": {
+                    "2023": 0
+                },
+                "free_school_meals": {
+                    "2023": null
+                },
+                "free_school_meals_reported": {
+                    "2023": 0
+                },
+                "gas_expense": {
+                    "2023": 0
+                },
+                "has_all_usda_elderly_disabled": {
+                    "2023": null
+                },
+                "has_heating_cooling_expense": {
+                    "2023": null
+                },
+                "has_phone_expense": {
+                    "2023": null
+                },
+                "has_usda_elderly_disabled": {
+                    "2023": null
+                },
+                "heating_cooling_expense": {
+                    "2023": 0
+                },
+                "hhs_smi": {
+                    "2023": null
+                },
+                "housing_assistance": {
+                    "2023": null
+                },
+                "housing_cost": {
+                    "2023": null
+                },
+                "housing_designated_welfare": {
+                    "2023": 0
+                },
+                "hud_adjusted_income": {
+                    "2023": null
+                },
+                "hud_annual_income": {
+                    "2023": null
+                },
+                "hud_gross_rent": {
+                    "2023": null
+                },
+                "hud_hap": {
+                    "2023": null
+                },
+                "hud_income_level": {
+                    "2023": null
+                },
+                "hud_max_subsidy": {
+                    "2023": null
+                },
+                "hud_minimum_rent": {
+                    "2023": 0
+                },
+                "hud_ttp": {
+                    "2023": null
+                },
+                "hud_ttp_adjusted_income_share": {
+                    "2023": null
+                },
+                "hud_ttp_income_share": {
+                    "2023": null
+                },
+                "hud_utility_allowance": {
+                    "2023": 0
+                },
+                "in_deep_poverty": {
+                    "2023": null
+                },
+                "in_poverty": {
+                    "2023": null
+                },
+                "is_acp_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_asset_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_continuous_income_eligible": {
+                    "2023": false
+                },
+                "is_ccdf_income_eligible": {
+                    "2023": null
+                },
+                "is_ccdf_initial_income_eligible": {
+                    "2023": false
+                },
+                "is_demographic_tanf_eligible": {
+                    "2023": null
+                },
+                "is_ebb_eligible": {
+                    "2023": null
+                },
+                "is_eligible_for_housing_assistance": {
+                    "2023": null
+                },
+                "is_hud_elderly_disabled_family": {
+                    "2023": null
+                },
+                "is_lifeline_eligible": {
+                    "2023": null
+                },
+                "is_snap_eligible": {
+                    "2023": null
+                },
+                "is_tanf_continuous_eligible": {
+                    "2023": null
+                },
+                "is_tanf_eligible": {
+                    "2023": null
+                },
+                "is_tanf_enrolled": {
+                    "2023": false
+                },
+                "is_tanf_initial_eligible": {
+                    "2023": null
+                },
+                "is_tanf_non_cash_eligible": {
+                    "2023": null
+                },
+                "is_tanf_non_cash_hheod": {
+                    "2023": null
+                },
+                "lifeline": {
+                    "2023": null
+                },
+                "md_tanf_count_children": {
+                    "2023": null
+                },
+                "md_tanf_eligible": {
+                    "2023": false
+                },
+                "md_tanf_gross_earned_income_deduction": {
+                    "2023": null
+                },
+                "md_tanf_maximum_benefit": {
+                    "2023": null
+                },
+                "meets_ccdf_activity_test": {
+                    "2023": false
+                },
+                "meets_school_meal_categorical_eligibility": {
+                    "2023": null
+                },
+                "meets_snap_asset_test": {
+                    "2023": null
+                },
+                "meets_snap_categorical_eligibility": {
+                    "2023": null
+                },
+                "meets_snap_gross_income_test": {
+                    "2023": null
+                },
+                "meets_snap_net_income_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_asset_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_gross_income_test": {
+                    "2023": null
+                },
+                "meets_tanf_non_cash_net_income_test": {
+                    "2023": null
+                },
+                "meets_wic_income_test": {
+                    "2023": null
+                },
+                "members": [
+                    "you",
+                    "your first dependent",
+                    "your second dependent"
+                ],
+                "mo_tanf_income_limit": {
+                    "2023": null
+                },
+                "nj_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "nj_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "nj_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "nj_tanf_maximum_allowable_income": {
+                    "2023": null
+                },
+                "nj_tanf_maximum_benefit": {
+                    "2023": null
+                },
+                "nj_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "ny_tanf": {
+                    "2023": null
+                },
+                "ny_tanf_countable_earned_income": {
+                    "2023": null
+                },
+                "ny_tanf_countable_gross_unearned_income": {
+                    "2023": null
+                },
+                "ny_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "ny_tanf_eligible": {
+                    "2023": null
+                },
+                "ny_tanf_grant_standard": {
+                    "2023": null
+                },
+                "ny_tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "ny_tanf_income_eligible": {
+                    "2023": null
+                },
+                "ny_tanf_need_standard": {
+                    "2023": null
+                },
+                "ny_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "ok_tanf": {
+                    "2023": 0
+                },
+                "pa_tanf_age_eligible": {
+                    "2023": null
+                },
+                "pa_tanf_age_eligible_on_pregnant_women_limitation": {
+                    "2023": null
+                },
+                "pa_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "pa_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "pell_grant": {
+                    "2023": 0
+                },
+                "pha_payment_standard": {
+                    "2023": 0
+                },
+                "phone_cost": {
+                    "2023": 0
+                },
+                "phone_expense": {
+                    "2023": null
+                },
+                "poverty_gap": {
+                    "2023": null
+                },
+                "poverty_line": {
+                    "2023": null
+                },
+                "receives_housing_assistance": {
+                    "2023": false
+                },
+                "reduced_price_school_meals": {
+                    "2023": null
+                },
+                "school_meal_countable_income": {
+                    "2023": null
+                },
+                "school_meal_daily_subsidy": {
+                    "2023": null
+                },
+                "school_meal_fpg_ratio": {
+                    "2023": null
+                },
+                "school_meal_net_subsidy": {
+                    "2023": null
+                },
+                "school_meal_paid_daily_subsidy": {
+                    "2023": null
+                },
+                "school_meal_tier": {
+                    "2023": null
+                },
+                "sewage_expense": {
+                    "2023": 0
+                },
+                "snap": {
+                    "2023": null
+                },
+                "snap_assets": {
+                    "2023": 0
+                },
+                "snap_child_support_deduction": {
+                    "2023": null
+                },
+                "snap_child_support_gross_income_deduction": {
+                    "2023": null
+                },
+                "snap_deductions": {
+                    "2023": null
+                },
+                "snap_dependent_care_deduction": {
+                    "2023": null
+                },
+                "snap_earned_income": {
+                    "2023": null
+                },
+                "snap_earned_income_deduction": {
+                    "2023": null
+                },
+                "snap_emergency_allotment": {
+                    "2023": null
+                },
+                "snap_excess_medical_expense_deduction": {
+                    "2023": null
+                },
+                "snap_excess_shelter_expense_deduction": {
+                    "2023": null
+                },
+                "snap_expected_contribution": {
+                    "2023": null
+                },
+                "snap_gross_income": {
+                    "2023": null
+                },
+                "snap_gross_income_fpg_ratio": {
+                    "2023": null
+                },
+                "snap_max_allotment": {
+                    "2023": null
+                },
+                "snap_min_allotment": {
+                    "2023": null
+                },
+                "snap_net_income": {
+                    "2023": null
+                },
+                "snap_net_income_fpg_ratio": {
+                    "2023": null
+                },
+                "snap_net_income_pre_shelter": {
+                    "2023": null
+                },
+                "snap_normal_allotment": {
+                    "2023": null
+                },
+                "snap_reported": {
+                    "2023": 0
+                },
+                "snap_standard_deduction": {
+                    "2023": null
+                },
+                "snap_unearned_income": {
+                    "2023": null
+                },
+                "snap_utility_allowance": {
+                    "2023": null
+                },
+                "snap_utility_allowance_type": {
+                    "2023": null
+                },
+                "spm_unit_assets": {
+                    "2023": 0
+                },
+                "spm_unit_benefits": {
+                    "2023": null
+                },
+                "spm_unit_capped_housing_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_capped_housing_subsidy_reported": {
+                    "2023": 0
+                },
+                "spm_unit_capped_work_childcare_expenses": {
+                    "2023": 0
+                },
+                "spm_unit_ccdf_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_count_adults": {
+                    "2023": null
+                },
+                "spm_unit_count_children": {
+                    "2023": null
+                },
+                "spm_unit_energy_subsidy": {
+                    "2023": null
+                },
+                "spm_unit_energy_subsidy_reported": {
+                    "2023": 0
+                },
+                "spm_unit_federal_tax": {
+                    "2023": null
+                },
+                "spm_unit_federal_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_fpg": {
+                    "2023": null
+                },
+                "spm_unit_id": {
+                    "2023": 0
+                },
+                "spm_unit_income_decile": {
+                    "2023": null
+                },
+                "spm_unit_is_in_deep_spm_poverty": {
+                    "2023": null
+                },
+                "spm_unit_is_in_spm_poverty": {
+                    "2023": null
+                },
+                "spm_unit_market_income": {
+                    "2023": null
+                },
+                "spm_unit_medical_expenses": {
+                    "2023": null
+                },
+                "spm_unit_net_income": {
+                    "2023": null
+                },
+                "spm_unit_net_income_reported": {
+                    "2023": 0
+                },
+                "spm_unit_oecd_equiv_net_income": {
+                    "2023": null
+                },
+                "spm_unit_payroll_tax": {
+                    "2023": null
+                },
+                "spm_unit_payroll_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_school_lunch_subsidy": {
+                    "2023": 0
+                },
+                "spm_unit_self_employment_tax": {
+                    "2023": null
+                },
+                "spm_unit_size": {
+                    "2023": null
+                },
+                "spm_unit_snap": {
+                    "2023": 0
+                },
+                "spm_unit_spm_threshold": {
+                    "2023": 0
+                },
+                "spm_unit_state_fips": {
+                    "2023": null
+                },
+                "spm_unit_state_tax": {
+                    "2023": null
+                },
+                "spm_unit_state_tax_reported": {
+                    "2023": 0
+                },
+                "spm_unit_taxes": {
+                    "2023": null
+                },
+                "spm_unit_total_ccdf_copay": {
+                    "2023": null
+                },
+                "spm_unit_total_income_reported": {
+                    "2023": 0
+                },
+                "spm_unit_weight": {
+                    "2023": null
+                },
+                "spm_unit_wic": {
+                    "2023": null
+                },
+                "spm_unit_wic_reported": {
+                    "2023": 0
+                },
+                "tanf": {
+                    "2023": null
+                },
+                "tanf_amount_if_eligible": {
+                    "2023": null
+                },
+                "tanf_countable_income": {
+                    "2023": null
+                },
+                "tanf_gross_earned_income": {
+                    "2023": null
+                },
+                "tanf_gross_unearned_income": {
+                    "2023": null
+                },
+                "tanf_initial_employment_deduction": {
+                    "2023": null
+                },
+                "tanf_max_amount": {
+                    "2023": null
+                },
+                "trash_expense": {
+                    "2023": 0
+                },
+                "tx_tanf_income_limit": {
+                    "2023": null
+                },
+                "utility_expense": {
+                    "2023": null
+                },
+                "wa_tanf_countable_resources": {
+                    "2023": 0
+                },
+                "wa_tanf_resources_eligible": {
+                    "2023": null
+                },
+                "water_expense": {
+                    "2023": 0
+                },
+                "wic_fpg": {
+                    "2023": null
+                }
+            }
+        },
+        "tax_units": {
+            "your tax unit": {
+                "a_lineno": {
+                    "2023": 0
+                },
+                "above_the_line_deductions": {
+                    "2023": null
+                },
+                "additional_medicare_tax": {
+                    "2023": null
+                },
+                "additional_standard_deduction": {
+                    "2023": null
+                },
+                "adjusted_gross_income": {
+                    "2023": null
+                },
+                "adjusted_net_capital_gain": {
+                    "2023": null
+                },
+                "advanced_main_air_circulating_fan_expenditures": {
+                    "2023": 0
+                },
+                "age_head": {
+                    "2023": null
+                },
+                "age_spouse": {
+                    "2023": null
+                },
+                "aged_blind_count": {
+                    "2023": null
+                },
+                "aged_blind_extra_standard_deduction": {
+                    "2023": null
+                },
+                "aged_head": {
+                    "2023": null
+                },
+                "aged_spouse": {
+                    "2023": null
+                },
+                "air_sealing_ventilation_expenditures": {
+                    "2023": 0
+                },
+                "al_agi": {
+                    "2023": 0
+                },
+                "al_dependent_exemption": {
+                    "2023": null
+                },
+                "al_income_tax_before_credits": {
+                    "2023": null
+                },
+                "al_personal_exemption": {
+                    "2023": null
+                },
+                "al_standard_deduction": {
+                    "2023": null
+                },
+                "al_taxable_income": {
+                    "2023": 0
+                },
+                "alternative_minimum_tax": {
+                    "2023": null
+                },
+                "american_opportunity_credit": {
+                    "2023": null
+                },
+                "amt_form_completed": {
+                    "2023": false
+                },
+                "amt_income": {
+                    "2023": null
+                },
+                "amt_non_agi_income": {
+                    "2023": 0
+                },
+                "az_income_tax": {
+                    "2023": null
+                },
+                "az_income_tax_before_non_refundable_credits": {
+                    "2023": null
+                },
+                "az_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "az_non_refundable_credits": {
+                    "2023": 0
+                },
+                "az_refundable_credits": {
+                    "2023": 0
+                },
+                "az_standard_deduction": {
+                    "2023": null
+                },
+                "az_taxable_income": {
+                    "2023": 0
+                },
+                "basic_income": {
+                    "2023": null
+                },
+                "basic_income_before_phase_out": {
+                    "2023": null
+                },
+                "basic_income_eligible": {
+                    "2023": null
+                },
+                "basic_income_phase_out": {
+                    "2023": null
+                },
+                "basic_standard_deduction": {
+                    "2023": null
+                },
+                "benefit_value_total": {
+                    "2023": 0
+                },
+                "biomass_stove_boiler_expenditures": {
+                    "2023": 0
+                },
+                "blind_head": {
+                    "2023": null
+                },
+                "blind_spouse": {
+                    "2023": null
+                },
+                "bonus_guaranteed_deduction": {
+                    "2023": null
+                },
+                "c01000": {
+                    "2023": null
+                },
+                "c04600": {
+                    "2023": null
+                },
+                "c05700": {
+                    "2023": 0
+                },
+                "c07100": {
+                    "2023": null
+                },
+                "c07200": {
+                    "2023": null
+                },
+                "c07230": {
+                    "2023": null
+                },
+                "c07240": {
+                    "2023": 0
+                },
+                "c07260": {
+                    "2023": 0
+                },
+                "c07300": {
+                    "2023": 0
+                },
+                "c07400": {
+                    "2023": 0
+                },
+                "c07600": {
+                    "2023": 0
+                },
+                "c08000": {
+                    "2023": 0
+                },
+                "c09600": {
+                    "2023": null
+                },
+                "c10960": {
+                    "2023": null
+                },
+                "c11070": {
+                    "2023": null
+                },
+                "c23650": {
+                    "2023": null
+                },
+                "c59660": {
+                    "2023": null
+                },
+                "c62100": {
+                    "2023": null
+                },
+                "c87668": {
+                    "2023": null
+                },
+                "ca_agi": {
+                    "2023": null
+                },
+                "ca_agi_additions": {
+                    "2023": 0
+                },
+                "ca_agi_subtractions": {
+                    "2023": null
+                },
+                "ca_cdcc": {
+                    "2023": null
+                },
+                "ca_eitc": {
+                    "2023": null
+                },
+                "ca_eitc_eligible": {
+                    "2023": null
+                },
+                "ca_exemptions": {
+                    "2023": null
+                },
+                "ca_income_tax": {
+                    "2023": null
+                },
+                "ca_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ca_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ca_itemized_deductions": {
+                    "2023": null
+                },
+                "ca_mental_health_services_tax": {
+                    "2023": null
+                },
+                "ca_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ca_refundable_credits": {
+                    "2023": null
+                },
+                "ca_renter_credit": {
+                    "2023": null
+                },
+                "ca_standard_deduction": {
+                    "2023": null
+                },
+                "ca_taxable_income": {
+                    "2023": null
+                },
+                "ca_use_tax": {
+                    "2023": null
+                },
+                "ca_yctc": {
+                    "2023": null
+                },
+                "capital_gains_28_percent_rate_gain": {
+                    "2023": null
+                },
+                "capital_gains_excluded_from_taxable_income": {
+                    "2023": null
+                },
+                "capital_gains_tax": {
+                    "2023": null
+                },
+                "capped_advanced_main_air_circulating_fan_credit": {
+                    "2023": null
+                },
+                "capped_electric_heat_pump_clothes_dryer_rebate": {
+                    "2023": null
+                },
+                "capped_electric_load_service_center_upgrade_rebate": {
+                    "2023": null
+                },
+                "capped_electric_stove_cooktop_range_or_oven_rebate": {
+                    "2023": null
+                },
+                "capped_electric_wiring_rebate": {
+                    "2023": null
+                },
+                "capped_energy_efficient_central_air_conditioner_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_door_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_insulation_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_roof_credit": {
+                    "2023": null
+                },
+                "capped_energy_efficient_window_credit": {
+                    "2023": null
+                },
+                "capped_heat_pump_heat_pump_water_heater_biomass_stove_boiler_credit": {
+                    "2023": null
+                },
+                "capped_heat_pump_rebate": {
+                    "2023": null
+                },
+                "capped_heat_pump_water_heater_rebate": {
+                    "2023": null
+                },
+                "capped_home_energy_audit_credit": {
+                    "2023": null
+                },
+                "capped_insulation_air_sealing_ventilation_rebate": {
+                    "2023": null
+                },
+                "capped_property_taxes": {
+                    "2023": null
+                },
+                "capped_qualified_furnace_or_hot_water_boiler_credit": {
+                    "2023": null
+                },
+                "care_deduction": {
+                    "2023": 0
+                },
+                "casualty_loss_deduction": {
+                    "2023": null
+                },
+                "cdcc": {
+                    "2023": null
+                },
+                "cdcc_rate": {
+                    "2023": null
+                },
+                "cdcc_relevant_expenses": {
+                    "2023": null
+                },
+                "charitable_deduction": {
+                    "2023": null
+                },
+                "charity_credit": {
+                    "2023": 0
+                },
+                "co_cdcc": {
+                    "2023": null
+                },
+                "co_eitc": {
+                    "2023": null
+                },
+                "co_income_tax": {
+                    "2023": null
+                },
+                "co_income_tax_before_non_refundable_credits": {
+                    "2023": null
+                },
+                "co_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "co_non_refundable_credits": {
+                    "2023": 0
+                },
+                "co_refundable_credits": {
+                    "2023": 0
+                },
+                "co_taxable_income": {
+                    "2023": 0
+                },
+                "cohabitating_spouses": {
+                    "2023": false
+                },
+                "combined": {
+                    "2023": null
+                },
+                "count_cdcc_eligible": {
+                    "2023": null
+                },
+                "ctc": {
+                    "2023": null
+                },
+                "ctc_arpa_addition": {
+                    "2023": null
+                },
+                "ctc_arpa_max_addition": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out_cap": {
+                    "2023": null
+                },
+                "ctc_arpa_phase_out_threshold": {
+                    "2023": null
+                },
+                "ctc_arpa_uncapped_phase_out": {
+                    "2023": null
+                },
+                "ctc_limiting_tax_liability": {
+                    "2023": null
+                },
+                "ctc_maximum": {
+                    "2023": null
+                },
+                "ctc_maximum_with_arpa_addition": {
+                    "2023": null
+                },
+                "ctc_new": {
+                    "2023": 0
+                },
+                "ctc_phase_out": {
+                    "2023": null
+                },
+                "ctc_phase_out_threshold": {
+                    "2023": null
+                },
+                "ctc_qualifying_children": {
+                    "2023": null
+                },
+                "ctc_refundable_maximum": {
+                    "2023": null
+                },
+                "ctc_value": {
+                    "2023": null
+                },
+                "data_source": {
+                    "2023": false
+                },
+                "dc_cdcc": {
+                    "2023": null
+                },
+                "dc_deduction_joint": {
+                    "2023": null
+                },
+                "dc_eitc": {
+                    "2023": null
+                },
+                "dc_eitc_with_qualifying_child": {
+                    "2023": null
+                },
+                "dc_eitc_without_qualifying_child": {
+                    "2023": null
+                },
+                "dc_files_separately": {
+                    "2023": null
+                },
+                "dc_income_tax": {
+                    "2023": null
+                },
+                "dc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "dc_income_tax_before_credits_indiv": {
+                    "2023": null
+                },
+                "dc_income_tax_before_credits_joint": {
+                    "2023": null
+                },
+                "dc_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "dc_itemized_deductions": {
+                    "2023": null
+                },
+                "dc_kccatc": {
+                    "2023": null
+                },
+                "dc_non_refundable_credits": {
+                    "2023": null
+                },
+                "dc_ptc": {
+                    "2023": null
+                },
+                "dc_refundable_credits": {
+                    "2023": null
+                },
+                "dc_standard_deduction": {
+                    "2023": null
+                },
+                "dc_taxable_income_joint": {
+                    "2023": null
+                },
+                "de_aged_personal_credits": {
+                    "2023": null
+                },
+                "de_cdcc": {
+                    "2023": null
+                },
+                "de_claims_refundable_eitc": {
+                    "2023": null
+                },
+                "de_eitc": {
+                    "2023": null
+                },
+                "de_income_tax": {
+                    "2023": null
+                },
+                "de_income_tax_before_non_refundable_credits": {
+                    "2023": null
+                },
+                "de_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "de_income_tax_if_claiming_non_refundable_eitc": {
+                    "2023": null
+                },
+                "de_income_tax_if_claiming_refundable_eitc": {
+                    "2023": null
+                },
+                "de_non_refundable_credits": {
+                    "2023": null
+                },
+                "de_non_refundable_eitc": {
+                    "2023": null
+                },
+                "de_non_refundable_eitc_if_claimed": {
+                    "2023": null
+                },
+                "de_personal_credit": {
+                    "2023": null
+                },
+                "de_refundable_credits": {
+                    "2023": null
+                },
+                "de_refundable_eitc": {
+                    "2023": null
+                },
+                "de_refundable_eitc_if_claimed": {
+                    "2023": null
+                },
+                "de_standard_deduction": {
+                    "2023": null
+                },
+                "de_taxable_income": {
+                    "2023": 0
+                },
+                "disabled_head": {
+                    "2023": null
+                },
+                "disabled_spouse": {
+                    "2023": null
+                },
+                "domestic_production_ald": {
+                    "2023": 0
+                },
+                "dsi": {
+                    "2023": null
+                },
+                "dsi_spouse": {
+                    "2023": null
+                },
+                "dwks10": {
+                    "2023": null
+                },
+                "dwks13": {
+                    "2023": null
+                },
+                "dwks14": {
+                    "2023": null
+                },
+                "dwks19": {
+                    "2023": null
+                },
+                "dwks6": {
+                    "2023": null
+                },
+                "dwks9": {
+                    "2023": null
+                },
+                "e07240": {
+                    "2023": 0
+                },
+                "e07400": {
+                    "2023": 0
+                },
+                "e07600": {
+                    "2023": 0
+                },
+                "earned_income_tax_credit": {
+                    "2023": null
+                },
+                "ecpa_adult_dependent_credit": {
+                    "2023": null
+                },
+                "ecpa_filer_credit": {
+                    "2023": null
+                },
+                "education_credit_phase_out": {
+                    "2023": null
+                },
+                "education_tax_credits": {
+                    "2023": null
+                },
+                "eitc": {
+                    "2023": null
+                },
+                "eitc_agi_limit": {
+                    "2023": null
+                },
+                "eitc_child_count": {
+                    "2023": null
+                },
+                "eitc_demographic_eligible": {
+                    "2023": null
+                },
+                "eitc_eligible": {
+                    "2023": null
+                },
+                "eitc_investment_income_eligible": {
+                    "2023": null
+                },
+                "eitc_maximum": {
+                    "2023": null
+                },
+                "eitc_phase_in_rate": {
+                    "2023": null
+                },
+                "eitc_phase_out_rate": {
+                    "2023": null
+                },
+                "eitc_phase_out_start": {
+                    "2023": null
+                },
+                "eitc_phased_in": {
+                    "2023": null
+                },
+                "eitc_reduction": {
+                    "2023": null
+                },
+                "eitc_relevant_investment_income": {
+                    "2023": null
+                },
+                "elderly_dependents": {
+                    "2023": 0
+                },
+                "elderly_disabled_credit": {
+                    "2023": null
+                },
+                "electric_heat_pump_clothes_dryer_expenditures": {
+                    "2023": 0
+                },
+                "electric_load_service_center_upgrade_expenditures": {
+                    "2023": 0
+                },
+                "electric_stove_cooktop_range_or_oven_expenditures": {
+                    "2023": 0
+                },
+                "electric_wiring_expenditures": {
+                    "2023": 0
+                },
+                "employee_payroll_tax": {
+                    "2023": null
+                },
+                "energy_efficient_central_air_conditioner_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_door_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_home_improvement_credit": {
+                    "2023": null
+                },
+                "energy_efficient_insulation_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_roof_expenditures": {
+                    "2023": 0
+                },
+                "energy_efficient_window_expenditures": {
+                    "2023": 0
+                },
+                "excess_payroll_tax_withheld": {
+                    "2023": 0
+                },
+                "exemption_phase_out_start": {
+                    "2023": null
+                },
+                "exemptions": {
+                    "2023": null
+                },
+                "f2441": {
+                    "2023": null
+                },
+                "f6251": {
+                    "2023": false
+                },
+                "federal_eitc_without_age_minimum": {
+                    "2023": null
+                },
+                "federal_state_income_tax": {
+                    "2023": null
+                },
+                "ffpos": {
+                    "2023": 0
+                },
+                "filer_cmbtp": {
+                    "2023": null
+                },
+                "filer_e00200": {
+                    "2023": null
+                },
+                "filer_e00300": {
+                    "2023": null
+                },
+                "filer_e02300": {
+                    "2023": null
+                },
+                "filer_e18400": {
+                    "2023": null
+                },
+                "filer_earned": {
+                    "2023": null
+                },
+                "filer_k1bx14": {
+                    "2023": null
+                },
+                "filer_pencon": {
+                    "2023": null
+                },
+                "filer_sey": {
+                    "2023": null
+                },
+                "filing_status": {
+                    "2023": null
+                },
+                "flat_tax": {
+                    "2023": null
+                },
+                "foreign_earned_income_exclusion": {
+                    "2023": 0
+                },
+                "foreign_tax_credit": {
+                    "2023": 0
+                },
+                "fstax": {
+                    "2023": 0
+                },
+                "fuel_cell_property_capacity": {
+                    "2023": 0
+                },
+                "fuel_cell_property_expenditures": {
+                    "2023": 0
+                },
+                "ga_cdcc": {
+                    "2023": null
+                },
+                "ga_income_tax": {
+                    "2023": null
+                },
+                "ga_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ga_refundable_credits": {
+                    "2023": 0
+                },
+                "ga_taxable_income": {
+                    "2023": 0
+                },
+                "geothermal_heat_pump_property_expenditures": {
+                    "2023": 0
+                },
+                "h_seq": {
+                    "2023": 0
+                },
+                "hasqdivltcg": {
+                    "2023": null
+                },
+                "head_earned": {
+                    "2023": null
+                },
+                "head_is_disabled": {
+                    "2023": null
+                },
+                "head_spouse_count": {
+                    "2023": null
+                },
+                "health_savings_account_ald": {
+                    "2023": 0
+                },
+                "heat_pump_expenditures": {
+                    "2023": 0
+                },
+                "heat_pump_water_heater_expenditures": {
+                    "2023": 0
+                },
+                "hi_agi": {
+                    "2023": 0
+                },
+                "hi_eitc": {
+                    "2023": null
+                },
+                "hi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "hi_standard_deduction": {
+                    "2023": null
+                },
+                "hi_taxable_income": {
+                    "2023": 0
+                },
+                "high_efficiency_electric_home_rebate": {
+                    "2023": null
+                },
+                "high_efficiency_electric_home_rebate_percent_covered": {
+                    "2023": null
+                },
+                "home_energy_audit_expenditures": {
+                    "2023": 0
+                },
+                "household_state_income_tax": {
+                    "2023": null
+                },
+                "ia_alternate_tax_unit": {
+                    "2023": null
+                },
+                "ia_cdcc": {
+                    "2023": null
+                },
+                "ia_eitc": {
+                    "2023": null
+                },
+                "ia_exemption_credit": {
+                    "2023": null
+                },
+                "ia_files_separately": {
+                    "2023": null
+                },
+                "ia_income_tax": {
+                    "2023": null
+                },
+                "ia_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ia_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ia_income_tax_indiv": {
+                    "2023": null
+                },
+                "ia_income_tax_joint": {
+                    "2023": null
+                },
+                "ia_is_tax_exempt": {
+                    "2023": null
+                },
+                "ia_itemized_deductions_unit": {
+                    "2023": null
+                },
+                "ia_modified_income": {
+                    "2023": null
+                },
+                "ia_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ia_reduced_tax": {
+                    "2023": null
+                },
+                "ia_refundable_credits": {
+                    "2023": null
+                },
+                "ia_reportable_social_security": {
+                    "2023": null
+                },
+                "iitax": {
+                    "2023": null
+                },
+                "il_aged_blind_exemption": {
+                    "2023": null
+                },
+                "il_base_income": {
+                    "2023": null
+                },
+                "il_base_income_additions": {
+                    "2023": null
+                },
+                "il_base_income_subtractions": {
+                    "2023": null
+                },
+                "il_dependent_exemption": {
+                    "2023": null
+                },
+                "il_eitc": {
+                    "2023": null
+                },
+                "il_income_tax": {
+                    "2023": null
+                },
+                "il_income_tax_before_nonrefundable_credits": {
+                    "2023": null
+                },
+                "il_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "il_is_exemption_eligible": {
+                    "2023": null
+                },
+                "il_k12_education_expense_credit": {
+                    "2023": null
+                },
+                "il_nonrefundable_credits": {
+                    "2023": null
+                },
+                "il_pass_through_entity_tax_credit": {
+                    "2023": 0
+                },
+                "il_pass_through_withholding": {
+                    "2023": 0
+                },
+                "il_personal_exemption": {
+                    "2023": null
+                },
+                "il_personal_exemption_eligibility_status": {
+                    "2023": null
+                },
+                "il_property_tax_credit": {
+                    "2023": null
+                },
+                "il_refundable_credits": {
+                    "2023": null
+                },
+                "il_schedule_m_additions": {
+                    "2023": 0
+                },
+                "il_schedule_m_subtractions": {
+                    "2023": 0
+                },
+                "il_taxable_income": {
+                    "2023": null
+                },
+                "il_total_exemptions": {
+                    "2023": null
+                },
+                "il_total_tax": {
+                    "2023": null
+                },
+                "il_use_tax": {
+                    "2023": null
+                },
+                "in_add_backs": {
+                    "2023": null
+                },
+                "in_additional_exemptions": {
+                    "2023": null
+                },
+                "in_aged_blind_exemptions": {
+                    "2023": null
+                },
+                "in_aged_low_agi_exemptions": {
+                    "2023": null
+                },
+                "in_agi": {
+                    "2023": null
+                },
+                "in_agi_tax": {
+                    "2023": null
+                },
+                "in_base_exemptions": {
+                    "2023": null
+                },
+                "in_bonus_depreciation_add_back": {
+                    "2023": 0
+                },
+                "in_deductions": {
+                    "2023": null
+                },
+                "in_exemptions": {
+                    "2023": null
+                },
+                "in_homeowners_property_tax": {
+                    "2023": 0
+                },
+                "in_homeowners_property_tax_deduction": {
+                    "2023": null
+                },
+                "in_military_service_deduction": {
+                    "2023": null
+                },
+                "in_nol": {
+                    "2023": 0
+                },
+                "in_nol_add_back": {
+                    "2023": 0
+                },
+                "in_nonpublic_school_deduction": {
+                    "2023": null
+                },
+                "in_oos_municipal_obligation_interest_add_back": {
+                    "2023": 0
+                },
+                "in_other_add_backs": {
+                    "2023": 0
+                },
+                "in_other_deductions": {
+                    "2023": 0
+                },
+                "in_other_taxes": {
+                    "2023": 0
+                },
+                "in_qualifying_child_count": {
+                    "2023": null
+                },
+                "in_renters_deduction": {
+                    "2023": null
+                },
+                "in_section_179_expense_add_back": {
+                    "2023": 0
+                },
+                "in_tax_add_back": {
+                    "2023": 0
+                },
+                "in_unemployment_compensation_deduction": {
+                    "2023": null
+                },
+                "in_unified_elderly_tax_credit": {
+                    "2023": null
+                },
+                "income_tax": {
+                    "2023": null
+                },
+                "income_tax_before_credits": {
+                    "2023": null
+                },
+                "income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_capped_non_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_main_rates": {
+                    "2023": null
+                },
+                "income_tax_non_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_refundable_credits": {
+                    "2023": null
+                },
+                "income_tax_unavailable_non_refundable_credits": {
+                    "2023": null
+                },
+                "interest_deduction": {
+                    "2023": null
+                },
+                "investment_in_529_plan": {
+                    "2023": 0
+                },
+                "investment_income_form_4952": {
+                    "2023": 0
+                },
+                "is_eligible_md_poverty_line_credit": {
+                    "2023": null
+                },
+                "is_ma_income_tax_exempt": {
+                    "2023": null
+                },
+                "is_ptc_eligible": {
+                    "2023": null
+                },
+                "itemized_deductions_less_salt": {
+                    "2023": null
+                },
+                "itemized_taxable_income_deductions": {
+                    "2023": null
+                },
+                "k12_tuition_and_fees": {
+                    "2023": 0
+                },
+                "ks_agi": {
+                    "2023": null
+                },
+                "ks_agi_additions": {
+                    "2023": 0
+                },
+                "ks_agi_subtractions": {
+                    "2023": null
+                },
+                "ks_cdcc": {
+                    "2023": null
+                },
+                "ks_count_exemptions": {
+                    "2023": null
+                },
+                "ks_exemptions": {
+                    "2023": null
+                },
+                "ks_fstc": {
+                    "2023": null
+                },
+                "ks_income_tax": {
+                    "2023": null
+                },
+                "ks_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ks_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ks_itemized_deductions": {
+                    "2023": null
+                },
+                "ks_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ks_nonrefundable_eitc": {
+                    "2023": null
+                },
+                "ks_refundable_credits": {
+                    "2023": null
+                },
+                "ks_refundable_eitc": {
+                    "2023": null
+                },
+                "ks_standard_deduction": {
+                    "2023": null
+                },
+                "ks_taxable_income": {
+                    "2023": null
+                },
+                "ks_total_eitc": {
+                    "2023": null
+                },
+                "ky_income_tax": {
+                    "2023": null
+                },
+                "ky_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ky_refundable_credits": {
+                    "2023": 0
+                },
+                "ky_standard_deduction": {
+                    "2023": null
+                },
+                "ky_taxable_income": {
+                    "2023": 0
+                },
+                "lifetime_learning_credit": {
+                    "2023": null
+                },
+                "limited_capital_loss": {
+                    "2023": null
+                },
+                "local_income_tax": {
+                    "2023": null
+                },
+                "local_sales_tax": {
+                    "2023": 0
+                },
+                "loss_ald": {
+                    "2023": null
+                },
+                "ma_agi": {
+                    "2023": null
+                },
+                "ma_dependent_care_credit": {
+                    "2023": null
+                },
+                "ma_dependent_credit": {
+                    "2023": null
+                },
+                "ma_dependent_or_dependent_care_credit": {
+                    "2023": null
+                },
+                "ma_eitc": {
+                    "2023": null
+                },
+                "ma_gross_income": {
+                    "2023": null
+                },
+                "ma_income_tax": {
+                    "2023": null
+                },
+                "ma_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ma_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ma_income_tax_exemption_threshold": {
+                    "2023": null
+                },
+                "ma_limited_income_tax_credit": {
+                    "2023": null
+                },
+                "ma_non_refundable_credits": {
+                    "2023": null
+                },
+                "ma_part_a_agi": {
+                    "2023": null
+                },
+                "ma_part_a_cg_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_a_div_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_a_gross_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_capital_gains_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_dividend_income": {
+                    "2023": null
+                },
+                "ma_part_a_taxable_income": {
+                    "2023": null
+                },
+                "ma_part_b_agi": {
+                    "2023": null
+                },
+                "ma_part_b_excess_exemption": {
+                    "2023": null
+                },
+                "ma_part_b_gross_income": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_before_exemption": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_deductions": {
+                    "2023": null
+                },
+                "ma_part_b_taxable_income_exemption": {
+                    "2023": null
+                },
+                "ma_part_c_agi": {
+                    "2023": null
+                },
+                "ma_part_c_gross_income": {
+                    "2023": null
+                },
+                "ma_part_c_taxable_income": {
+                    "2023": null
+                },
+                "ma_refundable_credits": {
+                    "2023": null
+                },
+                "ma_scb_total_income": {
+                    "2023": null
+                },
+                "ma_senior_circuit_breaker": {
+                    "2023": null
+                },
+                "mars": {
+                    "2023": null
+                },
+                "md_aged_blind_exemptions": {
+                    "2023": null
+                },
+                "md_aged_dependent_exemption": {
+                    "2023": null
+                },
+                "md_aged_exemption": {
+                    "2023": null
+                },
+                "md_agi": {
+                    "2023": null
+                },
+                "md_blind_exemption": {
+                    "2023": null
+                },
+                "md_cdcc": {
+                    "2023": null
+                },
+                "md_ctc": {
+                    "2023": null
+                },
+                "md_deductions": {
+                    "2023": null
+                },
+                "md_dependent_care_subtraction": {
+                    "2023": null
+                },
+                "md_eitc": {
+                    "2023": null
+                },
+                "md_exemptions": {
+                    "2023": null
+                },
+                "md_income_tax": {
+                    "2023": null
+                },
+                "md_income_tax_before_credits": {
+                    "2023": null
+                },
+                "md_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "md_local_income_tax_before_credits": {
+                    "2023": null
+                },
+                "md_non_refundable_credits": {
+                    "2023": null
+                },
+                "md_non_refundable_eitc": {
+                    "2023": null
+                },
+                "md_non_single_childless_non_refundable_eitc": {
+                    "2023": null
+                },
+                "md_non_single_childless_refundable_eitc": {
+                    "2023": null
+                },
+                "md_pension_subtraction": {
+                    "2023": null
+                },
+                "md_personal_exemption": {
+                    "2023": null
+                },
+                "md_poverty_line_credit": {
+                    "2023": null
+                },
+                "md_qualifies_for_single_childless_eitc": {
+                    "2023": null
+                },
+                "md_refundable_cdcc": {
+                    "2023": null
+                },
+                "md_refundable_credits": {
+                    "2023": null
+                },
+                "md_refundable_eitc": {
+                    "2023": null
+                },
+                "md_single_childless_eitc": {
+                    "2023": null
+                },
+                "md_socsec_subtraction": {
+                    "2023": null
+                },
+                "md_standard_deduction": {
+                    "2023": null
+                },
+                "md_tax_unit_earned_income": {
+                    "2023": null
+                },
+                "md_taxable_income": {
+                    "2023": null
+                },
+                "md_total_additions": {
+                    "2023": 0
+                },
+                "md_total_personal_exemptions": {
+                    "2023": null
+                },
+                "md_total_subtractions": {
+                    "2023": null
+                },
+                "md_two_income_subtraction": {
+                    "2023": null
+                },
+                "me_agi": {
+                    "2023": null
+                },
+                "me_agi_additions": {
+                    "2023": 0
+                },
+                "me_agi_subtractions": {
+                    "2023": null
+                },
+                "me_child_care_credit": {
+                    "2023": null
+                },
+                "me_deduction_phaseout_percentage": {
+                    "2023": null
+                },
+                "me_deductions": {
+                    "2023": null
+                },
+                "me_dependent_exemption": {
+                    "2023": null
+                },
+                "me_eitc": {
+                    "2023": null
+                },
+                "me_exemptions": {
+                    "2023": null
+                },
+                "me_income_tax": {
+                    "2023": null
+                },
+                "me_income_tax_before_credits": {
+                    "2023": null
+                },
+                "me_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "me_itemized_deductions_pre_phaseout": {
+                    "2023": null
+                },
+                "me_non_refundable_child_care_credit": {
+                    "2023": null
+                },
+                "me_non_refundable_credits": {
+                    "2023": null
+                },
+                "me_pension_income_deduction": {
+                    "2023": null
+                },
+                "me_personal_exemption_deduction": {
+                    "2023": null
+                },
+                "me_refundable_child_care_credit": {
+                    "2023": null
+                },
+                "me_refundable_credits": {
+                    "2023": null
+                },
+                "me_step_4_share_of_child_care_expenses": {
+                    "2023": 0
+                },
+                "me_taxable_income": {
+                    "2023": null
+                },
+                "medicaid_income": {
+                    "2023": null
+                },
+                "medical_expense_deduction": {
+                    "2023": null
+                },
+                "members": [
+                    "you",
+                    "your first dependent",
+                    "your second dependent"
+                ],
+                "mi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mi_taxable_income": {
+                    "2023": 0
+                },
+                "military_disabled_head": {
+                    "2023": null
+                },
+                "military_disabled_spouse": {
+                    "2023": null
+                },
+                "min_head_spouse_earned": {
+                    "2023": null
+                },
+                "misc_deduction": {
+                    "2023": 0
+                },
+                "mn_additions": {
+                    "2023": null
+                },
+                "mn_amt": {
+                    "2023": null
+                },
+                "mn_amt_taxable_income": {
+                    "2023": null
+                },
+                "mn_basic_tax": {
+                    "2023": null
+                },
+                "mn_cdcc": {
+                    "2023": null
+                },
+                "mn_charity_subtraction": {
+                    "2023": null
+                },
+                "mn_deductions": {
+                    "2023": null
+                },
+                "mn_elderly_disabled_subtraction": {
+                    "2023": null
+                },
+                "mn_exemptions": {
+                    "2023": null
+                },
+                "mn_income_tax": {
+                    "2023": null
+                },
+                "mn_income_tax_before_credits": {
+                    "2023": null
+                },
+                "mn_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mn_itemized_deductions": {
+                    "2023": null
+                },
+                "mn_itemizing": {
+                    "2023": null
+                },
+                "mn_marriage_credit": {
+                    "2023": null
+                },
+                "mn_nonrefundable_credits": {
+                    "2023": null
+                },
+                "mn_refundable_credits": {
+                    "2023": null
+                },
+                "mn_social_security_subtraction": {
+                    "2023": null
+                },
+                "mn_standard_deduction": {
+                    "2023": null
+                },
+                "mn_subtractions": {
+                    "2023": null
+                },
+                "mn_taxable_income": {
+                    "2023": null
+                },
+                "mn_wfc": {
+                    "2023": null
+                },
+                "mn_wfc_eligible": {
+                    "2023": null
+                },
+                "mo_federal_income_tax_deduction": {
+                    "2023": null
+                },
+                "mo_income_tax": {
+                    "2023": null
+                },
+                "mo_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mo_itemized_deductions": {
+                    "2023": null
+                },
+                "mo_net_state_income_taxes": {
+                    "2023": null
+                },
+                "mo_non_refundable_credits": {
+                    "2023": null
+                },
+                "mo_pension_and_ss_or_ssd_deduction": {
+                    "2023": null
+                },
+                "mo_property_tax_credit": {
+                    "2023": null
+                },
+                "mo_ptc_gross_income": {
+                    "2023": null
+                },
+                "mo_ptc_income_offset": {
+                    "2023": null
+                },
+                "mo_ptc_net_income": {
+                    "2023": null
+                },
+                "mo_ptc_taxunit_eligible": {
+                    "2023": null
+                },
+                "mo_refundable_credits": {
+                    "2023": null
+                },
+                "mo_wftc": {
+                    "2023": null
+                },
+                "ms_aged_exemption": {
+                    "2023": null
+                },
+                "ms_blind_exemption": {
+                    "2023": null
+                },
+                "ms_dependents_exemption": {
+                    "2023": null
+                },
+                "ms_regular_exemption": {
+                    "2023": null
+                },
+                "ms_standard_deduction": {
+                    "2023": null
+                },
+                "ms_total_exemptions": {
+                    "2023": null
+                },
+                "mt_eitc": {
+                    "2023": null
+                },
+                "mt_income_tax": {
+                    "2023": null
+                },
+                "mt_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "mt_refundable_credits": {
+                    "2023": 0
+                },
+                "mt_taxable_income": {
+                    "2023": 0
+                },
+                "n1820": {
+                    "2023": 0
+                },
+                "n21": {
+                    "2023": 0
+                },
+                "n24": {
+                    "2023": 0
+                },
+                "nc_income_tax": {
+                    "2023": null
+                },
+                "nc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nc_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nc_taxable_income": {
+                    "2023": 0
+                },
+                "nd_additions": {
+                    "2023": null
+                },
+                "nd_income_tax": {
+                    "2023": null
+                },
+                "nd_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nd_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nd_ltcg_subtraction": {
+                    "2023": null
+                },
+                "nd_mpc": {
+                    "2023": null
+                },
+                "nd_nonrefundable_credits": {
+                    "2023": null
+                },
+                "nd_qdiv_subtraction": {
+                    "2023": null
+                },
+                "nd_refundable_credits": {
+                    "2023": 0
+                },
+                "nd_rtrc": {
+                    "2023": null
+                },
+                "nd_subtractions": {
+                    "2023": null
+                },
+                "nd_taxable_income": {
+                    "2023": null
+                },
+                "ne_agi": {
+                    "2023": null
+                },
+                "ne_agi_additions": {
+                    "2023": 0
+                },
+                "ne_agi_subtractions": {
+                    "2023": null
+                },
+                "ne_cdcc_nonrefundable": {
+                    "2023": null
+                },
+                "ne_cdcc_refundable": {
+                    "2023": null
+                },
+                "ne_eitc": {
+                    "2023": null
+                },
+                "ne_elderly_disabled_credit": {
+                    "2023": null
+                },
+                "ne_exemptions": {
+                    "2023": null
+                },
+                "ne_income_tax": {
+                    "2023": null
+                },
+                "ne_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ne_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ne_itemized_deductions": {
+                    "2023": null
+                },
+                "ne_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ne_refundable_credits": {
+                    "2023": null
+                },
+                "ne_standard_deduction": {
+                    "2023": null
+                },
+                "ne_taxable_income": {
+                    "2023": null
+                },
+                "net_capital_gain": {
+                    "2023": null
+                },
+                "net_investment_income": {
+                    "2023": null
+                },
+                "net_investment_income_tax": {
+                    "2023": null
+                },
+                "new_clean_vehicle_battery_capacity": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_battery_components_made_in_north_america": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_battery_critical_minerals_extracted_in_trading_partner_country": {
+                    "2023": 0
+                },
+                "new_clean_vehicle_classification": {
+                    "2023": "OTHER"
+                },
+                "new_clean_vehicle_credit": {
+                    "2023": null
+                },
+                "new_clean_vehicle_credit_eligible": {
+                    "2023": null
+                },
+                "new_clean_vehicle_msrp": {
+                    "2023": 0
+                },
+                "nh_base_exemption": {
+                    "2023": null
+                },
+                "nh_blind_exemption": {
+                    "2023": null
+                },
+                "nh_disabled_exemption": {
+                    "2023": null
+                },
+                "nh_education_tax_credit": {
+                    "2023": null
+                },
+                "nh_income_tax": {
+                    "2023": null
+                },
+                "nh_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nh_old_age_exemption": {
+                    "2023": null
+                },
+                "nh_refundable_credits": {
+                    "2023": 0
+                },
+                "nh_taxable_income": {
+                    "2023": null
+                },
+                "nh_total_exemptions": {
+                    "2023": null
+                },
+                "nj_agi": {
+                    "2023": null
+                },
+                "nj_agi_additions": {
+                    "2023": 0
+                },
+                "nj_agi_subtractions": {
+                    "2023": null
+                },
+                "nj_blind_or_disabled_exemption": {
+                    "2023": null
+                },
+                "nj_cdcc": {
+                    "2023": null
+                },
+                "nj_childless_eitc_age_eligible": {
+                    "2023": null
+                },
+                "nj_ctc": {
+                    "2023": null
+                },
+                "nj_dependents_attending_college_exemption": {
+                    "2023": null
+                },
+                "nj_dependents_exemption": {
+                    "2023": null
+                },
+                "nj_eitc": {
+                    "2023": null
+                },
+                "nj_eitc_income_eligible": {
+                    "2023": null
+                },
+                "nj_homeowners_property_tax": {
+                    "2023": null
+                },
+                "nj_income_tax": {
+                    "2023": null
+                },
+                "nj_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nj_main_income_tax": {
+                    "2023": null
+                },
+                "nj_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nj_potential_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_property_tax_credit": {
+                    "2023": null
+                },
+                "nj_property_tax_credit_eligible": {
+                    "2023": null
+                },
+                "nj_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_property_tax_deduction_eligible": {
+                    "2023": null
+                },
+                "nj_refundable_credits": {
+                    "2023": null
+                },
+                "nj_regular_exemption": {
+                    "2023": null
+                },
+                "nj_senior_exemption": {
+                    "2023": null
+                },
+                "nj_taking_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_taxable_income": {
+                    "2023": null
+                },
+                "nj_taxable_income_before_property_tax_deduction": {
+                    "2023": null
+                },
+                "nj_total_deductions": {
+                    "2023": 0
+                },
+                "nj_total_exemptions": {
+                    "2023": null
+                },
+                "nm_2021_income_rebate": {
+                    "2023": null
+                },
+                "nm_additional_2021_income_rebate": {
+                    "2023": null
+                },
+                "nm_aged_blind_exemption": {
+                    "2023": null
+                },
+                "nm_agi": {
+                    "2023": null
+                },
+                "nm_agi_additions": {
+                    "2023": 0
+                },
+                "nm_cdcc": {
+                    "2023": null
+                },
+                "nm_cdcc_eligible": {
+                    "2023": null
+                },
+                "nm_cdcc_max_amount": {
+                    "2023": null
+                },
+                "nm_ctc": {
+                    "2023": null
+                },
+                "nm_deduction_for_certain_dependents": {
+                    "2023": null
+                },
+                "nm_deduction_for_certain_dependents_eligible": {
+                    "2023": null
+                },
+                "nm_deductions": {
+                    "2023": null
+                },
+                "nm_eitc": {
+                    "2023": null
+                },
+                "nm_eitc_demographic_eligible": {
+                    "2023": null
+                },
+                "nm_eitc_eligible": {
+                    "2023": null
+                },
+                "nm_exemptions": {
+                    "2023": null
+                },
+                "nm_hundred_year_exemption": {
+                    "2023": null
+                },
+                "nm_income_tax": {
+                    "2023": null
+                },
+                "nm_income_tax_before_non_refundable_credits": {
+                    "2023": null
+                },
+                "nm_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nm_itemized_deductions": {
+                    "2023": null
+                },
+                "nm_low_and_middle_income_exemption": {
+                    "2023": null
+                },
+                "nm_low_income_comprehensive_tax_rebate": {
+                    "2023": null
+                },
+                "nm_low_income_comprehensive_tax_rebate_exemptions": {
+                    "2023": null
+                },
+                "nm_medical_care_expense_deduction": {
+                    "2023": null
+                },
+                "nm_medical_expense_credit": {
+                    "2023": null
+                },
+                "nm_medical_expense_exemption": {
+                    "2023": null
+                },
+                "nm_modified_gross_income": {
+                    "2023": null
+                },
+                "nm_net_capital_gains_deduction": {
+                    "2023": null
+                },
+                "nm_non_refundable_credits": {
+                    "2023": 0
+                },
+                "nm_property_tax_rebate": {
+                    "2023": null
+                },
+                "nm_property_tax_rebate_eligible": {
+                    "2023": null
+                },
+                "nm_refundable_credits": {
+                    "2023": null
+                },
+                "nm_social_security_income_exemption": {
+                    "2023": null
+                },
+                "nm_subtractions": {
+                    "2023": null
+                },
+                "nm_supplemental_2021_income_rebate": {
+                    "2023": null
+                },
+                "nm_taxable_income": {
+                    "2023": null
+                },
+                "no_salt_income_tax": {
+                    "2023": null
+                },
+                "non_refundable_american_opportunity_credit": {
+                    "2023": null
+                },
+                "non_refundable_ctc": {
+                    "2023": null
+                },
+                "nu06": {
+                    "2023": 0
+                },
+                "nu13": {
+                    "2023": 0
+                },
+                "nu18": {
+                    "2023": 0
+                },
+                "num": {
+                    "2023": null
+                },
+                "ny_agi": {
+                    "2023": null
+                },
+                "ny_agi_additions": {
+                    "2023": 0
+                },
+                "ny_agi_subtractions": {
+                    "2023": null
+                },
+                "ny_cdcc": {
+                    "2023": null
+                },
+                "ny_cdcc_max": {
+                    "2023": null
+                },
+                "ny_cdcc_rate": {
+                    "2023": null
+                },
+                "ny_college_tuition_credit": {
+                    "2023": null
+                },
+                "ny_ctc": {
+                    "2023": null
+                },
+                "ny_deductions": {
+                    "2023": null
+                },
+                "ny_eitc": {
+                    "2023": null
+                },
+                "ny_exemptions": {
+                    "2023": null
+                },
+                "ny_household_credit": {
+                    "2023": null
+                },
+                "ny_income_tax": {
+                    "2023": null
+                },
+                "ny_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ny_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ny_itemized_deductions": {
+                    "2023": null
+                },
+                "ny_itemized_deductions_max": {
+                    "2023": null
+                },
+                "ny_itemized_deductions_reduction": {
+                    "2023": 0
+                },
+                "ny_itemizes": {
+                    "2023": null
+                },
+                "ny_main_income_tax": {
+                    "2023": null
+                },
+                "ny_non_refundable_credits": {
+                    "2023": null
+                },
+                "ny_real_property_tax_credit": {
+                    "2023": null
+                },
+                "ny_refundable_credits": {
+                    "2023": null
+                },
+                "ny_standard_deduction": {
+                    "2023": null
+                },
+                "ny_supplemental_eitc": {
+                    "2023": null
+                },
+                "ny_supplemental_tax": {
+                    "2023": null
+                },
+                "ny_taxable_income": {
+                    "2023": null
+                },
+                "nyc_cdcc": {
+                    "2023": null
+                },
+                "nyc_cdcc_age_restricted_expenses": {
+                    "2023": null
+                },
+                "nyc_cdcc_applicable_percentage": {
+                    "2023": null
+                },
+                "nyc_cdcc_eligible": {
+                    "2023": null
+                },
+                "nyc_cdcc_share_qualifying_childcare_expenses": {
+                    "2023": null
+                },
+                "nyc_eitc": {
+                    "2023": null
+                },
+                "nyc_household_credit": {
+                    "2023": null
+                },
+                "nyc_income_tax": {
+                    "2023": null
+                },
+                "nyc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "nyc_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_non_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_refundable_credits": {
+                    "2023": null
+                },
+                "nyc_school_credit_income": {
+                    "2023": null
+                },
+                "nyc_school_tax_credit_fixed_amount": {
+                    "2023": null
+                },
+                "nyc_school_tax_credit_rate_reduction_amount": {
+                    "2023": null
+                },
+                "nyc_taxable_income": {
+                    "2023": null
+                },
+                "nyc_unincorporated_business_credit": {
+                    "2023": 0
+                },
+                "oh_agi": {
+                    "2023": null
+                },
+                "oh_bonus_depreciation_add_back": {
+                    "2023": 0
+                },
+                "oh_cdcc": {
+                    "2023": null
+                },
+                "oh_eitc": {
+                    "2023": null
+                },
+                "oh_federal_conformity_deductions": {
+                    "2023": 0
+                },
+                "oh_income_tax_before_credits": {
+                    "2023": null
+                },
+                "oh_income_tax_exempt": {
+                    "2023": null
+                },
+                "oh_non_public_school_credits": {
+                    "2023": null
+                },
+                "oh_other_add_backs": {
+                    "2023": 0
+                },
+                "oh_section_179_expense_add_back": {
+                    "2023": 0
+                },
+                "oh_senior_citizen_credit": {
+                    "2023": null
+                },
+                "oh_taxable_income": {
+                    "2023": 0
+                },
+                "oh_uniformed_services_retirement_income_deduction": {
+                    "2023": 0
+                },
+                "ok_adjustments": {
+                    "2023": 0
+                },
+                "ok_agi": {
+                    "2023": null
+                },
+                "ok_agi_additions": {
+                    "2023": 0
+                },
+                "ok_agi_subtractions": {
+                    "2023": null
+                },
+                "ok_child_care_child_tax_credit": {
+                    "2023": null
+                },
+                "ok_count_exemptions": {
+                    "2023": null
+                },
+                "ok_eitc": {
+                    "2023": null
+                },
+                "ok_exemptions": {
+                    "2023": null
+                },
+                "ok_gross_income": {
+                    "2023": null
+                },
+                "ok_income_tax": {
+                    "2023": null
+                },
+                "ok_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ok_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ok_itemized_deductions": {
+                    "2023": null
+                },
+                "ok_nonrefundable_credits": {
+                    "2023": null
+                },
+                "ok_ptc": {
+                    "2023": null
+                },
+                "ok_refundable_credits": {
+                    "2023": null
+                },
+                "ok_standard_deduction": {
+                    "2023": null
+                },
+                "ok_stc": {
+                    "2023": null
+                },
+                "ok_taxable_income": {
+                    "2023": null
+                },
+                "ok_use_tax": {
+                    "2023": null
+                },
+                "or_deductions": {
+                    "2023": null
+                },
+                "or_disabled_child_dependent_exemptions": {
+                    "2023": null
+                },
+                "or_eitc": {
+                    "2023": null
+                },
+                "or_exemption_credit": {
+                    "2023": null
+                },
+                "or_federal_tax_liability_subtraction": {
+                    "2023": null
+                },
+                "or_income_additions": {
+                    "2023": 0
+                },
+                "or_income_after_additions": {
+                    "2023": null
+                },
+                "or_income_after_subtractions": {
+                    "2023": null
+                },
+                "or_income_subtractions": {
+                    "2023": null
+                },
+                "or_income_tax": {
+                    "2023": null
+                },
+                "or_income_tax_before_credits": {
+                    "2023": null
+                },
+                "or_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "or_itemized_deductions": {
+                    "2023": null
+                },
+                "or_kicker": {
+                    "2023": null
+                },
+                "or_non_refundable_credits": {
+                    "2023": null
+                },
+                "or_refundable_credits": {
+                    "2023": null
+                },
+                "or_regular_exemptions": {
+                    "2023": null
+                },
+                "or_severely_disabled_exemptions": {
+                    "2023": null
+                },
+                "or_standard_deduction": {
+                    "2023": null
+                },
+                "or_tax_before_credits_in_prior_year": {
+                    "2023": 0
+                },
+                "or_taxable_income": {
+                    "2023": null
+                },
+                "other_net_gain": {
+                    "2023": 0
+                },
+                "othertaxes": {
+                    "2023": 0
+                },
+                "pa_adjusted_taxable_income": {
+                    "2023": null
+                },
+                "pa_eligibility_income": {
+                    "2023": null
+                },
+                "pa_income_tax": {
+                    "2023": null
+                },
+                "pa_income_tax_after_forgiveness": {
+                    "2023": null
+                },
+                "pa_income_tax_before_forgiveness": {
+                    "2023": null
+                },
+                "pa_tax_deductions": {
+                    "2023": 0
+                },
+                "pa_tax_forgiveness_amount": {
+                    "2023": null
+                },
+                "pa_tax_forgiveness_rate": {
+                    "2023": null
+                },
+                "pa_total_taxable_income": {
+                    "2023": null
+                },
+                "pa_use_tax": {
+                    "2023": null
+                },
+                "positive_agi": {
+                    "2023": null
+                },
+                "pre_c04600": {
+                    "2023": null
+                },
+                "premium_tax_credit": {
+                    "2023": null
+                },
+                "prior_energy_efficient_home_improvement_credits": {
+                    "2023": 0
+                },
+                "prior_energy_efficient_window_credits": {
+                    "2023": 0
+                },
+                "property_tax_primary_residence": {
+                    "2023": null
+                },
+                "ptc_phase_out_rate": {
+                    "2023": null
+                },
+                "puerto_rico_income": {
+                    "2023": 0
+                },
+                "purchased_qualifying_new_clean_vehicle": {
+                    "2023": false
+                },
+                "purchased_qualifying_used_clean_vehicle": {
+                    "2023": false
+                },
+                "qualified_battery_storage_technology_expenditures": {
+                    "2023": 0
+                },
+                "qualified_business_income_deduction": {
+                    "2023": null
+                },
+                "qualified_furnace_or_hot_water_boiler_expenditures": {
+                    "2023": 0
+                },
+                "qualified_retirement_penalty": {
+                    "2023": 0
+                },
+                "recapture_of_investment_credit": {
+                    "2023": 0
+                },
+                "recovery_rebate_credit": {
+                    "2023": null
+                },
+                "refundable_american_opportunity_credit": {
+                    "2023": null
+                },
+                "refundable_ctc": {
+                    "2023": null
+                },
+                "refundable_payroll_tax_credit": {
+                    "2023": 0
+                },
+                "regular_tax_before_credits": {
+                    "2023": null
+                },
+                "rents": {
+                    "2023": null
+                },
+                "reported_slspc": {
+                    "2023": 0
+                },
+                "residential_clean_energy_credit": {
+                    "2023": null
+                },
+                "residential_efficiency_electrification_rebate": {
+                    "2023": null
+                },
+                "residential_efficiency_electrification_retrofit_energy_savings": {
+                    "2023": 0
+                },
+                "residential_efficiency_electrification_retrofit_expenditures": {
+                    "2023": 0
+                },
+                "retirement_savings_credit": {
+                    "2023": null
+                },
+                "ri_cdcc": {
+                    "2023": null
+                },
+                "ri_eitc": {
+                    "2023": null
+                },
+                "ri_income_tax": {
+                    "2023": null
+                },
+                "ri_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ri_refundable_credits": {
+                    "2023": 0
+                },
+                "ri_standard_deduction": {
+                    "2023": null
+                },
+                "ri_taxable_income": {
+                    "2023": 0
+                },
+                "rptc": {
+                    "2023": null
+                },
+                "rrc_arpa": {
+                    "2023": null
+                },
+                "rrc_caa": {
+                    "2023": null
+                },
+                "rrc_cares": {
+                    "2023": null
+                },
+                "salt_deduction": {
+                    "2023": null
+                },
+                "salt_refund_last_year": {
+                    "2023": 0
+                },
+                "sc_cdcc": {
+                    "2023": null
+                },
+                "sc_eitc": {
+                    "2023": null
+                },
+                "sc_income_tax_before_credits": {
+                    "2023": null
+                },
+                "sc_military_retirement_income_deduction_head": {
+                    "2023": 0
+                },
+                "sc_military_retirement_income_deduction_spouse": {
+                    "2023": 0
+                },
+                "sc_retirement_income_deduction_head": {
+                    "2023": 0
+                },
+                "sc_retirement_income_deduction_spouse": {
+                    "2023": 0
+                },
+                "sc_senior_exemption": {
+                    "2023": null
+                },
+                "sc_taxable_income": {
+                    "2023": 0
+                },
+                "sc_young_child_exemption": {
+                    "2023": null
+                },
+                "second_lowest_silver_plan_cost": {
+                    "2023": null
+                },
+                "section_22_income": {
+                    "2023": null
+                },
+                "self_employed_health_insurance_ald": {
+                    "2023": null
+                },
+                "self_employed_pension_contribution_ald": {
+                    "2023": null
+                },
+                "self_employment_tax_ald": {
+                    "2023": null
+                },
+                "sep": {
+                    "2023": 1
+                },
+                "separate_filer_itemizes": {
+                    "2023": false
+                },
+                "small_wind_energy_property_expenditures": {
+                    "2023": 0
+                },
+                "solar_electric_property_expenditures": {
+                    "2023": 0
+                },
+                "solar_water_heating_property_expenditures": {
+                    "2023": 0
+                },
+                "specified_possession_income": {
+                    "2023": 0
+                },
+                "spouse_earned": {
+                    "2023": null
+                },
+                "spouse_is_disabled": {
+                    "2023": null
+                },
+                "spouse_separate_adjusted_gross_income": {
+                    "2023": null
+                },
+                "spouse_separate_tax_unit_size": {
+                    "2023": null
+                },
+                "standard": {
+                    "2023": null
+                },
+                "standard_deduction": {
+                    "2023": null
+                },
+                "state_and_local_sales_or_income_tax": {
+                    "2023": null
+                },
+                "state_income_tax": {
+                    "2023": null
+                },
+                "state_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "state_sales_tax": {
+                    "2023": 0
+                },
+                "surtax": {
+                    "2023": 0
+                },
+                "tax": {
+                    "2023": null
+                },
+                "tax_exempt_social_security": {
+                    "2023": null
+                },
+                "tax_liability_if_itemizing": {
+                    "2023": null
+                },
+                "tax_liability_if_not_itemizing": {
+                    "2023": null
+                },
+                "tax_unit_childcare_expenses": {
+                    "2023": null
+                },
+                "tax_unit_children": {
+                    "2023": null
+                },
+                "tax_unit_count_dependents": {
+                    "2023": null
+                },
+                "tax_unit_dependent_elsewhere": {
+                    "2023": false
+                },
+                "tax_unit_dependents": {
+                    "2023": null
+                },
+                "tax_unit_earned_income": {
+                    "2023": null
+                },
+                "tax_unit_fpg": {
+                    "2023": null
+                },
+                "tax_unit_id": {
+                    "2023": 0
+                },
+                "tax_unit_income_ami_ratio": {
+                    "2023": 0
+                },
+                "tax_unit_is_joint": {
+                    "2023": null
+                },
+                "tax_unit_itemizes": {
+                    "2023": null
+                },
+                "tax_unit_medicaid_income_level": {
+                    "2023": null
+                },
+                "tax_unit_net_capital_gains": {
+                    "2023": null
+                },
+                "tax_unit_partnership_s_corp_income": {
+                    "2023": null
+                },
+                "tax_unit_rental_income": {
+                    "2023": null
+                },
+                "tax_unit_size": {
+                    "2023": null
+                },
+                "tax_unit_social_security": {
+                    "2023": null
+                },
+                "tax_unit_spouse_dependent_elsewhere": {
+                    "2023": false
+                },
+                "tax_unit_ss": {
+                    "2023": null
+                },
+                "tax_unit_ssi": {
+                    "2023": null
+                },
+                "tax_unit_state": {
+                    "2023": null
+                },
+                "tax_unit_taxable_social_security": {
+                    "2023": null
+                },
+                "tax_unit_taxable_unemployment_compensation": {
+                    "2023": null
+                },
+                "tax_unit_unemployment_compensation": {
+                    "2023": null
+                },
+                "tax_unit_weight": {
+                    "2023": 0
+                },
+                "taxable_income": {
+                    "2023": null
+                },
+                "taxable_income_deductions": {
+                    "2023": null
+                },
+                "taxable_income_deductions_if_itemizing": {
+                    "2023": null
+                },
+                "taxable_income_deductions_if_not_itemizing": {
+                    "2023": null
+                },
+                "taxable_income_less_qbid": {
+                    "2023": null
+                },
+                "taxable_ss_magi": {
+                    "2023": null
+                },
+                "taxable_uc_agi": {
+                    "2023": null
+                },
+                "taxbc": {
+                    "2023": null
+                },
+                "taxcalc_c04470": {
+                    "2023": null
+                },
+                "taxcalc_c09200": {
+                    "2023": null
+                },
+                "taxcalc_c17000": {
+                    "2023": null
+                },
+                "taxcalc_c18300": {
+                    "2023": null
+                },
+                "taxcalc_c19200": {
+                    "2023": null
+                },
+                "taxcalc_c19700": {
+                    "2023": null
+                },
+                "taxcalc_c20500": {
+                    "2023": null
+                },
+                "taxcalc_cmbtp": {
+                    "2023": null
+                },
+                "taxcalc_dsi": {
+                    "2023": null
+                },
+                "taxcalc_e00200": {
+                    "2023": null
+                },
+                "taxcalc_e00300": {
+                    "2023": null
+                },
+                "taxcalc_e00400": {
+                    "2023": null
+                },
+                "taxcalc_e00600": {
+                    "2023": null
+                },
+                "taxcalc_e00650": {
+                    "2023": null
+                },
+                "taxcalc_e00700": {
+                    "2023": null
+                },
+                "taxcalc_e00800": {
+                    "2023": null
+                },
+                "taxcalc_e00900": {
+                    "2023": null
+                },
+                "taxcalc_e01100": {
+                    "2023": null
+                },
+                "taxcalc_e01200": {
+                    "2023": null
+                },
+                "taxcalc_e01500": {
+                    "2023": null
+                },
+                "taxcalc_e01700": {
+                    "2023": null
+                },
+                "taxcalc_e02000": {
+                    "2023": null
+                },
+                "taxcalc_e02100": {
+                    "2023": null
+                },
+                "taxcalc_e02300": {
+                    "2023": null
+                },
+                "taxcalc_e02400": {
+                    "2023": null
+                },
+                "taxcalc_e03150": {
+                    "2023": null
+                },
+                "taxcalc_e03210": {
+                    "2023": null
+                },
+                "taxcalc_e03220": {
+                    "2023": null
+                },
+                "taxcalc_e03230": {
+                    "2023": null
+                },
+                "taxcalc_e03240": {
+                    "2023": null
+                },
+                "taxcalc_e03270": {
+                    "2023": null
+                },
+                "taxcalc_e03290": {
+                    "2023": null
+                },
+                "taxcalc_e03300": {
+                    "2023": null
+                },
+                "taxcalc_e03400": {
+                    "2023": null
+                },
+                "taxcalc_e03500": {
+                    "2023": null
+                },
+                "taxcalc_e09700": {
+                    "2023": null
+                },
+                "taxcalc_e09800": {
+                    "2023": null
+                },
+                "taxcalc_e09900": {
+                    "2023": null
+                },
+                "taxcalc_e11200": {
+                    "2023": null
+                },
+                "taxcalc_e17500": {
+                    "2023": null
+                },
+                "taxcalc_e18500": {
+                    "2023": null
+                },
+                "taxcalc_e19200": {
+                    "2023": null
+                },
+                "taxcalc_e19800": {
+                    "2023": null
+                },
+                "taxcalc_e20100": {
+                    "2023": null
+                },
+                "taxcalc_e20400": {
+                    "2023": null
+                },
+                "taxcalc_e24515": {
+                    "2023": null
+                },
+                "taxcalc_e24518": {
+                    "2023": null
+                },
+                "taxcalc_e26270": {
+                    "2023": null
+                },
+                "taxcalc_e27200": {
+                    "2023": null
+                },
+                "taxcalc_e32800": {
+                    "2023": null
+                },
+                "taxcalc_e58990": {
+                    "2023": null
+                },
+                "taxcalc_e62900": {
+                    "2023": null
+                },
+                "taxcalc_e87530": {
+                    "2023": null
+                },
+                "taxcalc_f2441": {
+                    "2023": null
+                },
+                "taxcalc_f6251": {
+                    "2023": null
+                },
+                "taxcalc_fips": {
+                    "2023": null
+                },
+                "taxcalc_g20500": {
+                    "2023": null
+                },
+                "taxcalc_hasqdivltcg": {
+                    "2023": null
+                },
+                "taxcalc_midr": {
+                    "2023": null
+                },
+                "taxcalc_niit": {
+                    "2023": null
+                },
+                "taxcalc_p22250": {
+                    "2023": null
+                },
+                "taxcalc_p23250": {
+                    "2023": null
+                },
+                "taxcalc_pencon": {
+                    "2023": null
+                },
+                "taxcalc_pt_binc_w2_wages": {
+                    "2023": null
+                },
+                "taxcalc_pt_sstb_income": {
+                    "2023": null
+                },
+                "taxcalc_pt_ubia_property": {
+                    "2023": null
+                },
+                "taxcalc_s006": {
+                    "2023": null
+                },
+                "taxsim_age1": {
+                    "2023": null
+                },
+                "taxsim_age2": {
+                    "2023": null
+                },
+                "taxsim_age3": {
+                    "2023": null
+                },
+                "taxsim_childcare": {
+                    "2023": null
+                },
+                "taxsim_dep13": {
+                    "2023": null
+                },
+                "taxsim_dep17": {
+                    "2023": null
+                },
+                "taxsim_dep18": {
+                    "2023": null
+                },
+                "taxsim_depx": {
+                    "2023": null
+                },
+                "taxsim_dividends": {
+                    "2023": null
+                },
+                "taxsim_fiitax": {
+                    "2023": null
+                },
+                "taxsim_gssi": {
+                    "2023": null
+                },
+                "taxsim_intrec": {
+                    "2023": null
+                },
+                "taxsim_ltcg": {
+                    "2023": null
+                },
+                "taxsim_mstat": {
+                    "2023": null
+                },
+                "taxsim_page": {
+                    "2023": null
+                },
+                "taxsim_pbusinc": {
+                    "2023": null
+                },
+                "taxsim_pensions": {
+                    "2023": null
+                },
+                "taxsim_pprofinc": {
+                    "2023": 0
+                },
+                "taxsim_psemp": {
+                    "2023": null
+                },
+                "taxsim_pui": {
+                    "2023": null
+                },
+                "taxsim_pwages": {
+                    "2023": null
+                },
+                "taxsim_sage": {
+                    "2023": null
+                },
+                "taxsim_sbusinc": {
+                    "2023": null
+                },
+                "taxsim_scorp": {
+                    "2023": null
+                },
+                "taxsim_siitax": {
+                    "2023": null
+                },
+                "taxsim_sprofinc": {
+                    "2023": 0
+                },
+                "taxsim_ssemp": {
+                    "2023": null
+                },
+                "taxsim_state": {
+                    "2023": null
+                },
+                "taxsim_stcg": {
+                    "2023": null
+                },
+                "taxsim_swages": {
+                    "2023": null
+                },
+                "taxsim_taxsimid": {
+                    "2023": null
+                },
+                "taxsim_tfica": {
+                    "2023": null
+                },
+                "taxsim_ui": {
+                    "2023": null
+                },
+                "taxsim_v10": {
+                    "2023": null
+                },
+                "taxsim_v11": {
+                    "2023": null
+                },
+                "taxsim_v12": {
+                    "2023": null
+                },
+                "taxsim_v18": {
+                    "2023": null
+                },
+                "taxsim_v25": {
+                    "2023": null
+                },
+                "taxsim_year": {
+                    "2023": null
+                },
+                "tuition_and_fees": {
+                    "2023": 0
+                },
+                "unrecaptured_section_1250_gain": {
+                    "2023": 0
+                },
+                "unreported_payroll_tax": {
+                    "2023": 0
+                },
+                "us_govt_interest": {
+                    "2023": 0
+                },
+                "used_clean_vehicle_credit": {
+                    "2023": null
+                },
+                "used_clean_vehicle_credit_eligible": {
+                    "2023": null
+                },
+                "used_clean_vehicle_sale_price": {
+                    "2023": 0
+                },
+                "ut_additions_to_income": {
+                    "2023": 0
+                },
+                "ut_at_home_parent_credit": {
+                    "2023": null
+                },
+                "ut_claims_retirement_credit": {
+                    "2023": null
+                },
+                "ut_eitc": {
+                    "2023": null
+                },
+                "ut_federal_deductions_for_taxpayer_credit": {
+                    "2023": null
+                },
+                "ut_income_tax": {
+                    "2023": null
+                },
+                "ut_income_tax_before_credits": {
+                    "2023": null
+                },
+                "ut_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "ut_income_tax_exempt": {
+                    "2023": null
+                },
+                "ut_personal_exemption": {
+                    "2023": null
+                },
+                "ut_refundable_credits": {
+                    "2023": 0
+                },
+                "ut_retirement_credit": {
+                    "2023": null
+                },
+                "ut_retirement_credit_max": {
+                    "2023": null
+                },
+                "ut_ss_benefits_credit": {
+                    "2023": null
+                },
+                "ut_ss_benefits_credit_max": {
+                    "2023": null
+                },
+                "ut_state_tax_refund": {
+                    "2023": null
+                },
+                "ut_subtractions_from_income": {
+                    "2023": 0
+                },
+                "ut_taxable_income": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_max": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_phase_out_income": {
+                    "2023": null
+                },
+                "ut_taxpayer_credit_reduction": {
+                    "2023": null
+                },
+                "ut_total_dependents": {
+                    "2023": null
+                },
+                "ut_total_income": {
+                    "2023": null
+                },
+                "va_afagi": {
+                    "2023": 0
+                },
+                "va_age_deduction": {
+                    "2023": null
+                },
+                "va_aged_blind_exemption": {
+                    "2023": null
+                },
+                "va_disability_income_subtraction": {
+                    "2023": null
+                },
+                "va_federal_state_employees_subtraction": {
+                    "2023": null
+                },
+                "va_income_tax_before_credits": {
+                    "2023": null
+                },
+                "va_military_basic_pay_subtraction": {
+                    "2023": null
+                },
+                "va_military_benefit_subtraction": {
+                    "2023": null
+                },
+                "va_personal_exemption": {
+                    "2023": null
+                },
+                "va_standard_deduction": {
+                    "2023": null
+                },
+                "va_taxable_income": {
+                    "2023": 0
+                },
+                "va_total_exemptions": {
+                    "2023": null
+                },
+                "vt_agi": {
+                    "2023": null
+                },
+                "vt_agi_additions": {
+                    "2023": 0
+                },
+                "vt_agi_subtractions": {
+                    "2023": 0
+                },
+                "vt_personal_exemptions": {
+                    "2023": null
+                },
+                "vt_standard_deduction": {
+                    "2023": null
+                },
+                "vt_taxable_income": {
+                    "2023": null
+                },
+                "wa_capital_gains_tax": {
+                    "2023": null
+                },
+                "wa_income_tax": {
+                    "2023": null
+                },
+                "wa_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "wa_refundable_credits": {
+                    "2023": null
+                },
+                "wa_working_families_tax_credit": {
+                    "2023": null
+                },
+                "wi_agi": {
+                    "2023": null
+                },
+                "wi_capital_gain_loss_addition": {
+                    "2023": null
+                },
+                "wi_capital_gain_loss_subtraction": {
+                    "2023": null
+                },
+                "wi_capital_loss": {
+                    "2023": null
+                },
+                "wi_childcare_expense_credit": {
+                    "2023": null
+                },
+                "wi_childcare_expense_subtraction": {
+                    "2023": null
+                },
+                "wi_earned_income_credit": {
+                    "2023": null
+                },
+                "wi_exemption": {
+                    "2023": null
+                },
+                "wi_homestead_credit": {
+                    "2023": null
+                },
+                "wi_homestead_eligible": {
+                    "2023": null
+                },
+                "wi_homestead_income": {
+                    "2023": null
+                },
+                "wi_homestead_property_tax": {
+                    "2023": null
+                },
+                "wi_income_additions": {
+                    "2023": null
+                },
+                "wi_income_subtractions": {
+                    "2023": null
+                },
+                "wi_income_tax": {
+                    "2023": null
+                },
+                "wi_income_tax_before_credits": {
+                    "2023": null
+                },
+                "wi_income_tax_before_refundable_credits": {
+                    "2023": null
+                },
+                "wi_itemized_deduction_credit": {
+                    "2023": null
+                },
+                "wi_married_couple_credit": {
+                    "2023": null
+                },
+                "wi_nonrefundable_credits": {
+                    "2023": null
+                },
+                "wi_property_tax_credit": {
+                    "2023": null
+                },
+                "wi_refundable_credits": {
+                    "2023": null
+                },
+                "wi_retirement_income_subtraction": {
+                    "2023": null
+                },
+                "wi_retirement_income_subtraction_agi_eligible": {
+                    "2023": null
+                },
+                "wi_standard_deduction": {
+                    "2023": null
+                },
+                "wi_taxable_income": {
+                    "2023": null
+                },
+                "wi_unemployment_compensation_subtraction": {
+                    "2023": null
+                },
+                "wv_income_tax_before_credits": {
+                    "2023": null
+                },
+                "wv_personal_exemption": {
+                    "2023": null
+                },
+                "wv_taxable_income": {
+                    "2023": 0
+                },
+                "xtot": {
+                    "2023": null
+                }
+            }
+        }
+    }',
+	"Zc70Xj7SEoewiCQ2XRhcjxaDgBZ47ZcGN16KhuIT6oE="
+);

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -5,7 +5,7 @@ from .household import (
     post_household,
     get_household_under_policy,
     get_calculate,
-    update_household
+    update_household,
 )
 from .policy import get_policy, set_policy, get_policy_search
 from .economy import get_economic_impact

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -5,6 +5,7 @@ from .household import (
     post_household,
     get_household_under_policy,
     get_calculate,
+    update_household
 )
 from .policy import get_policy, set_policy, get_policy_search
 from .economy import get_economic_impact

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -280,6 +280,12 @@ def get_calculate(country_id: str) -> dict:
     payload = request.json
     household_json = payload.get("household", {})
     policy_json = payload.get("policy", {})
+    
+    # Add in any missing yearly variables to household_json
+    household_json = add_yearly_variables(
+        household_json,
+        country_id
+    )
 
     country = COUNTRIES.get(country_id)
 

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -18,7 +18,33 @@ import json
 import dpath
 import math
 import logging
+import sys
 
+def add_yearly_variables(household, country_id):
+  """
+  Add yearly variables to a household dict before enqueueing calculation
+  """
+  metadata = COUNTRIES.get(country_id).metadata["result"]
+
+  variables = metadata["variables"]
+  entities = metadata["entities"]
+
+  for variable in variables:
+    if variables[variable]["definitionPeriod"] == "year":
+      entity_plural = entities[variables[variable]["entity"]]["plural"]
+      if entity_plural in household:
+        possible_entities = household[entity_plural].keys()
+        for entity in possible_entities:
+          if not variables[variable]["name"] in household[entity_plural][entity]:
+            if variables[variable]["isInputVariable"]:
+              household[entity_plural][entity][variables[variable]["name"]] = {
+                  2023: variables[variable]["defaultValue"]
+              }
+            else:
+              household[entity_plural][entity][variables[variable]["name"]] = {
+                2023: None
+              }
+  return household
 
 def get_household(country_id: str, household_id: str) -> dict:
     """Get a household's input data with a given ID.
@@ -167,6 +193,12 @@ def get_household_under_policy(
             status=404,
             mimetype="application/json",
         )
+    
+    # Add in any missing yearly variables
+    household["household_json"] = add_yearly_variables(
+        household["household_json"],
+        country_id
+    )
 
     # Retrieve from the policy table
 

--- a/policyengine_api/openapi_spec.yaml
+++ b/policyengine_api/openapi_spec.yaml
@@ -372,6 +372,62 @@ paths:
                     type: string
                   message:
                     type: string
+    put:
+      summary: Update an existing household
+      operationId: update_household
+      description: Update an exising household located at the passed ID
+      parameters:
+        - name: country_id
+          in: path
+          description: The country ID.
+          required: true
+          schema:
+            type: string
+        - name: household_id
+          in: path
+          description: The household ID.
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Household updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+                  result:
+                    type: object
+                    properties:
+                      household_id:
+                        type: integer
+        404:
+          description: Household not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
+        404:
+          description: Invalid country ID.
+          content:
+            text/html:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  message:
+                    type: string
   /{country_id}/household/{household_id}/policy/{policy_id}:
     get:
       summary: Get a household's output data under a given policy

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -58,7 +58,7 @@ def test_response(client, test: dict):
     elif test.get("method") == "PUT":
         response = client.put(
             test["endpoint"],
-            data = json.dumps(test["data"]),
+            data=json.dumps(test["data"]),
             content_type="application/json",
         )
     else:

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -55,6 +55,12 @@ def test_response(client, test: dict):
             data=json.dumps(test["data"]),
             content_type="application/json",
         )
+    elif test.get("method") == "PUT":
+        response = client.put(
+            test["endpoint"],
+            data = json.dumps(test["data"]),
+            content_type="application/json",
+        )
     else:
         raise ValueError(f"Unknown HTTP method: {test['method']}")
 

--- a/tests/api/test_update_household
+++ b/tests/api/test_update_household
@@ -1,0 +1,16 @@
+name: Update US household
+endpoint: /us/household/-8
+method: PUT
+data:
+  label: Updated US household \#-8
+  household_json: {
+    "testVal1": null,
+    "testVal2": true,
+    "testVal3": 3
+  }
+response:
+  data:
+    status: ok
+    result:
+      household_id: -8
+  status: 200

--- a/tests/api/test_update_household_lean
+++ b/tests/api/test_update_household_lean
@@ -1,0 +1,15 @@
+name: Update US household with only some values
+endpoint: /us/household/-8
+method: PUT
+data:
+  household_json: {
+    "testVal1": null,
+    "testVal2": true,
+    "testVal3": 3
+  }
+response:
+  data:
+    status: ok
+    result:
+      household_id: -8
+  status: 200

--- a/tests/python/data/uk_household.json
+++ b/tests/python/data/uk_household.json
@@ -1,0 +1,88 @@
+{
+  "benunits": {
+    "your immediate family": {
+      "is_married": {
+        "2023": true
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first child",
+        "your second child",
+        "your third child",
+        "your fourth child"
+      ]
+    }
+  },
+  "households": {
+    "your household": {
+      "BRMA": {
+        "2023": "MAIDSTONE"
+      },
+      "local_authority": {
+        "2023": "MAIDSTONE"
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first child",
+        "your second child",
+        "your third child",
+        "your fourth child"
+      ],
+      "region": {
+        "2023": "LONDON"
+      }
+    }
+  },
+  "people": {
+    "you": {
+      "age": {
+        "2023": 40
+      },
+      "employment_income": {
+        "2023": 40000
+      }
+    },
+    "your first child": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      }
+    },
+    "your fourth child": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      }
+    },
+    "your partner": {
+      "age": {
+        "2023": 40
+      },
+      "employment_income": {
+        "2023": 0
+      }
+    },
+    "your second child": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      }
+    },
+    "your third child": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      }
+    }
+  }
+}

--- a/tests/python/data/uk_household_under_policy_target.json
+++ b/tests/python/data/uk_household_under_policy_target.json
@@ -1,0 +1,5629 @@
+{
+  "benunits": {
+    "your immediate family": {
+      "BRMA_LHA_rate": {
+        "2023": 12009.673
+      },
+      "CTC_child_element": {
+        "2023": 11740
+      },
+      "CTC_disabled_child_element": {
+        "2023": 0
+      },
+      "CTC_family_element": {
+        "2023": 0
+      },
+      "CTC_maximum_rate": {
+        "2023": 11740
+      },
+      "CTC_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "ESA_income": {
+        "2023": 0
+      },
+      "ESA_income_eligible": {
+        "2023": false
+      },
+      "HB_non_dep_deductions": {
+        "2023": 0
+      },
+      "JSA": {
+        "2023": 0
+      },
+      "JSA_income": {
+        "2023": 0
+      },
+      "JSA_income_applicable_amount": {
+        "2023": 0
+      },
+      "JSA_income_applicable_income": {
+        "2023": 30954.396
+      },
+      "JSA_income_eligible": {
+        "2023": false
+      },
+      "LHA_allowed_bedrooms": {
+        "2023": 3
+      },
+      "LHA_cap": {
+        "2023": 0
+      },
+      "LHA_category": {
+        "2023": "D"
+      },
+      "LHA_eligible": {
+        "2023": false
+      },
+      "UC_LCWRA_element": {
+        "2023": 0
+      },
+      "UC_carer_element": {
+        "2023": 0
+      },
+      "UC_child_element": {
+        "2023": 12284.88
+      },
+      "UC_childcare_element": {
+        "2023": 0
+      },
+      "UC_childcare_work_condition": {
+        "2023": false
+      },
+      "UC_claimant_type": {
+        "2023": "COUPLE_OLD"
+      },
+      "UC_disability_elements": {
+        "2023": 0
+      },
+      "UC_earned_income": {
+        "2023": 24598.396
+      },
+      "UC_housing_costs_element": {
+        "2023": 0
+      },
+      "UC_income_reduction": {
+        "2023": 13529.118
+      },
+      "UC_maximum_amount": {
+        "2023": 18593.52
+      },
+      "UC_maximum_childcare": {
+        "2023": 13296.48
+      },
+      "UC_non_dep_deductions": {
+        "2023": 0
+      },
+      "UC_standard_allowance": {
+        "2023": 6308.64
+      },
+      "UC_unearned_income": {
+        "2023": 0
+      },
+      "UC_work_allowance": {
+        "2023": 6876
+      },
+      "WTC_basic_element": {
+        "2023": 0
+      },
+      "WTC_childcare_element": {
+        "2023": 0
+      },
+      "WTC_couple_element": {
+        "2023": 0
+      },
+      "WTC_disabled_element": {
+        "2023": 0
+      },
+      "WTC_lone_parent_element": {
+        "2023": 0
+      },
+      "WTC_maximum_rate": {
+        "2023": 0
+      },
+      "WTC_severely_disabled_element": {
+        "2023": 0
+      },
+      "WTC_worker_element": {
+        "2023": 0
+      },
+      "additional_minimum_guarantee": {
+        "2023": 11720.8
+      },
+      "baseline_child_benefit_entitlement": {
+        "2023": 0
+      },
+      "baseline_ctc_entitlement": {
+        "2023": 0
+      },
+      "baseline_housing_benefit_entitlement": {
+        "2023": 0
+      },
+      "baseline_income_support_entitlement": {
+        "2023": 0
+      },
+      "baseline_pension_credit_entitlement": {
+        "2023": 0
+      },
+      "baseline_universal_credit_entitlement": {
+        "2023": 0
+      },
+      "baseline_wtc_entitlement": {
+        "2023": 0
+      },
+      "benefit_cap": {
+        "2023": 23000.12
+      },
+      "benefit_cap_reduction": {
+        "2023": 0
+      },
+      "benefits_premiums": {
+        "2023": 0
+      },
+      "benunit_has_carer": {
+        "2023": false
+      },
+      "benunit_id": {
+        "2023": 0
+      },
+      "benunit_is_renting": {
+        "2023": false
+      },
+      "benunit_rent": {
+        "2023": 0
+      },
+      "benunit_tax": {
+        "2023": 8525.604
+      },
+      "benunit_tenure_type": {
+        "2023": "RENT_PRIVATELY"
+      },
+      "benunit_weekly_hours": {
+        "2023": 0
+      },
+      "benunit_weight": {
+        "2023": 0
+      },
+      "carer_minimum_guarantee_addition": {
+        "2023": 0
+      },
+      "carer_premium": {
+        "2023": 0
+      },
+      "child_benefit": {
+        "2023": 3387.8
+      },
+      "child_benefit_entitlement": {
+        "2023": 3387.8
+      },
+      "child_benefit_less_tax_charge": {
+        "2023": 3387.8
+      },
+      "child_minimum_guarantee_addition": {
+        "2023": 11720.8
+      },
+      "child_tax_credit": {
+        "2023": 0
+      },
+      "child_tax_credit_pre_minimum": {
+        "2023": 2312.0498
+      },
+      "claims_ESA_income": {
+        "2023": false
+      },
+      "claims_all_entitled_benefits": {
+        "2023": true
+      },
+      "claims_legacy_benefits": {
+        "2023": false
+      },
+      "council_tax_benefit": {
+        "2023": 0
+      },
+      "count_children_and_qyp": {
+        "2023": 4
+      },
+      "ctc_child_limit_affected": {
+        "2023": false
+      },
+      "ctc_entitlement": {
+        "2023": 0
+      },
+      "disability_premium": {
+        "2023": 0
+      },
+      "eldest_adult_age": {
+        "2023": 40
+      },
+      "eldest_child_age": {
+        "2023": 10
+      },
+      "enhanced_disability_premium": {
+        "2023": 0
+      },
+      "families": {
+        "2023": 1
+      },
+      "family_rent": {
+        "2023": 0
+      },
+      "family_type": {
+        "2023": "COUPLE_WITH_CHILDREN"
+      },
+      "guarantee_credit": {
+        "2023": 0
+      },
+      "housing_benefit": {
+        "2023": 0
+      },
+      "housing_benefit_applicable_amount": {
+        "2023": 0
+      },
+      "housing_benefit_applicable_income": {
+        "2023": 36654.246
+      },
+      "housing_benefit_eligible": {
+        "2023": false
+      },
+      "housing_benefit_entitlement": {
+        "2023": 0
+      },
+      "housing_benefit_pre_benefit_cap": {
+        "2023": 0
+      },
+      "income_support": {
+        "2023": 0
+      },
+      "income_support_applicable_amount": {
+        "2023": 6826.7266
+      },
+      "income_support_applicable_income": {
+        "2023": 30954.396
+      },
+      "income_support_eligible": {
+        "2023": false
+      },
+      "income_support_entitlement": {
+        "2023": 0
+      },
+      "is_CTC_eligible": {
+        "2023": false
+      },
+      "is_UC_eligible": {
+        "2023": true
+      },
+      "is_UC_work_allowance_eligible": {
+        "2023": true
+      },
+      "is_WTC_eligible": {
+        "2023": false
+      },
+      "is_benefit_cap_exempt": {
+        "2023": false
+      },
+      "is_couple": {
+        "2023": true
+      },
+      "is_guarantee_credit_eligible": {
+        "2023": false
+      },
+      "is_lone_parent": {
+        "2023": false
+      },
+      "is_married": {
+        "2023": true
+      },
+      "is_pension_credit_eligible": {
+        "2023": false
+      },
+      "is_savings_credit_eligible": {
+        "2023": true
+      },
+      "is_single": {
+        "2023": false
+      },
+      "is_single_person": {
+        "2023": false
+      },
+      "legacy_benefits": {
+        "2023": 0
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first child",
+        "your second child",
+        "your third child",
+        "your fourth child"
+      ],
+      "minimum_guarantee": {
+        "2023": 26213.2
+      },
+      "num_UC_eligible_children": {
+        "2023": 4
+      },
+      "num_adults": {
+        "2023": 2
+      },
+      "num_carers": {
+        "2023": 0
+      },
+      "num_children": {
+        "2023": 4
+      },
+      "num_disabled_adults": {
+        "2023": 0
+      },
+      "num_disabled_children": {
+        "2023": 0
+      },
+      "num_enhanced_disabled_adults": {
+        "2023": 0
+      },
+      "num_enhanced_disabled_children": {
+        "2023": 0
+      },
+      "num_severely_disabled_adults": {
+        "2023": 0
+      },
+      "num_severely_disabled_children": {
+        "2023": 0
+      },
+      "pension_credit": {
+        "2023": 0
+      },
+      "pension_credit_entitlement": {
+        "2023": 0
+      },
+      "pension_credit_income": {
+        "2023": 31474.396
+      },
+      "relation_type": {
+        "2023": "COUPLE"
+      },
+      "savings_credit": {
+        "2023": 5786.9365
+      },
+      "savings_credit_income": {
+        "2023": 31474.396
+      },
+      "severe_disability_minimum_guarantee_addition": {
+        "2023": 0
+      },
+      "severe_disability_premium": {
+        "2023": 0
+      },
+      "standard_minimum_guarantee": {
+        "2023": 14492.4
+      },
+      "tax_credits": {
+        "2023": 2312.0498
+      },
+      "tax_credits_applicable_income": {
+        "2023": 40000
+      },
+      "tax_credits_reduction": {
+        "2023": 9427.95
+      },
+      "uc_child_limit_affected": {
+        "2023": false
+      },
+      "uc_has_entitlement": {
+        "2023": true
+      },
+      "universal_credit": {
+        "2023": 5064.4014
+      },
+      "universal_credit_entitlement": {
+        "2023": 5064.4014
+      },
+      "universal_credit_pre_benefit_cap": {
+        "2023": 5064.4014
+      },
+      "working_tax_credit": {
+        "2023": 0
+      },
+      "working_tax_credit_pre_minimum": {
+        "2023": 0
+      },
+      "would_claim_CTC": {
+        "2023": true
+      },
+      "would_claim_ESA_income": {
+        "2023": true
+      },
+      "would_claim_HB": {
+        "2023": true
+      },
+      "would_claim_IS": {
+        "2023": true
+      },
+      "would_claim_JSA": {
+        "2023": false
+      },
+      "would_claim_UC": {
+        "2023": true
+      },
+      "would_claim_WTC": {
+        "2023": true
+      },
+      "would_claim_child_benefit": {
+        "2023": true
+      },
+      "would_claim_pc": {
+        "2023": true
+      },
+      "wtc_entitlement": {
+        "2023": 0
+      },
+      "youngest_adult_age": {
+        "2023": 40
+      },
+      "youngest_child_age": {
+        "2023": 10
+      }
+    }
+  },
+  "households": {
+    "your household": {
+      "BRMA": {
+        "2023": "MAIDSTONE"
+      },
+      "LVT": {
+        "2023": 0
+      },
+      "accommodation_type": {
+        "2023": "UNKNOWN"
+      },
+      "additional_residential_property_purchased": {
+        "2023": 0
+      },
+      "alcohol_and_tobacco_consumption": {
+        "2023": 0
+      },
+      "baseline_business_rates": {
+        "2023": 0
+      },
+      "baseline_corporate_sdlt": {
+        "2023": 0
+      },
+      "baseline_expected_lbtt": {
+        "2023": 0
+      },
+      "baseline_expected_ltt": {
+        "2023": 0
+      },
+      "baseline_expected_sdlt": {
+        "2023": 0
+      },
+      "baseline_fuel_duty": {
+        "2023": 0
+      },
+      "baseline_hbai_excluded_income": {
+        "2023": 0
+      },
+      "baseline_vat": {
+        "2023": 0
+      },
+      "business_rates": {
+        "2023": 0
+      },
+      "business_rates_change_incidence": {
+        "2023": 0
+      },
+      "carbon_consumption": {
+        "2023": 0
+      },
+      "carbon_tax": {
+        "2023": 0
+      },
+      "change_in_business_rates": {
+        "2023": 0
+      },
+      "change_in_expected_lbtt": {
+        "2023": 0
+      },
+      "change_in_expected_ltt": {
+        "2023": 0
+      },
+      "change_in_expected_sdlt": {
+        "2023": 0
+      },
+      "change_in_fuel_duty": {
+        "2023": 0
+      },
+      "clothing_and_footwear_consumption": {
+        "2023": 0
+      },
+      "communication_consumption": {
+        "2023": 0
+      },
+      "consumption": {
+        "2023": 0
+      },
+      "corporate_land_value": {
+        "2023": 0
+      },
+      "corporate_sdlt": {
+        "2023": 0
+      },
+      "corporate_sdlt_change_incidence": {
+        "2023": 0
+      },
+      "corporate_tax_incidence": {
+        "2023": 0
+      },
+      "corporate_wealth": {
+        "2023": 0
+      },
+      "cost_of_living_support_payment": {
+        "2023": 0
+      },
+      "council_tax": {
+        "2023": 0
+      },
+      "council_tax_band": {
+        "2023": "D"
+      },
+      "council_tax_less_benefit": {
+        "2023": 0
+      },
+      "country": {
+        "2023": "ENGLAND"
+      },
+      "cumulative_non_residential_rent": {
+        "2023": 0
+      },
+      "cumulative_residential_rent": {
+        "2023": 0
+      },
+      "deep_poverty_gap": {
+        "2023": 0
+      },
+      "deep_poverty_line": {
+        "2023": 16041.12
+      },
+      "diesel_litres": {
+        "2023": 0
+      },
+      "diesel_price": {
+        "2023": 1.6703
+      },
+      "diesel_spending": {
+        "2023": 0
+      },
+      "domestic_energy_consumption": {
+        "2023": 0
+      },
+      "domestic_rates": {
+        "2023": 0
+      },
+      "ebr_council_tax_rebate": {
+        "2023": 150
+      },
+      "ebr_energy_bills_credit": {
+        "2023": 0
+      },
+      "education_consumption": {
+        "2023": 0
+      },
+      "energy_bills_rebate": {
+        "2023": 150
+      },
+      "epg_subsidy": {
+        "2023": 0
+      },
+      "equiv_hbai_household_net_income": {
+        "2023": 22176.445
+      },
+      "equiv_hbai_household_net_income_ahc": {
+        "2023": 22176.445
+      },
+      "equiv_household_net_income": {
+        "2023": 22176.445
+      },
+      "expected_lbtt": {
+        "2023": 0
+      },
+      "expected_ltt": {
+        "2023": 0
+      },
+      "expected_sdlt": {
+        "2023": 0
+      },
+      "food_and_non_alcoholic_beverages_consumption": {
+        "2023": 0
+      },
+      "fuel_duty": {
+        "2023": 0
+      },
+      "full_rate_vat_consumption": {
+        "2023": 0
+      },
+      "gross_financial_wealth": {
+        "2023": 0
+      },
+      "hbai_excluded_income": {
+        "2023": 0
+      },
+      "hbai_excluded_income_change": {
+        "2023": 0
+      },
+      "hbai_household_net_income": {
+        "2023": 39917.6
+      },
+      "hbai_household_net_income_ahc": {
+        "2023": 39917.6
+      },
+      "health_consumption": {
+        "2023": 0
+      },
+      "household_benefits": {
+        "2023": 8602.201
+      },
+      "household_count_people": {
+        "2023": 6
+      },
+      "household_equivalisation_ahc": {
+        "2023": 1.8
+      },
+      "household_equivalisation_bhc": {
+        "2023": 1.8
+      },
+      "household_furnishings_consumption": {
+        "2023": 0
+      },
+      "household_gross_income": {
+        "2023": 48602.203
+      },
+      "household_id": {
+        "2023": 0
+      },
+      "household_income_decile": {
+        "2023": -2147483648
+      },
+      "household_land_value": {
+        "2023": 0
+      },
+      "household_market_income": {
+        "2023": 40000
+      },
+      "household_net_income": {
+        "2023": 39917.6
+      },
+      "household_num_benunits": {
+        "2023": 1
+      },
+      "household_owns_tv": {
+        "2023": true
+      },
+      "household_tax": {
+        "2023": 8684.604
+      },
+      "household_weight": {
+        "2023": 0
+      },
+      "households": {
+        "2023": 1
+      },
+      "housing_costs": {
+        "2023": 0
+      },
+      "housing_service_charges": {
+        "2023": 0
+      },
+      "housing_water_and_electricity_consumption": {
+        "2023": 0
+      },
+      "in_deep_poverty": {
+        "2023": false
+      },
+      "in_deep_poverty_ahc": {
+        "2023": false
+      },
+      "in_deep_poverty_bhc": {
+        "2023": false
+      },
+      "in_original_frs": {
+        "2023": 0
+      },
+      "in_poverty": {
+        "2023": false
+      },
+      "in_poverty_ahc": {
+        "2023": false
+      },
+      "in_poverty_bhc": {
+        "2023": false
+      },
+      "in_relative_poverty_ahc": {
+        "2023": false
+      },
+      "is_renting": {
+        "2023": true
+      },
+      "is_shared_accommodation": {
+        "2023": false
+      },
+      "land_and_buildings_transaction_tax": {
+        "2023": 0
+      },
+      "land_transaction_tax": {
+        "2023": 0
+      },
+      "land_value": {
+        "2023": 0
+      },
+      "lbtt_liable": {
+        "2023": false
+      },
+      "lbtt_on_non_residential_property_rent": {
+        "2023": 0
+      },
+      "lbtt_on_non_residential_property_transactions": {
+        "2023": 0
+      },
+      "lbtt_on_rent": {
+        "2023": 0
+      },
+      "lbtt_on_residential_property_rent": {
+        "2023": 0
+      },
+      "lbtt_on_residential_property_transactions": {
+        "2023": 0
+      },
+      "lbtt_on_transactions": {
+        "2023": 0
+      },
+      "local_authority": {
+        "2023": "MAIDSTONE"
+      },
+      "ltt_liable": {
+        "2023": false
+      },
+      "ltt_on_non_residential_property_rent": {
+        "2023": 0
+      },
+      "ltt_on_non_residential_property_transactions": {
+        "2023": 0
+      },
+      "ltt_on_rent": {
+        "2023": 0
+      },
+      "ltt_on_residential_property_rent": {
+        "2023": 0
+      },
+      "ltt_on_residential_property_transactions": {
+        "2023": 0
+      },
+      "ltt_on_transactions": {
+        "2023": 0
+      },
+      "main_residence_value": {
+        "2023": 0
+      },
+      "main_residential_property_purchased": {
+        "2023": 0
+      },
+      "main_residential_property_purchased_is_first_home": {
+        "2023": false
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first child",
+        "your second child",
+        "your third child",
+        "your fourth child"
+      ],
+      "miscellaneous_consumption": {
+        "2023": 0
+      },
+      "mortgage": {
+        "2023": 0
+      },
+      "mortgage_capital_repayment": {
+        "2023": 0
+      },
+      "mortgage_interest_repayment": {
+        "2023": 0
+      },
+      "net_financial_wealth": {
+        "2023": 0
+      },
+      "non_primary_residence_wealth_tax": {
+        "2023": 0
+      },
+      "non_residential_property_purchased": {
+        "2023": 0
+      },
+      "non_residential_property_value": {
+        "2023": 0
+      },
+      "non_residential_rent": {
+        "2023": 0
+      },
+      "num_bedrooms": {
+        "2023": 0
+      },
+      "ons_tenure_type": {
+        "2023": "RENT_PRIVATELY"
+      },
+      "original_weight": {
+        "2023": 0
+      },
+      "other_residential_property_value": {
+        "2023": 0
+      },
+      "owned_land": {
+        "2023": 0
+      },
+      "petrol_litres": {
+        "2023": 0
+      },
+      "petrol_price": {
+        "2023": 1.6703
+      },
+      "petrol_spending": {
+        "2023": 0
+      },
+      "poverty_gap": {
+        "2023": 0
+      },
+      "poverty_gap_ahc": {
+        "2023": 0
+      },
+      "poverty_gap_bhc": {
+        "2023": 0
+      },
+      "poverty_line": {
+        "2023": 32082.24
+      },
+      "poverty_line_ahc": {
+        "2023": 27488.123
+      },
+      "poverty_line_bhc": {
+        "2023": 32082.238
+      },
+      "poverty_threshold_bhc": {
+        "2023": 17823.467
+      },
+      "property_purchased": {
+        "2023": true
+      },
+      "property_wealth": {
+        "2023": 0
+      },
+      "real_household_net_income": {
+        "2023": 32706.912
+      },
+      "recreation_consumption": {
+        "2023": 0
+      },
+      "reduced_rate_vat_consumption": {
+        "2023": 0
+      },
+      "region": {
+        "2023": "LONDON"
+      },
+      "rent": {
+        "2023": 0
+      },
+      "residential_property_value": {
+        "2023": 0
+      },
+      "restaurants_and_hotels_consumption": {
+        "2023": 0
+      },
+      "savings": {
+        "2023": 0
+      },
+      "sdlt_liable": {
+        "2023": true
+      },
+      "sdlt_on_non_residential_property_rent": {
+        "2023": 0
+      },
+      "sdlt_on_non_residential_property_transactions": {
+        "2023": 0
+      },
+      "sdlt_on_rent": {
+        "2023": 0
+      },
+      "sdlt_on_residential_property_rent": {
+        "2023": 0
+      },
+      "sdlt_on_residential_property_transactions": {
+        "2023": 0
+      },
+      "sdlt_on_transactions": {
+        "2023": 0
+      },
+      "shareholding": {
+        "2023": 0
+      },
+      "spi_imputed": {
+        "2023": 0
+      },
+      "stamp_duty_land_tax": {
+        "2023": 0
+      },
+      "tenure_type": {
+        "2023": "RENT_PRIVATELY"
+      },
+      "total_wealth": {
+        "2023": 0
+      },
+      "transport_consumption": {
+        "2023": 0
+      },
+      "tv_licence": {
+        "2023": 159
+      },
+      "tv_licence_discount": {
+        "2023": 0
+      },
+      "uc_migrated": {
+        "2023": 0
+      },
+      "vat": {
+        "2023": 0
+      },
+      "vat_change": {
+        "2023": 0
+      },
+      "water_and_sewerage_charges": {
+        "2023": 0
+      },
+      "wealth_tax": {
+        "2023": 0
+      },
+      "winter_fuel_allowance": {
+        "2023": 0
+      },
+      "would_evade_tv_licence_fee": {
+        "2023": false
+      }
+    }
+  },
+  "people": {
+    "you": {
+      "AA_reported": {
+        "2023": 0
+      },
+      "AFCS": {
+        "2023": 0
+      },
+      "AFCS_reported": {
+        "2023": 0
+      },
+      "BSP": {
+        "2023": 0
+      },
+      "BSP_reported": {
+        "2023": 0
+      },
+      "CB_HITC": {
+        "2023": 0
+      },
+      "DLA_M_reported": {
+        "2023": 0
+      },
+      "DLA_SC_reported": {
+        "2023": 0
+      },
+      "ESA_contrib": {
+        "2023": 0
+      },
+      "ESA_contrib_reported": {
+        "2023": 0
+      },
+      "ESA_income_reported": {
+        "2023": 0
+      },
+      "HB_individual_non_dep_deduction": {
+        "2023": 1272.6
+      },
+      "IIDB": {
+        "2023": 0
+      },
+      "IIDB_reported": {
+        "2023": 0
+      },
+      "ISA_interest_income": {
+        "2023": 0
+      },
+      "JSA_contrib": {
+        "2023": 0
+      },
+      "JSA_contrib_reported": {
+        "2023": 0
+      },
+      "JSA_income_reported": {
+        "2023": 0
+      },
+      "NI_class_2": {
+        "2023": 0
+      },
+      "NI_class_4": {
+        "2023": 0
+      },
+      "NI_exempt": {
+        "2023": false
+      },
+      "PIP_DL_reported": {
+        "2023": 0
+      },
+      "PIP_M_reported": {
+        "2023": 0
+      },
+      "SDA_reported": {
+        "2023": 0
+      },
+      "SMP": {
+        "2023": 0
+      },
+      "SSP": {
+        "2023": 0
+      },
+      "UC_MIF_applies": {
+        "2023": false
+      },
+      "UC_MIF_capped_earned_income": {
+        "2023": 40000
+      },
+      "UC_individual_child_element": {
+        "2023": 0
+      },
+      "UC_individual_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_individual_non_dep_deduction": {
+        "2023": 934.44
+      },
+      "UC_individual_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_minimum_income_floor": {
+        "2023": 17290
+      },
+      "UC_non_dep_deduction_exempt": {
+        "2023": false
+      },
+      "aa_category": {
+        "2023": "NONE"
+      },
+      "access_fund": {
+        "2023": 0
+      },
+      "add_rate_earned_income": {
+        "2023": 0
+      },
+      "add_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "add_rate_savings_income": {
+        "2023": 0
+      },
+      "adjusted_net_income": {
+        "2023": 40000
+      },
+      "adult_ema": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 1
+      },
+      "age": {
+        "2023": 40
+      },
+      "age_18_64": {
+        "2023": true
+      },
+      "age_over_64": {
+        "2023": false
+      },
+      "age_under_18": {
+        "2023": false
+      },
+      "allowances": {
+        "2023": 12570
+      },
+      "armed_forces_independence_payment": {
+        "2023": 0
+      },
+      "attendance_allowance": {
+        "2023": 0
+      },
+      "base_net_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income": {
+        "2023": 26170
+      },
+      "basic_rate_earned_income_tax": {
+        "2023": 5234
+      },
+      "basic_rate_savings_income": {
+        "2023": 0
+      },
+      "basic_rate_savings_income_pre_starter": {
+        "2023": 0
+      },
+      "benefits": {
+        "2023": 0
+      },
+      "benefits_modelling": {
+        "2023": 0
+      },
+      "benefits_reported": {
+        "2023": 0
+      },
+      "bi_household_phaseout": {
+        "2023": 0
+      },
+      "bi_individual_phaseout": {
+        "2023": 0
+      },
+      "bi_maximum": {
+        "2023": 0
+      },
+      "bi_phaseout": {
+        "2023": 0
+      },
+      "birth_year": {
+        "2023": 1983
+      },
+      "blind_persons_allowance": {
+        "2023": 0
+      },
+      "capital_allowances": {
+        "2023": 0
+      },
+      "capital_income": {
+        "2023": 0
+      },
+      "capped_mcad": {
+        "2023": 0
+      },
+      "care_hours": {
+        "2023": 0
+      },
+      "carers_allowance": {
+        "2023": 0
+      },
+      "carers_allowance_reported": {
+        "2023": 0
+      },
+      "charitable_investment_gifts": {
+        "2023": 0
+      },
+      "child_benefit_reported": {
+        "2023": 0
+      },
+      "child_benefit_respective_amount": {
+        "2023": 0
+      },
+      "child_ema": {
+        "2023": 0
+      },
+      "child_index": {
+        "2023": -1
+      },
+      "child_tax_credit_reported": {
+        "2023": 0
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "council_tax_benefit_reported": {
+        "2023": 0
+      },
+      "covenanted_payments": {
+        "2023": 0
+      },
+      "current_education": {
+        "2023": "NOT_IN_EDUCATION"
+      },
+      "deficiency_relief": {
+        "2023": 0
+      },
+      "dividend_allowance": {
+        "2023": 2000
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "dividend_income_tax": {
+        "2023": 0
+      },
+      "dla": {
+        "2023": 0
+      },
+      "dla_m": {
+        "2023": 0
+      },
+      "dla_m_category": {
+        "2023": "NONE"
+      },
+      "dla_sc": {
+        "2023": 0
+      },
+      "dla_sc_category": {
+        "2023": "NONE"
+      },
+      "dla_sc_middle_plus": {
+        "2023": false
+      },
+      "earned_income": {
+        "2023": 40000
+      },
+      "earned_income_tax": {
+        "2023": 5234
+      },
+      "earned_taxable_income": {
+        "2023": 26170
+      },
+      "education_grants": {
+        "2023": 0
+      },
+      "employee_NI": {
+        "2023": 3291.6038
+      },
+      "employee_NI_class_1": {
+        "2023": 3291.6038
+      },
+      "employer_NI": {
+        "2023": 4264.1997
+      },
+      "employer_NI_class_1": {
+        "2023": 4264.1997
+      },
+      "employer_pension_contributions": {
+        "2023": 0
+      },
+      "employment_benefits": {
+        "2023": 0
+      },
+      "employment_deductions": {
+        "2023": 0
+      },
+      "employment_expenses": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 40000
+      },
+      "employment_status": {
+        "2023": "UNEMPLOYED"
+      },
+      "family_benefits": {
+        "2023": 0
+      },
+      "family_benefits_reported": {
+        "2023": 0
+      },
+      "gender": {
+        "2023": "MALE"
+      },
+      "gift_aid": {
+        "2023": 0
+      },
+      "gross_income": {
+        "2023": 40000
+      },
+      "higher_rate_earned_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "higher_rate_savings_income": {
+        "2023": 0
+      },
+      "highest_education": {
+        "2023": "UPPER_SECONDARY"
+      },
+      "hours_worked": {
+        "2023": 0
+      },
+      "housing_benefit_reported": {
+        "2023": 0
+      },
+      "in_FE": {
+        "2023": false
+      },
+      "in_HE": {
+        "2023": false
+      },
+      "in_social_housing": {
+        "2023": false
+      },
+      "in_work": {
+        "2023": true
+      },
+      "incapacity_benefit": {
+        "2023": 0
+      },
+      "incapacity_benefit_reported": {
+        "2023": 0
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "income_support_reported": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": 5234
+      },
+      "income_tax_pre_charges": {
+        "2023": 5234
+      },
+      "is_CTC_child_limit_exempt": {
+        "2023": true
+      },
+      "is_QYP": {
+        "2023": false
+      },
+      "is_SP_age": {
+        "2023": false
+      },
+      "is_WA_adult": {
+        "2023": true
+      },
+      "is_adult": {
+        "2023": true
+      },
+      "is_apprentice": {
+        "2023": false
+      },
+      "is_benunit_eldest_child": {
+        "2023": false
+      },
+      "is_benunit_head": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_carer_for_benefits": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": false
+      },
+      "is_child_born_before_child_limit": {
+        "2023": false
+      },
+      "is_child_for_CTC": {
+        "2023": false
+      },
+      "is_child_or_QYP": {
+        "2023": false
+      },
+      "is_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_eldest_child": {
+        "2023": false
+      },
+      "is_enhanced_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_higher_earner": {
+        "2023": true
+      },
+      "is_household_head": {
+        "2023": false
+      },
+      "is_in_startup_period": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_older_child": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_severely_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_young_child": {
+        "2023": false
+      },
+      "limited_capability_for_WRA": {
+        "2023": false
+      },
+      "loss_relief": {
+        "2023": 0
+      },
+      "lump_sum_income": {
+        "2023": 0
+      },
+      "maintenance_expenses": {
+        "2023": 0
+      },
+      "maintenance_income": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0.69400394
+      },
+      "marital_status": {
+        "2023": "MARRIED"
+      },
+      "market_income": {
+        "2023": 40000
+      },
+      "marriage_allowance": {
+        "2023": 1260
+      },
+      "married_couples_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance_deduction": {
+        "2023": 0
+      },
+      "maternity_allowance": {
+        "2023": 0
+      },
+      "maternity_allowance_reported": {
+        "2023": 0
+      },
+      "meets_marriage_allowance_income_conditions": {
+        "2023": true
+      },
+      "minimum_wage": {
+        "2023": 9.5
+      },
+      "minimum_wage_category": {
+        "2023": "OVER_24"
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "national_insurance": {
+        "2023": 3291.6038
+      },
+      "net_income": {
+        "2023": 31474.396
+      },
+      "occupational_pension_contributions": {
+        "2023": 0
+      },
+      "other_benefits": {
+        "2023": 0
+      },
+      "other_deductions": {
+        "2023": 0
+      },
+      "over_16": {
+        "2023": true
+      },
+      "partners_unused_personal_allowance": {
+        "2023": 12570
+      },
+      "pays_scottish_income_tax": {
+        "2023": 0
+      },
+      "pension_annual_allowance": {
+        "2023": 40000
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_contributions_relief": {
+        "2023": 0
+      },
+      "pension_credit_reported": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "person_benunit_id": {
+        "2023": 0
+      },
+      "person_benunit_role": {
+        "2023": ""
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_household_role": {
+        "2023": ""
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_state_id": {
+        "2023": 0
+      },
+      "person_state_role": {
+        "2023": ""
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "personal_allowance": {
+        "2023": 12570
+      },
+      "personal_benefits": {
+        "2023": 0
+      },
+      "personal_benefits_reported": {
+        "2023": 0
+      },
+      "personal_rent": {
+        "2023": 0
+      },
+      "pip": {
+        "2023": 0
+      },
+      "pip_dl": {
+        "2023": 0
+      },
+      "pip_dl_category": {
+        "2023": "NONE"
+      },
+      "pip_m": {
+        "2023": 0
+      },
+      "pip_m_category": {
+        "2023": "NONE"
+      },
+      "private_pension_contributions": {
+        "2023": 0
+      },
+      "private_transfer_income": {
+        "2023": 0
+      },
+      "property_allowance": {
+        "2023": 1000
+      },
+      "property_allowance_deduction": {
+        "2023": 0
+      },
+      "property_income": {
+        "2023": 0
+      },
+      "raw_person_weight": {
+        "2023": 1
+      },
+      "receives_carers_allowance": {
+        "2023": false
+      },
+      "receives_enhanced_pip_dl": {
+        "2023": false
+      },
+      "receives_highest_dla_sc": {
+        "2023": false
+      },
+      "role": {
+        "2023": ""
+      },
+      "savings_allowance": {
+        "2023": 1000
+      },
+      "savings_income_tax": {
+        "2023": 0
+      },
+      "savings_interest_income": {
+        "2023": 0
+      },
+      "savings_starter_rate_income": {
+        "2023": 5000
+      },
+      "sda": {
+        "2023": 0
+      },
+      "self_employed_NI": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "social_security_income": {
+        "2023": 0
+      },
+      "ssmg": {
+        "2023": 0
+      },
+      "ssmg_reported": {
+        "2023": 0
+      },
+      "state_pension": {
+        "2023": 0
+      },
+      "state_pension_age": {
+        "2023": 66
+      },
+      "state_pension_reported": {
+        "2023": 0
+      },
+      "student_loans": {
+        "2023": 0
+      },
+      "student_payments": {
+        "2023": 0
+      },
+      "sublet_income": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": 8525.604
+      },
+      "tax_band": {
+        "2023": "BASIC"
+      },
+      "tax_free_savings_income": {
+        "2023": 0
+      },
+      "tax_modelling": {
+        "2023": 8525.604
+      },
+      "tax_reported": {
+        "2023": 0
+      },
+      "taxable_dividend_income": {
+        "2023": 0
+      },
+      "taxable_employment_income": {
+        "2023": 40000
+      },
+      "taxable_miscellaneous_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_property_income": {
+        "2023": 0
+      },
+      "taxable_savings_interest_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security_income": {
+        "2023": 0
+      },
+      "taxed_dividend_income": {
+        "2023": 0
+      },
+      "taxed_income": {
+        "2023": 26170
+      },
+      "taxed_savings_income": {
+        "2023": 0
+      },
+      "total_NI": {
+        "2023": 7555.8037
+      },
+      "total_income": {
+        "2023": 40000
+      },
+      "total_pension_income": {
+        "2023": 0
+      },
+      "trading_allowance": {
+        "2023": 1000
+      },
+      "trading_allowance_deduction": {
+        "2023": 0
+      },
+      "trading_loss": {
+        "2023": 0
+      },
+      "triple_lock_uprating": {
+        "2023": 1.0564573
+      },
+      "universal_credit_reported": {
+        "2023": 0
+      },
+      "unused_personal_allowance": {
+        "2023": 0
+      },
+      "weekly_NI_class_2": {
+        "2023": 0
+      },
+      "weekly_childcare_expenses": {
+        "2023": 0
+      },
+      "weekly_hours": {
+        "2023": 0
+      },
+      "winter_fuel_allowance_reported": {
+        "2023": 0
+      },
+      "working_tax_credit_reported": {
+        "2023": 0
+      }
+    },
+    "your first child": {
+      "AA_reported": {
+        "2023": 0
+      },
+      "AFCS": {
+        "2023": 0
+      },
+      "AFCS_reported": {
+        "2023": 0
+      },
+      "BSP": {
+        "2023": 0
+      },
+      "BSP_reported": {
+        "2023": 0
+      },
+      "CB_HITC": {
+        "2023": 0
+      },
+      "DLA_M_reported": {
+        "2023": 0
+      },
+      "DLA_SC_reported": {
+        "2023": 0
+      },
+      "ESA_contrib": {
+        "2023": 0
+      },
+      "ESA_contrib_reported": {
+        "2023": 0
+      },
+      "ESA_income_reported": {
+        "2023": 0
+      },
+      "HB_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "IIDB": {
+        "2023": 0
+      },
+      "IIDB_reported": {
+        "2023": 0
+      },
+      "ISA_interest_income": {
+        "2023": 0
+      },
+      "JSA_contrib": {
+        "2023": 0
+      },
+      "JSA_contrib_reported": {
+        "2023": 0
+      },
+      "JSA_income_reported": {
+        "2023": 0
+      },
+      "NI_class_2": {
+        "2023": 0
+      },
+      "NI_class_4": {
+        "2023": 0
+      },
+      "NI_exempt": {
+        "2023": true
+      },
+      "PIP_DL_reported": {
+        "2023": 0
+      },
+      "PIP_M_reported": {
+        "2023": 0
+      },
+      "SDA_reported": {
+        "2023": 0
+      },
+      "SMP": {
+        "2023": 0
+      },
+      "SSP": {
+        "2023": 0
+      },
+      "UC_MIF_applies": {
+        "2023": false
+      },
+      "UC_MIF_capped_earned_income": {
+        "2023": 0
+      },
+      "UC_individual_child_element": {
+        "2023": 3480
+      },
+      "UC_individual_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "UC_individual_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_minimum_income_floor": {
+        "2023": 8754.199
+      },
+      "UC_non_dep_deduction_exempt": {
+        "2023": false
+      },
+      "aa_category": {
+        "2023": "NONE"
+      },
+      "access_fund": {
+        "2023": 0
+      },
+      "add_rate_earned_income": {
+        "2023": 0
+      },
+      "add_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "add_rate_savings_income": {
+        "2023": 0
+      },
+      "adjusted_net_income": {
+        "2023": 0
+      },
+      "adult_ema": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_18_64": {
+        "2023": false
+      },
+      "age_over_64": {
+        "2023": false
+      },
+      "age_under_18": {
+        "2023": true
+      },
+      "allowances": {
+        "2023": 12570
+      },
+      "armed_forces_independence_payment": {
+        "2023": 0
+      },
+      "attendance_allowance": {
+        "2023": 0
+      },
+      "base_net_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "basic_rate_savings_income": {
+        "2023": 0
+      },
+      "basic_rate_savings_income_pre_starter": {
+        "2023": 0
+      },
+      "benefits": {
+        "2023": 8452.201
+      },
+      "benefits_modelling": {
+        "2023": 8452.201
+      },
+      "benefits_reported": {
+        "2023": 0
+      },
+      "bi_household_phaseout": {
+        "2023": 0
+      },
+      "bi_individual_phaseout": {
+        "2023": 0
+      },
+      "bi_maximum": {
+        "2023": 0
+      },
+      "bi_phaseout": {
+        "2023": 0
+      },
+      "birth_year": {
+        "2023": 2013
+      },
+      "blind_persons_allowance": {
+        "2023": 0
+      },
+      "capital_allowances": {
+        "2023": 0
+      },
+      "capital_income": {
+        "2023": 0
+      },
+      "capped_mcad": {
+        "2023": 0
+      },
+      "care_hours": {
+        "2023": 0
+      },
+      "carers_allowance": {
+        "2023": 0
+      },
+      "carers_allowance_reported": {
+        "2023": 0
+      },
+      "charitable_investment_gifts": {
+        "2023": 0
+      },
+      "child_benefit_reported": {
+        "2023": 0
+      },
+      "child_benefit_respective_amount": {
+        "2023": 1133.6
+      },
+      "child_ema": {
+        "2023": 0
+      },
+      "child_index": {
+        "2023": 1
+      },
+      "child_tax_credit_reported": {
+        "2023": 0
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "council_tax_benefit_reported": {
+        "2023": 0
+      },
+      "covenanted_payments": {
+        "2023": 0
+      },
+      "current_education": {
+        "2023": "PRIMARY"
+      },
+      "deficiency_relief": {
+        "2023": 0
+      },
+      "dividend_allowance": {
+        "2023": 2000
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "dividend_income_tax": {
+        "2023": 0
+      },
+      "dla": {
+        "2023": 0
+      },
+      "dla_m": {
+        "2023": 0
+      },
+      "dla_m_category": {
+        "2023": "NONE"
+      },
+      "dla_sc": {
+        "2023": 0
+      },
+      "dla_sc_category": {
+        "2023": "NONE"
+      },
+      "dla_sc_middle_plus": {
+        "2023": false
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "earned_income_tax": {
+        "2023": 0
+      },
+      "earned_taxable_income": {
+        "2023": 0
+      },
+      "education_grants": {
+        "2023": 0
+      },
+      "employee_NI": {
+        "2023": 0
+      },
+      "employee_NI_class_1": {
+        "2023": 0
+      },
+      "employer_NI": {
+        "2023": 0
+      },
+      "employer_NI_class_1": {
+        "2023": 0
+      },
+      "employer_pension_contributions": {
+        "2023": 0
+      },
+      "employment_benefits": {
+        "2023": 0
+      },
+      "employment_deductions": {
+        "2023": 0
+      },
+      "employment_expenses": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "employment_status": {
+        "2023": "UNEMPLOYED"
+      },
+      "family_benefits": {
+        "2023": 8452.201
+      },
+      "family_benefits_reported": {
+        "2023": 0
+      },
+      "gender": {
+        "2023": "MALE"
+      },
+      "gift_aid": {
+        "2023": 0
+      },
+      "gross_income": {
+        "2023": 8452.201
+      },
+      "higher_rate_earned_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "higher_rate_savings_income": {
+        "2023": 0
+      },
+      "highest_education": {
+        "2023": "UPPER_SECONDARY"
+      },
+      "hours_worked": {
+        "2023": 0
+      },
+      "housing_benefit_reported": {
+        "2023": 0
+      },
+      "in_FE": {
+        "2023": false
+      },
+      "in_HE": {
+        "2023": false
+      },
+      "in_social_housing": {
+        "2023": false
+      },
+      "in_work": {
+        "2023": false
+      },
+      "incapacity_benefit": {
+        "2023": 0
+      },
+      "incapacity_benefit_reported": {
+        "2023": 0
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "income_support_reported": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": 0
+      },
+      "income_tax_pre_charges": {
+        "2023": 0
+      },
+      "is_CTC_child_limit_exempt": {
+        "2023": true
+      },
+      "is_QYP": {
+        "2023": true
+      },
+      "is_SP_age": {
+        "2023": false
+      },
+      "is_WA_adult": {
+        "2023": false
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_apprentice": {
+        "2023": false
+      },
+      "is_benunit_eldest_child": {
+        "2023": true
+      },
+      "is_benunit_head": {
+        "2023": true
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_carer_for_benefits": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_born_before_child_limit": {
+        "2023": true
+      },
+      "is_child_for_CTC": {
+        "2023": true
+      },
+      "is_child_or_QYP": {
+        "2023": true
+      },
+      "is_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_eldest_child": {
+        "2023": true
+      },
+      "is_enhanced_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_higher_earner": {
+        "2023": false
+      },
+      "is_household_head": {
+        "2023": true
+      },
+      "is_in_startup_period": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_older_child": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_severely_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_young_child": {
+        "2023": true
+      },
+      "limited_capability_for_WRA": {
+        "2023": false
+      },
+      "loss_relief": {
+        "2023": 0
+      },
+      "lump_sum_income": {
+        "2023": 0
+      },
+      "maintenance_expenses": {
+        "2023": 0
+      },
+      "maintenance_income": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "marital_status": {
+        "2023": "MARRIED"
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "marriage_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance_deduction": {
+        "2023": 0
+      },
+      "maternity_allowance": {
+        "2023": 0
+      },
+      "maternity_allowance_reported": {
+        "2023": 0
+      },
+      "meets_marriage_allowance_income_conditions": {
+        "2023": false
+      },
+      "minimum_wage": {
+        "2023": 4.81
+      },
+      "minimum_wage_category": {
+        "2023": "UNDER_18"
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "national_insurance": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 8452.201
+      },
+      "occupational_pension_contributions": {
+        "2023": 0
+      },
+      "other_benefits": {
+        "2023": -8452.201
+      },
+      "other_deductions": {
+        "2023": 0
+      },
+      "over_16": {
+        "2023": false
+      },
+      "partners_unused_personal_allowance": {
+        "2023": 0
+      },
+      "pays_scottish_income_tax": {
+        "2023": 0
+      },
+      "pension_annual_allowance": {
+        "2023": 40000
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_contributions_relief": {
+        "2023": 0
+      },
+      "pension_credit_reported": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "person_benunit_id": {
+        "2023": 0
+      },
+      "person_benunit_role": {
+        "2023": ""
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_household_role": {
+        "2023": ""
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_state_id": {
+        "2023": 0
+      },
+      "person_state_role": {
+        "2023": ""
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "personal_allowance": {
+        "2023": 12570
+      },
+      "personal_benefits": {
+        "2023": 0
+      },
+      "personal_benefits_reported": {
+        "2023": 0
+      },
+      "personal_rent": {
+        "2023": 0
+      },
+      "pip": {
+        "2023": 0
+      },
+      "pip_dl": {
+        "2023": 0
+      },
+      "pip_dl_category": {
+        "2023": "NONE"
+      },
+      "pip_m": {
+        "2023": 0
+      },
+      "pip_m_category": {
+        "2023": "NONE"
+      },
+      "private_pension_contributions": {
+        "2023": 0
+      },
+      "private_transfer_income": {
+        "2023": 0
+      },
+      "property_allowance": {
+        "2023": 1000
+      },
+      "property_allowance_deduction": {
+        "2023": 0
+      },
+      "property_income": {
+        "2023": 0
+      },
+      "raw_person_weight": {
+        "2023": 1
+      },
+      "receives_carers_allowance": {
+        "2023": false
+      },
+      "receives_enhanced_pip_dl": {
+        "2023": false
+      },
+      "receives_highest_dla_sc": {
+        "2023": false
+      },
+      "role": {
+        "2023": ""
+      },
+      "savings_allowance": {
+        "2023": 1000
+      },
+      "savings_income_tax": {
+        "2023": 0
+      },
+      "savings_interest_income": {
+        "2023": 0
+      },
+      "savings_starter_rate_income": {
+        "2023": 5000
+      },
+      "sda": {
+        "2023": 0
+      },
+      "self_employed_NI": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "social_security_income": {
+        "2023": 0
+      },
+      "ssmg": {
+        "2023": 0
+      },
+      "ssmg_reported": {
+        "2023": 0
+      },
+      "state_pension": {
+        "2023": 0
+      },
+      "state_pension_age": {
+        "2023": 66
+      },
+      "state_pension_reported": {
+        "2023": 0
+      },
+      "student_loans": {
+        "2023": 0
+      },
+      "student_payments": {
+        "2023": 0
+      },
+      "sublet_income": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": 0
+      },
+      "tax_band": {
+        "2023": "NONE"
+      },
+      "tax_free_savings_income": {
+        "2023": 0
+      },
+      "tax_modelling": {
+        "2023": 0
+      },
+      "tax_reported": {
+        "2023": 0
+      },
+      "taxable_dividend_income": {
+        "2023": 0
+      },
+      "taxable_employment_income": {
+        "2023": 0
+      },
+      "taxable_miscellaneous_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_property_income": {
+        "2023": 0
+      },
+      "taxable_savings_interest_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security_income": {
+        "2023": 0
+      },
+      "taxed_dividend_income": {
+        "2023": 0
+      },
+      "taxed_income": {
+        "2023": 0
+      },
+      "taxed_savings_income": {
+        "2023": 0
+      },
+      "total_NI": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "total_pension_income": {
+        "2023": 0
+      },
+      "trading_allowance": {
+        "2023": 1000
+      },
+      "trading_allowance_deduction": {
+        "2023": 0
+      },
+      "trading_loss": {
+        "2023": 0
+      },
+      "triple_lock_uprating": {
+        "2023": 1.0564573
+      },
+      "universal_credit_reported": {
+        "2023": 0
+      },
+      "unused_personal_allowance": {
+        "2023": 12570
+      },
+      "weekly_NI_class_2": {
+        "2023": 0
+      },
+      "weekly_childcare_expenses": {
+        "2023": 0
+      },
+      "weekly_hours": {
+        "2023": 0
+      },
+      "winter_fuel_allowance_reported": {
+        "2023": 0
+      },
+      "working_tax_credit_reported": {
+        "2023": 0
+      }
+    },
+    "your fourth child": {
+      "AA_reported": {
+        "2023": 0
+      },
+      "AFCS": {
+        "2023": 0
+      },
+      "AFCS_reported": {
+        "2023": 0
+      },
+      "BSP": {
+        "2023": 0
+      },
+      "BSP_reported": {
+        "2023": 0
+      },
+      "CB_HITC": {
+        "2023": 0
+      },
+      "DLA_M_reported": {
+        "2023": 0
+      },
+      "DLA_SC_reported": {
+        "2023": 0
+      },
+      "ESA_contrib": {
+        "2023": 0
+      },
+      "ESA_contrib_reported": {
+        "2023": 0
+      },
+      "ESA_income_reported": {
+        "2023": 0
+      },
+      "HB_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "IIDB": {
+        "2023": 0
+      },
+      "IIDB_reported": {
+        "2023": 0
+      },
+      "ISA_interest_income": {
+        "2023": 0
+      },
+      "JSA_contrib": {
+        "2023": 0
+      },
+      "JSA_contrib_reported": {
+        "2023": 0
+      },
+      "JSA_income_reported": {
+        "2023": 0
+      },
+      "NI_class_2": {
+        "2023": 0
+      },
+      "NI_class_4": {
+        "2023": 0
+      },
+      "NI_exempt": {
+        "2023": true
+      },
+      "PIP_DL_reported": {
+        "2023": 0
+      },
+      "PIP_M_reported": {
+        "2023": 0
+      },
+      "SDA_reported": {
+        "2023": 0
+      },
+      "SMP": {
+        "2023": 0
+      },
+      "SSP": {
+        "2023": 0
+      },
+      "UC_MIF_applies": {
+        "2023": false
+      },
+      "UC_MIF_capped_earned_income": {
+        "2023": 0
+      },
+      "UC_individual_child_element": {
+        "2023": 2934.96
+      },
+      "UC_individual_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "UC_individual_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_minimum_income_floor": {
+        "2023": 8754.199
+      },
+      "UC_non_dep_deduction_exempt": {
+        "2023": false
+      },
+      "aa_category": {
+        "2023": "NONE"
+      },
+      "access_fund": {
+        "2023": 0
+      },
+      "add_rate_earned_income": {
+        "2023": 0
+      },
+      "add_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "add_rate_savings_income": {
+        "2023": 0
+      },
+      "adjusted_net_income": {
+        "2023": 0
+      },
+      "adult_ema": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_18_64": {
+        "2023": false
+      },
+      "age_over_64": {
+        "2023": false
+      },
+      "age_under_18": {
+        "2023": true
+      },
+      "allowances": {
+        "2023": 12570
+      },
+      "armed_forces_independence_payment": {
+        "2023": 0
+      },
+      "attendance_allowance": {
+        "2023": 0
+      },
+      "base_net_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "basic_rate_savings_income": {
+        "2023": 0
+      },
+      "basic_rate_savings_income_pre_starter": {
+        "2023": 0
+      },
+      "benefits": {
+        "2023": 0
+      },
+      "benefits_modelling": {
+        "2023": 0
+      },
+      "benefits_reported": {
+        "2023": 0
+      },
+      "bi_household_phaseout": {
+        "2023": 0
+      },
+      "bi_individual_phaseout": {
+        "2023": 0
+      },
+      "bi_maximum": {
+        "2023": 0
+      },
+      "bi_phaseout": {
+        "2023": 0
+      },
+      "birth_year": {
+        "2023": 2013
+      },
+      "blind_persons_allowance": {
+        "2023": 0
+      },
+      "capital_allowances": {
+        "2023": 0
+      },
+      "capital_income": {
+        "2023": 0
+      },
+      "capped_mcad": {
+        "2023": 0
+      },
+      "care_hours": {
+        "2023": 0
+      },
+      "carers_allowance": {
+        "2023": 0
+      },
+      "carers_allowance_reported": {
+        "2023": 0
+      },
+      "charitable_investment_gifts": {
+        "2023": 0
+      },
+      "child_benefit_reported": {
+        "2023": 0
+      },
+      "child_benefit_respective_amount": {
+        "2023": 751.4
+      },
+      "child_ema": {
+        "2023": 0
+      },
+      "child_index": {
+        "2023": 3
+      },
+      "child_tax_credit_reported": {
+        "2023": 0
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "council_tax_benefit_reported": {
+        "2023": 0
+      },
+      "covenanted_payments": {
+        "2023": 0
+      },
+      "current_education": {
+        "2023": "PRIMARY"
+      },
+      "deficiency_relief": {
+        "2023": 0
+      },
+      "dividend_allowance": {
+        "2023": 2000
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "dividend_income_tax": {
+        "2023": 0
+      },
+      "dla": {
+        "2023": 0
+      },
+      "dla_m": {
+        "2023": 0
+      },
+      "dla_m_category": {
+        "2023": "NONE"
+      },
+      "dla_sc": {
+        "2023": 0
+      },
+      "dla_sc_category": {
+        "2023": "NONE"
+      },
+      "dla_sc_middle_plus": {
+        "2023": false
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "earned_income_tax": {
+        "2023": 0
+      },
+      "earned_taxable_income": {
+        "2023": 0
+      },
+      "education_grants": {
+        "2023": 0
+      },
+      "employee_NI": {
+        "2023": 0
+      },
+      "employee_NI_class_1": {
+        "2023": 0
+      },
+      "employer_NI": {
+        "2023": 0
+      },
+      "employer_NI_class_1": {
+        "2023": 0
+      },
+      "employer_pension_contributions": {
+        "2023": 0
+      },
+      "employment_benefits": {
+        "2023": 0
+      },
+      "employment_deductions": {
+        "2023": 0
+      },
+      "employment_expenses": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "employment_status": {
+        "2023": "UNEMPLOYED"
+      },
+      "family_benefits": {
+        "2023": 0
+      },
+      "family_benefits_reported": {
+        "2023": 0
+      },
+      "gender": {
+        "2023": "MALE"
+      },
+      "gift_aid": {
+        "2023": 0
+      },
+      "gross_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "higher_rate_savings_income": {
+        "2023": 0
+      },
+      "highest_education": {
+        "2023": "UPPER_SECONDARY"
+      },
+      "hours_worked": {
+        "2023": 0
+      },
+      "housing_benefit_reported": {
+        "2023": 0
+      },
+      "in_FE": {
+        "2023": false
+      },
+      "in_HE": {
+        "2023": false
+      },
+      "in_social_housing": {
+        "2023": false
+      },
+      "in_work": {
+        "2023": false
+      },
+      "incapacity_benefit": {
+        "2023": 0
+      },
+      "incapacity_benefit_reported": {
+        "2023": 0
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "income_support_reported": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": 0
+      },
+      "income_tax_pre_charges": {
+        "2023": 0
+      },
+      "is_CTC_child_limit_exempt": {
+        "2023": true
+      },
+      "is_QYP": {
+        "2023": true
+      },
+      "is_SP_age": {
+        "2023": false
+      },
+      "is_WA_adult": {
+        "2023": false
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_apprentice": {
+        "2023": false
+      },
+      "is_benunit_eldest_child": {
+        "2023": true
+      },
+      "is_benunit_head": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_carer_for_benefits": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_born_before_child_limit": {
+        "2023": true
+      },
+      "is_child_for_CTC": {
+        "2023": true
+      },
+      "is_child_or_QYP": {
+        "2023": true
+      },
+      "is_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_eldest_child": {
+        "2023": false
+      },
+      "is_enhanced_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_higher_earner": {
+        "2023": false
+      },
+      "is_household_head": {
+        "2023": false
+      },
+      "is_in_startup_period": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_older_child": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_severely_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_young_child": {
+        "2023": true
+      },
+      "limited_capability_for_WRA": {
+        "2023": false
+      },
+      "loss_relief": {
+        "2023": 0
+      },
+      "lump_sum_income": {
+        "2023": 0
+      },
+      "maintenance_expenses": {
+        "2023": 0
+      },
+      "maintenance_income": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "marital_status": {
+        "2023": "MARRIED"
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "marriage_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance_deduction": {
+        "2023": 0
+      },
+      "maternity_allowance": {
+        "2023": 0
+      },
+      "maternity_allowance_reported": {
+        "2023": 0
+      },
+      "meets_marriage_allowance_income_conditions": {
+        "2023": false
+      },
+      "minimum_wage": {
+        "2023": 4.81
+      },
+      "minimum_wage_category": {
+        "2023": "UNDER_18"
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "national_insurance": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "occupational_pension_contributions": {
+        "2023": 0
+      },
+      "other_benefits": {
+        "2023": 0
+      },
+      "other_deductions": {
+        "2023": 0
+      },
+      "over_16": {
+        "2023": false
+      },
+      "partners_unused_personal_allowance": {
+        "2023": 0
+      },
+      "pays_scottish_income_tax": {
+        "2023": 0
+      },
+      "pension_annual_allowance": {
+        "2023": 40000
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_contributions_relief": {
+        "2023": 0
+      },
+      "pension_credit_reported": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "person_benunit_id": {
+        "2023": 0
+      },
+      "person_benunit_role": {
+        "2023": ""
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_household_role": {
+        "2023": ""
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_state_id": {
+        "2023": 0
+      },
+      "person_state_role": {
+        "2023": ""
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "personal_allowance": {
+        "2023": 12570
+      },
+      "personal_benefits": {
+        "2023": 0
+      },
+      "personal_benefits_reported": {
+        "2023": 0
+      },
+      "personal_rent": {
+        "2023": 0
+      },
+      "pip": {
+        "2023": 0
+      },
+      "pip_dl": {
+        "2023": 0
+      },
+      "pip_dl_category": {
+        "2023": "NONE"
+      },
+      "pip_m": {
+        "2023": 0
+      },
+      "pip_m_category": {
+        "2023": "NONE"
+      },
+      "private_pension_contributions": {
+        "2023": 0
+      },
+      "private_transfer_income": {
+        "2023": 0
+      },
+      "property_allowance": {
+        "2023": 1000
+      },
+      "property_allowance_deduction": {
+        "2023": 0
+      },
+      "property_income": {
+        "2023": 0
+      },
+      "raw_person_weight": {
+        "2023": 1
+      },
+      "receives_carers_allowance": {
+        "2023": false
+      },
+      "receives_enhanced_pip_dl": {
+        "2023": false
+      },
+      "receives_highest_dla_sc": {
+        "2023": false
+      },
+      "role": {
+        "2023": ""
+      },
+      "savings_allowance": {
+        "2023": 1000
+      },
+      "savings_income_tax": {
+        "2023": 0
+      },
+      "savings_interest_income": {
+        "2023": 0
+      },
+      "savings_starter_rate_income": {
+        "2023": 5000
+      },
+      "sda": {
+        "2023": 0
+      },
+      "self_employed_NI": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "social_security_income": {
+        "2023": 0
+      },
+      "ssmg": {
+        "2023": 0
+      },
+      "ssmg_reported": {
+        "2023": 0
+      },
+      "state_pension": {
+        "2023": 0
+      },
+      "state_pension_age": {
+        "2023": 66
+      },
+      "state_pension_reported": {
+        "2023": 0
+      },
+      "student_loans": {
+        "2023": 0
+      },
+      "student_payments": {
+        "2023": 0
+      },
+      "sublet_income": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": 0
+      },
+      "tax_band": {
+        "2023": "NONE"
+      },
+      "tax_free_savings_income": {
+        "2023": 0
+      },
+      "tax_modelling": {
+        "2023": 0
+      },
+      "tax_reported": {
+        "2023": 0
+      },
+      "taxable_dividend_income": {
+        "2023": 0
+      },
+      "taxable_employment_income": {
+        "2023": 0
+      },
+      "taxable_miscellaneous_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_property_income": {
+        "2023": 0
+      },
+      "taxable_savings_interest_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security_income": {
+        "2023": 0
+      },
+      "taxed_dividend_income": {
+        "2023": 0
+      },
+      "taxed_income": {
+        "2023": 0
+      },
+      "taxed_savings_income": {
+        "2023": 0
+      },
+      "total_NI": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "total_pension_income": {
+        "2023": 0
+      },
+      "trading_allowance": {
+        "2023": 1000
+      },
+      "trading_allowance_deduction": {
+        "2023": 0
+      },
+      "trading_loss": {
+        "2023": 0
+      },
+      "triple_lock_uprating": {
+        "2023": 1.0564573
+      },
+      "universal_credit_reported": {
+        "2023": 0
+      },
+      "unused_personal_allowance": {
+        "2023": 12570
+      },
+      "weekly_NI_class_2": {
+        "2023": 0
+      },
+      "weekly_childcare_expenses": {
+        "2023": 0
+      },
+      "weekly_hours": {
+        "2023": 0
+      },
+      "winter_fuel_allowance_reported": {
+        "2023": 0
+      },
+      "working_tax_credit_reported": {
+        "2023": 0
+      }
+    },
+    "your partner": {
+      "AA_reported": {
+        "2023": 0
+      },
+      "AFCS": {
+        "2023": 0
+      },
+      "AFCS_reported": {
+        "2023": 0
+      },
+      "BSP": {
+        "2023": 0
+      },
+      "BSP_reported": {
+        "2023": 0
+      },
+      "CB_HITC": {
+        "2023": 0
+      },
+      "DLA_M_reported": {
+        "2023": 0
+      },
+      "DLA_SC_reported": {
+        "2023": 0
+      },
+      "ESA_contrib": {
+        "2023": 0
+      },
+      "ESA_contrib_reported": {
+        "2023": 0
+      },
+      "ESA_income_reported": {
+        "2023": 0
+      },
+      "HB_individual_non_dep_deduction": {
+        "2023": 197.4
+      },
+      "IIDB": {
+        "2023": 0
+      },
+      "IIDB_reported": {
+        "2023": 0
+      },
+      "ISA_interest_income": {
+        "2023": 0
+      },
+      "JSA_contrib": {
+        "2023": 0
+      },
+      "JSA_contrib_reported": {
+        "2023": 0
+      },
+      "JSA_income_reported": {
+        "2023": 0
+      },
+      "NI_class_2": {
+        "2023": 0
+      },
+      "NI_class_4": {
+        "2023": 0
+      },
+      "NI_exempt": {
+        "2023": false
+      },
+      "PIP_DL_reported": {
+        "2023": 0
+      },
+      "PIP_M_reported": {
+        "2023": 0
+      },
+      "SDA_reported": {
+        "2023": 0
+      },
+      "SMP": {
+        "2023": 0
+      },
+      "SSP": {
+        "2023": 0
+      },
+      "UC_MIF_applies": {
+        "2023": false
+      },
+      "UC_MIF_capped_earned_income": {
+        "2023": 0
+      },
+      "UC_individual_child_element": {
+        "2023": 0
+      },
+      "UC_individual_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_individual_non_dep_deduction": {
+        "2023": 934.44
+      },
+      "UC_individual_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_minimum_income_floor": {
+        "2023": 17290
+      },
+      "UC_non_dep_deduction_exempt": {
+        "2023": false
+      },
+      "aa_category": {
+        "2023": "NONE"
+      },
+      "access_fund": {
+        "2023": 0
+      },
+      "add_rate_earned_income": {
+        "2023": 0
+      },
+      "add_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "add_rate_savings_income": {
+        "2023": 0
+      },
+      "adjusted_net_income": {
+        "2023": 0
+      },
+      "adult_ema": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 2
+      },
+      "age": {
+        "2023": 40
+      },
+      "age_18_64": {
+        "2023": true
+      },
+      "age_over_64": {
+        "2023": false
+      },
+      "age_under_18": {
+        "2023": false
+      },
+      "allowances": {
+        "2023": 12570
+      },
+      "armed_forces_independence_payment": {
+        "2023": 0
+      },
+      "attendance_allowance": {
+        "2023": 0
+      },
+      "base_net_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "basic_rate_savings_income": {
+        "2023": 0
+      },
+      "basic_rate_savings_income_pre_starter": {
+        "2023": 0
+      },
+      "benefits": {
+        "2023": 0
+      },
+      "benefits_modelling": {
+        "2023": 0
+      },
+      "benefits_reported": {
+        "2023": 0
+      },
+      "bi_household_phaseout": {
+        "2023": 0
+      },
+      "bi_individual_phaseout": {
+        "2023": 0
+      },
+      "bi_maximum": {
+        "2023": 0
+      },
+      "bi_phaseout": {
+        "2023": 0
+      },
+      "birth_year": {
+        "2023": 1983
+      },
+      "blind_persons_allowance": {
+        "2023": 0
+      },
+      "capital_allowances": {
+        "2023": 0
+      },
+      "capital_income": {
+        "2023": 0
+      },
+      "capped_mcad": {
+        "2023": 0
+      },
+      "care_hours": {
+        "2023": 0
+      },
+      "carers_allowance": {
+        "2023": 0
+      },
+      "carers_allowance_reported": {
+        "2023": 0
+      },
+      "charitable_investment_gifts": {
+        "2023": 0
+      },
+      "child_benefit_reported": {
+        "2023": 0
+      },
+      "child_benefit_respective_amount": {
+        "2023": 0
+      },
+      "child_ema": {
+        "2023": 0
+      },
+      "child_index": {
+        "2023": -1
+      },
+      "child_tax_credit_reported": {
+        "2023": 0
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "council_tax_benefit_reported": {
+        "2023": 0
+      },
+      "covenanted_payments": {
+        "2023": 0
+      },
+      "current_education": {
+        "2023": "NOT_IN_EDUCATION"
+      },
+      "deficiency_relief": {
+        "2023": 0
+      },
+      "dividend_allowance": {
+        "2023": 2000
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "dividend_income_tax": {
+        "2023": 0
+      },
+      "dla": {
+        "2023": 0
+      },
+      "dla_m": {
+        "2023": 0
+      },
+      "dla_m_category": {
+        "2023": "NONE"
+      },
+      "dla_sc": {
+        "2023": 0
+      },
+      "dla_sc_category": {
+        "2023": "NONE"
+      },
+      "dla_sc_middle_plus": {
+        "2023": false
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "earned_income_tax": {
+        "2023": 0
+      },
+      "earned_taxable_income": {
+        "2023": 0
+      },
+      "education_grants": {
+        "2023": 0
+      },
+      "employee_NI": {
+        "2023": 0
+      },
+      "employee_NI_class_1": {
+        "2023": 0
+      },
+      "employer_NI": {
+        "2023": 0
+      },
+      "employer_NI_class_1": {
+        "2023": 0
+      },
+      "employer_pension_contributions": {
+        "2023": 0
+      },
+      "employment_benefits": {
+        "2023": 0
+      },
+      "employment_deductions": {
+        "2023": 0
+      },
+      "employment_expenses": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "employment_status": {
+        "2023": "UNEMPLOYED"
+      },
+      "family_benefits": {
+        "2023": 0
+      },
+      "family_benefits_reported": {
+        "2023": 0
+      },
+      "gender": {
+        "2023": "MALE"
+      },
+      "gift_aid": {
+        "2023": 0
+      },
+      "gross_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "higher_rate_savings_income": {
+        "2023": 0
+      },
+      "highest_education": {
+        "2023": "UPPER_SECONDARY"
+      },
+      "hours_worked": {
+        "2023": 0
+      },
+      "housing_benefit_reported": {
+        "2023": 0
+      },
+      "in_FE": {
+        "2023": false
+      },
+      "in_HE": {
+        "2023": false
+      },
+      "in_social_housing": {
+        "2023": false
+      },
+      "in_work": {
+        "2023": false
+      },
+      "incapacity_benefit": {
+        "2023": 0
+      },
+      "incapacity_benefit_reported": {
+        "2023": 0
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "income_support_reported": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": 0
+      },
+      "income_tax_pre_charges": {
+        "2023": 0
+      },
+      "is_CTC_child_limit_exempt": {
+        "2023": true
+      },
+      "is_QYP": {
+        "2023": false
+      },
+      "is_SP_age": {
+        "2023": false
+      },
+      "is_WA_adult": {
+        "2023": true
+      },
+      "is_adult": {
+        "2023": true
+      },
+      "is_apprentice": {
+        "2023": false
+      },
+      "is_benunit_eldest_child": {
+        "2023": false
+      },
+      "is_benunit_head": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_carer_for_benefits": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": false
+      },
+      "is_child_born_before_child_limit": {
+        "2023": false
+      },
+      "is_child_for_CTC": {
+        "2023": false
+      },
+      "is_child_or_QYP": {
+        "2023": false
+      },
+      "is_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_eldest_child": {
+        "2023": false
+      },
+      "is_enhanced_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_higher_earner": {
+        "2023": false
+      },
+      "is_household_head": {
+        "2023": false
+      },
+      "is_in_startup_period": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_older_child": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_severely_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_young_child": {
+        "2023": false
+      },
+      "limited_capability_for_WRA": {
+        "2023": false
+      },
+      "loss_relief": {
+        "2023": 0
+      },
+      "lump_sum_income": {
+        "2023": 0
+      },
+      "maintenance_expenses": {
+        "2023": 0
+      },
+      "maintenance_income": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0.55
+      },
+      "marital_status": {
+        "2023": "MARRIED"
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "marriage_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance_deduction": {
+        "2023": 0
+      },
+      "maternity_allowance": {
+        "2023": 0
+      },
+      "maternity_allowance_reported": {
+        "2023": 0
+      },
+      "meets_marriage_allowance_income_conditions": {
+        "2023": false
+      },
+      "minimum_wage": {
+        "2023": 9.5
+      },
+      "minimum_wage_category": {
+        "2023": "OVER_24"
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "national_insurance": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "occupational_pension_contributions": {
+        "2023": 0
+      },
+      "other_benefits": {
+        "2023": 0
+      },
+      "other_deductions": {
+        "2023": 0
+      },
+      "over_16": {
+        "2023": true
+      },
+      "partners_unused_personal_allowance": {
+        "2023": 0
+      },
+      "pays_scottish_income_tax": {
+        "2023": 0
+      },
+      "pension_annual_allowance": {
+        "2023": 40000
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_contributions_relief": {
+        "2023": 0
+      },
+      "pension_credit_reported": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "person_benunit_id": {
+        "2023": 0
+      },
+      "person_benunit_role": {
+        "2023": ""
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_household_role": {
+        "2023": ""
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_state_id": {
+        "2023": 0
+      },
+      "person_state_role": {
+        "2023": ""
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "personal_allowance": {
+        "2023": 12570
+      },
+      "personal_benefits": {
+        "2023": 0
+      },
+      "personal_benefits_reported": {
+        "2023": 0
+      },
+      "personal_rent": {
+        "2023": 0
+      },
+      "pip": {
+        "2023": 0
+      },
+      "pip_dl": {
+        "2023": 0
+      },
+      "pip_dl_category": {
+        "2023": "NONE"
+      },
+      "pip_m": {
+        "2023": 0
+      },
+      "pip_m_category": {
+        "2023": "NONE"
+      },
+      "private_pension_contributions": {
+        "2023": 0
+      },
+      "private_transfer_income": {
+        "2023": 0
+      },
+      "property_allowance": {
+        "2023": 1000
+      },
+      "property_allowance_deduction": {
+        "2023": 0
+      },
+      "property_income": {
+        "2023": 0
+      },
+      "raw_person_weight": {
+        "2023": 1
+      },
+      "receives_carers_allowance": {
+        "2023": false
+      },
+      "receives_enhanced_pip_dl": {
+        "2023": false
+      },
+      "receives_highest_dla_sc": {
+        "2023": false
+      },
+      "role": {
+        "2023": ""
+      },
+      "savings_allowance": {
+        "2023": 1000
+      },
+      "savings_income_tax": {
+        "2023": 0
+      },
+      "savings_interest_income": {
+        "2023": 0
+      },
+      "savings_starter_rate_income": {
+        "2023": 5000
+      },
+      "sda": {
+        "2023": 0
+      },
+      "self_employed_NI": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "social_security_income": {
+        "2023": 0
+      },
+      "ssmg": {
+        "2023": 0
+      },
+      "ssmg_reported": {
+        "2023": 0
+      },
+      "state_pension": {
+        "2023": 0
+      },
+      "state_pension_age": {
+        "2023": 66
+      },
+      "state_pension_reported": {
+        "2023": 0
+      },
+      "student_loans": {
+        "2023": 0
+      },
+      "student_payments": {
+        "2023": 0
+      },
+      "sublet_income": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": 0
+      },
+      "tax_band": {
+        "2023": "NONE"
+      },
+      "tax_free_savings_income": {
+        "2023": 0
+      },
+      "tax_modelling": {
+        "2023": 0
+      },
+      "tax_reported": {
+        "2023": 0
+      },
+      "taxable_dividend_income": {
+        "2023": 0
+      },
+      "taxable_employment_income": {
+        "2023": 0
+      },
+      "taxable_miscellaneous_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_property_income": {
+        "2023": 0
+      },
+      "taxable_savings_interest_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security_income": {
+        "2023": 0
+      },
+      "taxed_dividend_income": {
+        "2023": 0
+      },
+      "taxed_income": {
+        "2023": 0
+      },
+      "taxed_savings_income": {
+        "2023": 0
+      },
+      "total_NI": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "total_pension_income": {
+        "2023": 0
+      },
+      "trading_allowance": {
+        "2023": 1000
+      },
+      "trading_allowance_deduction": {
+        "2023": 0
+      },
+      "trading_loss": {
+        "2023": 0
+      },
+      "triple_lock_uprating": {
+        "2023": 1.0564573
+      },
+      "universal_credit_reported": {
+        "2023": 0
+      },
+      "unused_personal_allowance": {
+        "2023": 12570
+      },
+      "weekly_NI_class_2": {
+        "2023": 0
+      },
+      "weekly_childcare_expenses": {
+        "2023": 0
+      },
+      "weekly_hours": {
+        "2023": 0
+      },
+      "winter_fuel_allowance_reported": {
+        "2023": 0
+      },
+      "working_tax_credit_reported": {
+        "2023": 0
+      }
+    },
+    "your second child": {
+      "AA_reported": {
+        "2023": 0
+      },
+      "AFCS": {
+        "2023": 0
+      },
+      "AFCS_reported": {
+        "2023": 0
+      },
+      "BSP": {
+        "2023": 0
+      },
+      "BSP_reported": {
+        "2023": 0
+      },
+      "CB_HITC": {
+        "2023": 0
+      },
+      "DLA_M_reported": {
+        "2023": 0
+      },
+      "DLA_SC_reported": {
+        "2023": 0
+      },
+      "ESA_contrib": {
+        "2023": 0
+      },
+      "ESA_contrib_reported": {
+        "2023": 0
+      },
+      "ESA_income_reported": {
+        "2023": 0
+      },
+      "HB_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "IIDB": {
+        "2023": 0
+      },
+      "IIDB_reported": {
+        "2023": 0
+      },
+      "ISA_interest_income": {
+        "2023": 0
+      },
+      "JSA_contrib": {
+        "2023": 0
+      },
+      "JSA_contrib_reported": {
+        "2023": 0
+      },
+      "JSA_income_reported": {
+        "2023": 0
+      },
+      "NI_class_2": {
+        "2023": 0
+      },
+      "NI_class_4": {
+        "2023": 0
+      },
+      "NI_exempt": {
+        "2023": true
+      },
+      "PIP_DL_reported": {
+        "2023": 0
+      },
+      "PIP_M_reported": {
+        "2023": 0
+      },
+      "SDA_reported": {
+        "2023": 0
+      },
+      "SMP": {
+        "2023": 0
+      },
+      "SSP": {
+        "2023": 0
+      },
+      "UC_MIF_applies": {
+        "2023": false
+      },
+      "UC_MIF_capped_earned_income": {
+        "2023": 0
+      },
+      "UC_individual_child_element": {
+        "2023": 2934.96
+      },
+      "UC_individual_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "UC_individual_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_minimum_income_floor": {
+        "2023": 8754.199
+      },
+      "UC_non_dep_deduction_exempt": {
+        "2023": false
+      },
+      "aa_category": {
+        "2023": "NONE"
+      },
+      "access_fund": {
+        "2023": 0
+      },
+      "add_rate_earned_income": {
+        "2023": 0
+      },
+      "add_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "add_rate_savings_income": {
+        "2023": 0
+      },
+      "adjusted_net_income": {
+        "2023": 0
+      },
+      "adult_ema": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_18_64": {
+        "2023": false
+      },
+      "age_over_64": {
+        "2023": false
+      },
+      "age_under_18": {
+        "2023": true
+      },
+      "allowances": {
+        "2023": 12570
+      },
+      "armed_forces_independence_payment": {
+        "2023": 0
+      },
+      "attendance_allowance": {
+        "2023": 0
+      },
+      "base_net_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "basic_rate_savings_income": {
+        "2023": 0
+      },
+      "basic_rate_savings_income_pre_starter": {
+        "2023": 0
+      },
+      "benefits": {
+        "2023": 0
+      },
+      "benefits_modelling": {
+        "2023": 0
+      },
+      "benefits_reported": {
+        "2023": 0
+      },
+      "bi_household_phaseout": {
+        "2023": 0
+      },
+      "bi_individual_phaseout": {
+        "2023": 0
+      },
+      "bi_maximum": {
+        "2023": 0
+      },
+      "bi_phaseout": {
+        "2023": 0
+      },
+      "birth_year": {
+        "2023": 2013
+      },
+      "blind_persons_allowance": {
+        "2023": 0
+      },
+      "capital_allowances": {
+        "2023": 0
+      },
+      "capital_income": {
+        "2023": 0
+      },
+      "capped_mcad": {
+        "2023": 0
+      },
+      "care_hours": {
+        "2023": 0
+      },
+      "carers_allowance": {
+        "2023": 0
+      },
+      "carers_allowance_reported": {
+        "2023": 0
+      },
+      "charitable_investment_gifts": {
+        "2023": 0
+      },
+      "child_benefit_reported": {
+        "2023": 0
+      },
+      "child_benefit_respective_amount": {
+        "2023": 751.4
+      },
+      "child_ema": {
+        "2023": 0
+      },
+      "child_index": {
+        "2023": 4
+      },
+      "child_tax_credit_reported": {
+        "2023": 0
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "council_tax_benefit_reported": {
+        "2023": 0
+      },
+      "covenanted_payments": {
+        "2023": 0
+      },
+      "current_education": {
+        "2023": "PRIMARY"
+      },
+      "deficiency_relief": {
+        "2023": 0
+      },
+      "dividend_allowance": {
+        "2023": 2000
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "dividend_income_tax": {
+        "2023": 0
+      },
+      "dla": {
+        "2023": 0
+      },
+      "dla_m": {
+        "2023": 0
+      },
+      "dla_m_category": {
+        "2023": "NONE"
+      },
+      "dla_sc": {
+        "2023": 0
+      },
+      "dla_sc_category": {
+        "2023": "NONE"
+      },
+      "dla_sc_middle_plus": {
+        "2023": false
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "earned_income_tax": {
+        "2023": 0
+      },
+      "earned_taxable_income": {
+        "2023": 0
+      },
+      "education_grants": {
+        "2023": 0
+      },
+      "employee_NI": {
+        "2023": 0
+      },
+      "employee_NI_class_1": {
+        "2023": 0
+      },
+      "employer_NI": {
+        "2023": 0
+      },
+      "employer_NI_class_1": {
+        "2023": 0
+      },
+      "employer_pension_contributions": {
+        "2023": 0
+      },
+      "employment_benefits": {
+        "2023": 0
+      },
+      "employment_deductions": {
+        "2023": 0
+      },
+      "employment_expenses": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "employment_status": {
+        "2023": "UNEMPLOYED"
+      },
+      "family_benefits": {
+        "2023": 0
+      },
+      "family_benefits_reported": {
+        "2023": 0
+      },
+      "gender": {
+        "2023": "MALE"
+      },
+      "gift_aid": {
+        "2023": 0
+      },
+      "gross_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "higher_rate_savings_income": {
+        "2023": 0
+      },
+      "highest_education": {
+        "2023": "UPPER_SECONDARY"
+      },
+      "hours_worked": {
+        "2023": 0
+      },
+      "housing_benefit_reported": {
+        "2023": 0
+      },
+      "in_FE": {
+        "2023": false
+      },
+      "in_HE": {
+        "2023": false
+      },
+      "in_social_housing": {
+        "2023": false
+      },
+      "in_work": {
+        "2023": false
+      },
+      "incapacity_benefit": {
+        "2023": 0
+      },
+      "incapacity_benefit_reported": {
+        "2023": 0
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "income_support_reported": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": 0
+      },
+      "income_tax_pre_charges": {
+        "2023": 0
+      },
+      "is_CTC_child_limit_exempt": {
+        "2023": true
+      },
+      "is_QYP": {
+        "2023": true
+      },
+      "is_SP_age": {
+        "2023": false
+      },
+      "is_WA_adult": {
+        "2023": false
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_apprentice": {
+        "2023": false
+      },
+      "is_benunit_eldest_child": {
+        "2023": true
+      },
+      "is_benunit_head": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_carer_for_benefits": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_born_before_child_limit": {
+        "2023": true
+      },
+      "is_child_for_CTC": {
+        "2023": true
+      },
+      "is_child_or_QYP": {
+        "2023": true
+      },
+      "is_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_eldest_child": {
+        "2023": false
+      },
+      "is_enhanced_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_higher_earner": {
+        "2023": false
+      },
+      "is_household_head": {
+        "2023": false
+      },
+      "is_in_startup_period": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_older_child": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_severely_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_young_child": {
+        "2023": true
+      },
+      "limited_capability_for_WRA": {
+        "2023": false
+      },
+      "loss_relief": {
+        "2023": 0
+      },
+      "lump_sum_income": {
+        "2023": 0
+      },
+      "maintenance_expenses": {
+        "2023": 0
+      },
+      "maintenance_income": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "marital_status": {
+        "2023": "MARRIED"
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "marriage_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance_deduction": {
+        "2023": 0
+      },
+      "maternity_allowance": {
+        "2023": 0
+      },
+      "maternity_allowance_reported": {
+        "2023": 0
+      },
+      "meets_marriage_allowance_income_conditions": {
+        "2023": false
+      },
+      "minimum_wage": {
+        "2023": 4.81
+      },
+      "minimum_wage_category": {
+        "2023": "UNDER_18"
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "national_insurance": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "occupational_pension_contributions": {
+        "2023": 0
+      },
+      "other_benefits": {
+        "2023": 0
+      },
+      "other_deductions": {
+        "2023": 0
+      },
+      "over_16": {
+        "2023": false
+      },
+      "partners_unused_personal_allowance": {
+        "2023": 0
+      },
+      "pays_scottish_income_tax": {
+        "2023": 0
+      },
+      "pension_annual_allowance": {
+        "2023": 40000
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_contributions_relief": {
+        "2023": 0
+      },
+      "pension_credit_reported": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "person_benunit_id": {
+        "2023": 0
+      },
+      "person_benunit_role": {
+        "2023": ""
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_household_role": {
+        "2023": ""
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_state_id": {
+        "2023": 0
+      },
+      "person_state_role": {
+        "2023": ""
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "personal_allowance": {
+        "2023": 12570
+      },
+      "personal_benefits": {
+        "2023": 0
+      },
+      "personal_benefits_reported": {
+        "2023": 0
+      },
+      "personal_rent": {
+        "2023": 0
+      },
+      "pip": {
+        "2023": 0
+      },
+      "pip_dl": {
+        "2023": 0
+      },
+      "pip_dl_category": {
+        "2023": "NONE"
+      },
+      "pip_m": {
+        "2023": 0
+      },
+      "pip_m_category": {
+        "2023": "NONE"
+      },
+      "private_pension_contributions": {
+        "2023": 0
+      },
+      "private_transfer_income": {
+        "2023": 0
+      },
+      "property_allowance": {
+        "2023": 1000
+      },
+      "property_allowance_deduction": {
+        "2023": 0
+      },
+      "property_income": {
+        "2023": 0
+      },
+      "raw_person_weight": {
+        "2023": 1
+      },
+      "receives_carers_allowance": {
+        "2023": false
+      },
+      "receives_enhanced_pip_dl": {
+        "2023": false
+      },
+      "receives_highest_dla_sc": {
+        "2023": false
+      },
+      "role": {
+        "2023": ""
+      },
+      "savings_allowance": {
+        "2023": 1000
+      },
+      "savings_income_tax": {
+        "2023": 0
+      },
+      "savings_interest_income": {
+        "2023": 0
+      },
+      "savings_starter_rate_income": {
+        "2023": 5000
+      },
+      "sda": {
+        "2023": 0
+      },
+      "self_employed_NI": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "social_security_income": {
+        "2023": 0
+      },
+      "ssmg": {
+        "2023": 0
+      },
+      "ssmg_reported": {
+        "2023": 0
+      },
+      "state_pension": {
+        "2023": 0
+      },
+      "state_pension_age": {
+        "2023": 66
+      },
+      "state_pension_reported": {
+        "2023": 0
+      },
+      "student_loans": {
+        "2023": 0
+      },
+      "student_payments": {
+        "2023": 0
+      },
+      "sublet_income": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": 0
+      },
+      "tax_band": {
+        "2023": "NONE"
+      },
+      "tax_free_savings_income": {
+        "2023": 0
+      },
+      "tax_modelling": {
+        "2023": 0
+      },
+      "tax_reported": {
+        "2023": 0
+      },
+      "taxable_dividend_income": {
+        "2023": 0
+      },
+      "taxable_employment_income": {
+        "2023": 0
+      },
+      "taxable_miscellaneous_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_property_income": {
+        "2023": 0
+      },
+      "taxable_savings_interest_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security_income": {
+        "2023": 0
+      },
+      "taxed_dividend_income": {
+        "2023": 0
+      },
+      "taxed_income": {
+        "2023": 0
+      },
+      "taxed_savings_income": {
+        "2023": 0
+      },
+      "total_NI": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "total_pension_income": {
+        "2023": 0
+      },
+      "trading_allowance": {
+        "2023": 1000
+      },
+      "trading_allowance_deduction": {
+        "2023": 0
+      },
+      "trading_loss": {
+        "2023": 0
+      },
+      "triple_lock_uprating": {
+        "2023": 1.0564573
+      },
+      "universal_credit_reported": {
+        "2023": 0
+      },
+      "unused_personal_allowance": {
+        "2023": 12570
+      },
+      "weekly_NI_class_2": {
+        "2023": 0
+      },
+      "weekly_childcare_expenses": {
+        "2023": 0
+      },
+      "weekly_hours": {
+        "2023": 0
+      },
+      "winter_fuel_allowance_reported": {
+        "2023": 0
+      },
+      "working_tax_credit_reported": {
+        "2023": 0
+      }
+    },
+    "your third child": {
+      "AA_reported": {
+        "2023": 0
+      },
+      "AFCS": {
+        "2023": 0
+      },
+      "AFCS_reported": {
+        "2023": 0
+      },
+      "BSP": {
+        "2023": 0
+      },
+      "BSP_reported": {
+        "2023": 0
+      },
+      "CB_HITC": {
+        "2023": 0
+      },
+      "DLA_M_reported": {
+        "2023": 0
+      },
+      "DLA_SC_reported": {
+        "2023": 0
+      },
+      "ESA_contrib": {
+        "2023": 0
+      },
+      "ESA_contrib_reported": {
+        "2023": 0
+      },
+      "ESA_income_reported": {
+        "2023": 0
+      },
+      "HB_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "IIDB": {
+        "2023": 0
+      },
+      "IIDB_reported": {
+        "2023": 0
+      },
+      "ISA_interest_income": {
+        "2023": 0
+      },
+      "JSA_contrib": {
+        "2023": 0
+      },
+      "JSA_contrib_reported": {
+        "2023": 0
+      },
+      "JSA_income_reported": {
+        "2023": 0
+      },
+      "NI_class_2": {
+        "2023": 0
+      },
+      "NI_class_4": {
+        "2023": 0
+      },
+      "NI_exempt": {
+        "2023": true
+      },
+      "PIP_DL_reported": {
+        "2023": 0
+      },
+      "PIP_M_reported": {
+        "2023": 0
+      },
+      "SDA_reported": {
+        "2023": 0
+      },
+      "SMP": {
+        "2023": 0
+      },
+      "SSP": {
+        "2023": 0
+      },
+      "UC_MIF_applies": {
+        "2023": false
+      },
+      "UC_MIF_capped_earned_income": {
+        "2023": 0
+      },
+      "UC_individual_child_element": {
+        "2023": 2934.96
+      },
+      "UC_individual_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_individual_non_dep_deduction": {
+        "2023": 0
+      },
+      "UC_individual_severely_disabled_child_element": {
+        "2023": 0
+      },
+      "UC_minimum_income_floor": {
+        "2023": 8754.199
+      },
+      "UC_non_dep_deduction_exempt": {
+        "2023": false
+      },
+      "aa_category": {
+        "2023": "NONE"
+      },
+      "access_fund": {
+        "2023": 0
+      },
+      "add_rate_earned_income": {
+        "2023": 0
+      },
+      "add_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "add_rate_savings_income": {
+        "2023": 0
+      },
+      "adjusted_net_income": {
+        "2023": 0
+      },
+      "adult_ema": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_18_64": {
+        "2023": false
+      },
+      "age_over_64": {
+        "2023": false
+      },
+      "age_under_18": {
+        "2023": true
+      },
+      "allowances": {
+        "2023": 12570
+      },
+      "armed_forces_independence_payment": {
+        "2023": 0
+      },
+      "attendance_allowance": {
+        "2023": 0
+      },
+      "base_net_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income": {
+        "2023": 0
+      },
+      "basic_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "basic_rate_savings_income": {
+        "2023": 0
+      },
+      "basic_rate_savings_income_pre_starter": {
+        "2023": 0
+      },
+      "benefits": {
+        "2023": 0
+      },
+      "benefits_modelling": {
+        "2023": 0
+      },
+      "benefits_reported": {
+        "2023": 0
+      },
+      "bi_household_phaseout": {
+        "2023": 0
+      },
+      "bi_individual_phaseout": {
+        "2023": 0
+      },
+      "bi_maximum": {
+        "2023": 0
+      },
+      "bi_phaseout": {
+        "2023": 0
+      },
+      "birth_year": {
+        "2023": 2013
+      },
+      "blind_persons_allowance": {
+        "2023": 0
+      },
+      "capital_allowances": {
+        "2023": 0
+      },
+      "capital_income": {
+        "2023": 0
+      },
+      "capped_mcad": {
+        "2023": 0
+      },
+      "care_hours": {
+        "2023": 0
+      },
+      "carers_allowance": {
+        "2023": 0
+      },
+      "carers_allowance_reported": {
+        "2023": 0
+      },
+      "charitable_investment_gifts": {
+        "2023": 0
+      },
+      "child_benefit_reported": {
+        "2023": 0
+      },
+      "child_benefit_respective_amount": {
+        "2023": 751.4
+      },
+      "child_ema": {
+        "2023": 0
+      },
+      "child_index": {
+        "2023": 2
+      },
+      "child_tax_credit_reported": {
+        "2023": 0
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "council_tax_benefit_reported": {
+        "2023": 0
+      },
+      "covenanted_payments": {
+        "2023": 0
+      },
+      "current_education": {
+        "2023": "PRIMARY"
+      },
+      "deficiency_relief": {
+        "2023": 0
+      },
+      "dividend_allowance": {
+        "2023": 2000
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "dividend_income_tax": {
+        "2023": 0
+      },
+      "dla": {
+        "2023": 0
+      },
+      "dla_m": {
+        "2023": 0
+      },
+      "dla_m_category": {
+        "2023": "NONE"
+      },
+      "dla_sc": {
+        "2023": 0
+      },
+      "dla_sc_category": {
+        "2023": "NONE"
+      },
+      "dla_sc_middle_plus": {
+        "2023": false
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "earned_income_tax": {
+        "2023": 0
+      },
+      "earned_taxable_income": {
+        "2023": 0
+      },
+      "education_grants": {
+        "2023": 0
+      },
+      "employee_NI": {
+        "2023": 0
+      },
+      "employee_NI_class_1": {
+        "2023": 0
+      },
+      "employer_NI": {
+        "2023": 0
+      },
+      "employer_NI_class_1": {
+        "2023": 0
+      },
+      "employer_pension_contributions": {
+        "2023": 0
+      },
+      "employment_benefits": {
+        "2023": 0
+      },
+      "employment_deductions": {
+        "2023": 0
+      },
+      "employment_expenses": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "employment_status": {
+        "2023": "UNEMPLOYED"
+      },
+      "family_benefits": {
+        "2023": 0
+      },
+      "family_benefits_reported": {
+        "2023": 0
+      },
+      "gender": {
+        "2023": "MALE"
+      },
+      "gift_aid": {
+        "2023": 0
+      },
+      "gross_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income": {
+        "2023": 0
+      },
+      "higher_rate_earned_income_tax": {
+        "2023": 0
+      },
+      "higher_rate_savings_income": {
+        "2023": 0
+      },
+      "highest_education": {
+        "2023": "UPPER_SECONDARY"
+      },
+      "hours_worked": {
+        "2023": 0
+      },
+      "housing_benefit_reported": {
+        "2023": 0
+      },
+      "in_FE": {
+        "2023": false
+      },
+      "in_HE": {
+        "2023": false
+      },
+      "in_social_housing": {
+        "2023": false
+      },
+      "in_work": {
+        "2023": false
+      },
+      "incapacity_benefit": {
+        "2023": 0
+      },
+      "incapacity_benefit_reported": {
+        "2023": 0
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "income_support_reported": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": 0
+      },
+      "income_tax_pre_charges": {
+        "2023": 0
+      },
+      "is_CTC_child_limit_exempt": {
+        "2023": true
+      },
+      "is_QYP": {
+        "2023": true
+      },
+      "is_SP_age": {
+        "2023": false
+      },
+      "is_WA_adult": {
+        "2023": false
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_apprentice": {
+        "2023": false
+      },
+      "is_benunit_eldest_child": {
+        "2023": true
+      },
+      "is_benunit_head": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_carer_for_benefits": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_born_before_child_limit": {
+        "2023": true
+      },
+      "is_child_for_CTC": {
+        "2023": true
+      },
+      "is_child_or_QYP": {
+        "2023": true
+      },
+      "is_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_eldest_child": {
+        "2023": false
+      },
+      "is_enhanced_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_higher_earner": {
+        "2023": false
+      },
+      "is_household_head": {
+        "2023": false
+      },
+      "is_in_startup_period": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_older_child": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_severely_disabled_for_benefits": {
+        "2023": false
+      },
+      "is_young_child": {
+        "2023": true
+      },
+      "limited_capability_for_WRA": {
+        "2023": false
+      },
+      "loss_relief": {
+        "2023": 0
+      },
+      "lump_sum_income": {
+        "2023": 0
+      },
+      "maintenance_expenses": {
+        "2023": 0
+      },
+      "maintenance_income": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "marital_status": {
+        "2023": "MARRIED"
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "marriage_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance": {
+        "2023": 0
+      },
+      "married_couples_allowance_deduction": {
+        "2023": 0
+      },
+      "maternity_allowance": {
+        "2023": 0
+      },
+      "maternity_allowance_reported": {
+        "2023": 0
+      },
+      "meets_marriage_allowance_income_conditions": {
+        "2023": false
+      },
+      "minimum_wage": {
+        "2023": 4.81
+      },
+      "minimum_wage_category": {
+        "2023": "UNDER_18"
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "national_insurance": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "occupational_pension_contributions": {
+        "2023": 0
+      },
+      "other_benefits": {
+        "2023": 0
+      },
+      "other_deductions": {
+        "2023": 0
+      },
+      "over_16": {
+        "2023": false
+      },
+      "partners_unused_personal_allowance": {
+        "2023": 0
+      },
+      "pays_scottish_income_tax": {
+        "2023": 0
+      },
+      "pension_annual_allowance": {
+        "2023": 40000
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_contributions_relief": {
+        "2023": 0
+      },
+      "pension_credit_reported": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "person_benunit_id": {
+        "2023": 0
+      },
+      "person_benunit_role": {
+        "2023": ""
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_household_role": {
+        "2023": ""
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_state_id": {
+        "2023": 0
+      },
+      "person_state_role": {
+        "2023": ""
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "personal_allowance": {
+        "2023": 12570
+      },
+      "personal_benefits": {
+        "2023": 0
+      },
+      "personal_benefits_reported": {
+        "2023": 0
+      },
+      "personal_rent": {
+        "2023": 0
+      },
+      "pip": {
+        "2023": 0
+      },
+      "pip_dl": {
+        "2023": 0
+      },
+      "pip_dl_category": {
+        "2023": "NONE"
+      },
+      "pip_m": {
+        "2023": 0
+      },
+      "pip_m_category": {
+        "2023": "NONE"
+      },
+      "private_pension_contributions": {
+        "2023": 0
+      },
+      "private_transfer_income": {
+        "2023": 0
+      },
+      "property_allowance": {
+        "2023": 1000
+      },
+      "property_allowance_deduction": {
+        "2023": 0
+      },
+      "property_income": {
+        "2023": 0
+      },
+      "raw_person_weight": {
+        "2023": 1
+      },
+      "receives_carers_allowance": {
+        "2023": false
+      },
+      "receives_enhanced_pip_dl": {
+        "2023": false
+      },
+      "receives_highest_dla_sc": {
+        "2023": false
+      },
+      "role": {
+        "2023": ""
+      },
+      "savings_allowance": {
+        "2023": 1000
+      },
+      "savings_income_tax": {
+        "2023": 0
+      },
+      "savings_interest_income": {
+        "2023": 0
+      },
+      "savings_starter_rate_income": {
+        "2023": 5000
+      },
+      "sda": {
+        "2023": 0
+      },
+      "self_employed_NI": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "social_security_income": {
+        "2023": 0
+      },
+      "ssmg": {
+        "2023": 0
+      },
+      "ssmg_reported": {
+        "2023": 0
+      },
+      "state_pension": {
+        "2023": 0
+      },
+      "state_pension_age": {
+        "2023": 66
+      },
+      "state_pension_reported": {
+        "2023": 0
+      },
+      "student_loans": {
+        "2023": 0
+      },
+      "student_payments": {
+        "2023": 0
+      },
+      "sublet_income": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": 0
+      },
+      "tax_band": {
+        "2023": "NONE"
+      },
+      "tax_free_savings_income": {
+        "2023": 0
+      },
+      "tax_modelling": {
+        "2023": 0
+      },
+      "tax_reported": {
+        "2023": 0
+      },
+      "taxable_dividend_income": {
+        "2023": 0
+      },
+      "taxable_employment_income": {
+        "2023": 0
+      },
+      "taxable_miscellaneous_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_property_income": {
+        "2023": 0
+      },
+      "taxable_savings_interest_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security_income": {
+        "2023": 0
+      },
+      "taxed_dividend_income": {
+        "2023": 0
+      },
+      "taxed_income": {
+        "2023": 0
+      },
+      "taxed_savings_income": {
+        "2023": 0
+      },
+      "total_NI": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "total_pension_income": {
+        "2023": 0
+      },
+      "trading_allowance": {
+        "2023": 1000
+      },
+      "trading_allowance_deduction": {
+        "2023": 0
+      },
+      "trading_loss": {
+        "2023": 0
+      },
+      "triple_lock_uprating": {
+        "2023": 1.0564573
+      },
+      "universal_credit_reported": {
+        "2023": 0
+      },
+      "unused_personal_allowance": {
+        "2023": 12570
+      },
+      "weekly_NI_class_2": {
+        "2023": 0
+      },
+      "weekly_childcare_expenses": {
+        "2023": 0
+      },
+      "weekly_hours": {
+        "2023": 0
+      },
+      "winter_fuel_allowance_reported": {
+        "2023": 0
+      },
+      "working_tax_credit_reported": {
+        "2023": 0
+      }
+    }
+  }
+}

--- a/tests/python/data/us_household.json
+++ b/tests/python/data/us_household.json
@@ -1,0 +1,155 @@
+{
+  "families": {
+    "your family": {
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ]
+    }
+  },
+  "households": {
+    "your household": {
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ],
+      "state_name": {
+        "2023": "AL"
+      }
+    }
+  },
+  "marital_units": {
+    "your first dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 1
+      },
+      "members": [
+        "your first dependent"
+      ]
+    },
+    "your fourth dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 4
+      },
+      "members": [
+        "your fourth dependent"
+      ]
+    },
+    "your marital unit": {
+      "members": [
+        "you",
+        "your partner"
+      ]
+    },
+    "your second dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 2
+      },
+      "members": [
+        "your second dependent"
+      ]
+    },
+    "your third dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 3
+      },
+      "members": [
+        "your third dependent"
+      ]
+    }
+  },
+  "people": {
+    "you": {
+      "age": {
+        "2023": 40
+      },
+      "employment_income": {
+        "2023": 40000
+      }
+    },
+    "your first dependent": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      }
+    },
+    "your fourth dependent": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      }
+    },
+    "your partner": {
+      "age": {
+        "2023": 40
+      },
+      "employment_income": {
+        "2023": 0
+      }
+    },
+    "your second dependent": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      }
+    },
+    "your third dependent": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      }
+    }
+  },
+  "spm_units": {
+    "your household": {
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ]
+    }
+  },
+  "tax_units": {
+    "your tax unit": {
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ]
+    }
+  }
+}

--- a/tests/python/data/us_household.json
+++ b/tests/python/data/us_household.json
@@ -27,26 +27,18 @@
     }
   },
   "marital_units": {
+    "your marital unit": {
+      "members": [
+        "you",
+        "your partner"
+      ]
+    },
     "your first dependent's marital unit": {
       "marital_unit_id": {
         "2023": 1
       },
       "members": [
         "your first dependent"
-      ]
-    },
-    "your fourth dependent's marital unit": {
-      "marital_unit_id": {
-        "2023": 4
-      },
-      "members": [
-        "your fourth dependent"
-      ]
-    },
-    "your marital unit": {
-      "members": [
-        "you",
-        "your partner"
       ]
     },
     "your second dependent's marital unit": {
@@ -64,6 +56,14 @@
       "members": [
         "your third dependent"
       ]
+    },
+    "your fourth dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 4
+      },
+      "members": [
+        "your fourth dependent"
+      ]
     }
   },
   "people": {
@@ -76,17 +76,6 @@
       }
     },
     "your first dependent": {
-      "age": {
-        "2023": 10
-      },
-      "employment_income": {
-        "2023": 0
-      },
-      "is_tax_unit_dependent": {
-        "2023": true
-      }
-    },
-    "your fourth dependent": {
       "age": {
         "2023": 10
       },
@@ -117,6 +106,17 @@
       }
     },
     "your third dependent": {
+      "age": {
+        "2023": 10
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      }
+    },
+    "your fourth dependent": {
       "age": {
         "2023": 10
       },

--- a/tests/python/data/us_household_under_policy_target.json
+++ b/tests/python/data/us_household_under_policy_target.json
@@ -332,7 +332,7 @@
   "marital_units": {
     "your first dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 1
+        "2023": 2
       },
       "marital_unit_weight": {
         "2023": 0
@@ -343,7 +343,7 @@
     },
     "your fourth dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 4
+        "2023": 5
       },
       "marital_unit_weight": {
         "2023": 0
@@ -366,7 +366,7 @@
     },
     "your second dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 2
+        "2023": 3
       },
       "marital_unit_weight": {
         "2023": 0
@@ -377,7 +377,7 @@
     },
     "your third dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 3
+        "2023": 4
       },
       "marital_unit_weight": {
         "2023": 0
@@ -487,6 +487,9 @@
       },
       "co_oap_eligible": {
         "2023": false
+      },
+      "co_pension_subtraction_income": {
+        "2023": 0
       },
       "co_pension_subtraction_indv": {
         "2023": 0
@@ -952,6 +955,12 @@
       },
       "k1bx14": {
         "2023": 0
+      },
+      "la_quality_rating_of_child_care_facility": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_eligible_child": {
+        "2023": false
       },
       "long_term_capital_gains": {
         "2023": 0
@@ -1528,6 +1537,9 @@
       "co_oap_eligible": {
         "2023": false
       },
+      "co_pension_subtraction_income": {
+        "2023": 0
+      },
       "co_pension_subtraction_indv": {
         "2023": 0
       },
@@ -1992,6 +2004,12 @@
       },
       "k1bx14": {
         "2023": 0
+      },
+      "la_quality_rating_of_child_care_facility": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_eligible_child": {
+        "2023": false
       },
       "long_term_capital_gains": {
         "2023": 0
@@ -2568,6 +2586,9 @@
       "co_oap_eligible": {
         "2023": false
       },
+      "co_pension_subtraction_income": {
+        "2023": 0
+      },
       "co_pension_subtraction_indv": {
         "2023": 0
       },
@@ -3032,6 +3053,12 @@
       },
       "k1bx14": {
         "2023": 0
+      },
+      "la_quality_rating_of_child_care_facility": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_eligible_child": {
+        "2023": false
       },
       "long_term_capital_gains": {
         "2023": 0
@@ -3608,6 +3635,9 @@
       "co_oap_eligible": {
         "2023": false
       },
+      "co_pension_subtraction_income": {
+        "2023": 0
+      },
       "co_pension_subtraction_indv": {
         "2023": 0
       },
@@ -4072,6 +4102,12 @@
       },
       "k1bx14": {
         "2023": 0
+      },
+      "la_quality_rating_of_child_care_facility": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_eligible_child": {
+        "2023": false
       },
       "long_term_capital_gains": {
         "2023": 0
@@ -4648,6 +4684,9 @@
       "co_oap_eligible": {
         "2023": false
       },
+      "co_pension_subtraction_income": {
+        "2023": 0
+      },
       "co_pension_subtraction_indv": {
         "2023": 0
       },
@@ -5112,6 +5151,12 @@
       },
       "k1bx14": {
         "2023": 0
+      },
+      "la_quality_rating_of_child_care_facility": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_eligible_child": {
+        "2023": false
       },
       "long_term_capital_gains": {
         "2023": 0
@@ -5688,6 +5733,9 @@
       "co_oap_eligible": {
         "2023": false
       },
+      "co_pension_subtraction_income": {
+        "2023": 0
+      },
       "co_pension_subtraction_indv": {
         "2023": 0
       },
@@ -6152,6 +6200,12 @@
       },
       "k1bx14": {
         "2023": 0
+      },
+      "la_quality_rating_of_child_care_facility": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_eligible_child": {
+        "2023": false
       },
       "long_term_capital_gains": {
         "2023": 0
@@ -7366,6 +7420,9 @@
       "az_agi": {
         "2023": 0
       },
+      "az_dependent_tax_credit": {
+        "2023": 0
+      },
       "az_family_tax_credit": {
         "2023": 0
       },
@@ -7435,9 +7492,6 @@
       "c04600": {
         "2023": 0
       },
-      "c05700": {
-        "2023": 0
-      },
       "c07100": {
         "2023": 2375
       },
@@ -7465,9 +7519,6 @@
       "c08000": {
         "2023": 0
       },
-      "c09600": {
-        "2023": 0
-      },
       "c10960": {
         "2023": 0
       },
@@ -7479,9 +7530,6 @@
       },
       "c59660": {
         "2023": 4930.1777
-      },
-      "c62100": {
-        "2023": 40000
       },
       "c87668": {
         "2023": 0
@@ -7553,6 +7601,9 @@
         "2023": 0
       },
       "capped_advanced_main_air_circulating_fan_credit": {
+        "2023": 0
+      },
+      "capped_cdcc": {
         "2023": 0
       },
       "capped_electric_heat_pump_clothes_dryer_rebate": {
@@ -7651,9 +7702,6 @@
       "co_federal_deduction_addback_required": {
         "2023": false
       },
-      "co_federal_taxable_income": {
-        "2023": 0
-      },
       "co_income_qualified_senior_housing_credit": {
         "2023": 0
       },
@@ -7705,6 +7753,9 @@
       "co_sales_tax_refund_eligible": {
         "2023": false
       },
+      "co_state_addback": {
+        "2023": 0
+      },
       "co_subtractions": {
         "2023": 0
       },
@@ -7727,6 +7778,9 @@
         "2023": 0
       },
       "ct_agi_subtractions": {
+        "2023": 0
+      },
+      "ct_eitc": {
         "2023": 0
       },
       "ct_income_tax": {
@@ -7910,6 +7964,9 @@
         "2023": 0
       },
       "de_income_tax_if_claiming_refundable_eitc": {
+        "2023": 0
+      },
+      "de_itemized_deductions": {
         "2023": 0
       },
       "de_non_refundable_credits": {
@@ -8143,6 +8200,9 @@
       "foreign_tax_credit": {
         "2023": 0
       },
+      "form_4972_lumpsum_distributions": {
+        "2023": 0
+      },
       "fstax": {
         "2023": 0
       },
@@ -8180,6 +8240,9 @@
         "2023": 0
       },
       "ga_refundable_credits": {
+        "2023": 0
+      },
+      "ga_standard_deduction": {
         "2023": 0
       },
       "ga_taxable_income": {
@@ -8646,6 +8709,18 @@
       },
       "la_refundable_credits": {
         "2023": 0
+      },
+      "la_school_readiness_credit": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_non_refundable": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_refundable": {
+        "2023": 0
+      },
+      "la_school_readiness_credit_refundable_eligible": {
+        "2023": false
       },
       "la_taxable_income": {
         "2023": 0
@@ -9153,6 +9228,9 @@
       "n24": {
         "2023": 0
       },
+      "nc_child_deduction": {
+        "2023": 0
+      },
       "nc_ctc": {
         "2023": 0
       },
@@ -9162,7 +9240,16 @@
       "nc_income_tax_before_credits": {
         "2023": 0
       },
+      "nc_itemized_deductions": {
+        "2023": 0
+      },
       "nc_non_refundable_credits": {
+        "2023": 0
+      },
+      "nc_standard_deduction": {
+        "2023": 0
+      },
+      "nc_standard_or_itemized_deductions": {
         "2023": 0
       },
       "nc_taxable_income": {
@@ -9687,6 +9774,12 @@
       "oh_other_add_backs": {
         "2023": 0
       },
+      "oh_retirement_income_credit": {
+        "2023": 0
+      },
+      "oh_retirement_income_credit_eligible": {
+        "2023": false
+      },
       "oh_section_179_expense_add_back": {
         "2023": 0
       },
@@ -9960,6 +10053,9 @@
       "retirement_savings_credit": {
         "2023": 0
       },
+      "ri_agi": {
+        "2023": 0
+      },
       "ri_cdcc": {
         "2023": 0
       },
@@ -9976,6 +10072,9 @@
         "2023": 0
       },
       "ri_standard_deduction": {
+        "2023": 0
+      },
+      "ri_standard_deduction_applicable_percentage": {
         "2023": 0
       },
       "ri_taxable_income": {
@@ -10211,9 +10310,6 @@
       },
       "taxable_uc_agi": {
         "2023": 40000
-      },
-      "taxbc": {
-        "2023": 1230
       },
       "taxcalc_c04470": {
         "2023": 0

--- a/tests/python/data/us_household_under_policy_target.json
+++ b/tests/python/data/us_household_under_policy_target.json
@@ -332,7 +332,7 @@
   "marital_units": {
     "your first dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 2
+        "2023": 1
       },
       "marital_unit_weight": {
         "2023": 0
@@ -343,7 +343,7 @@
     },
     "your fourth dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 5
+        "2023": 4
       },
       "marital_unit_weight": {
         "2023": 0
@@ -366,7 +366,7 @@
     },
     "your second dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 3
+        "2023": 2
       },
       "marital_unit_weight": {
         "2023": 0
@@ -377,7 +377,7 @@
     },
     "your third dependent's marital unit": {
       "marital_unit_id": {
-        "2023": 4
+        "2023": 3
       },
       "marital_unit_weight": {
         "2023": 0

--- a/tests/python/data/us_household_under_policy_target.json
+++ b/tests/python/data/us_household_under_policy_target.json
@@ -1,0 +1,10811 @@
+{
+  "families": {
+    "your family": {
+      "family_id": {
+        "2023": 0
+      },
+      "family_weight": {
+        "2023": 0
+      },
+      "is_married": {
+        "2023": true
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ]
+    }
+  },
+  "households": {
+    "your household": {
+      "AK": {
+        "2023": false
+      },
+      "AL": {
+        "2023": true
+      },
+      "AR": {
+        "2023": false
+      },
+      "AZ": {
+        "2023": false
+      },
+      "CA": {
+        "2023": false
+      },
+      "CO": {
+        "2023": false
+      },
+      "CT": {
+        "2023": false
+      },
+      "DC": {
+        "2023": false
+      },
+      "DE": {
+        "2023": false
+      },
+      "FL": {
+        "2023": false
+      },
+      "GA": {
+        "2023": false
+      },
+      "HI": {
+        "2023": false
+      },
+      "IA": {
+        "2023": false
+      },
+      "ID": {
+        "2023": false
+      },
+      "IL": {
+        "2023": false
+      },
+      "IN": {
+        "2023": false
+      },
+      "KS": {
+        "2023": false
+      },
+      "KY": {
+        "2023": false
+      },
+      "LA": {
+        "2023": false
+      },
+      "MA": {
+        "2023": false
+      },
+      "MD": {
+        "2023": false
+      },
+      "ME": {
+        "2023": false
+      },
+      "MI": {
+        "2023": false
+      },
+      "MN": {
+        "2023": false
+      },
+      "MO": {
+        "2023": false
+      },
+      "MS": {
+        "2023": false
+      },
+      "MT": {
+        "2023": false
+      },
+      "NC": {
+        "2023": false
+      },
+      "ND": {
+        "2023": false
+      },
+      "NE": {
+        "2023": false
+      },
+      "NH": {
+        "2023": false
+      },
+      "NJ": {
+        "2023": false
+      },
+      "NM": {
+        "2023": false
+      },
+      "NV": {
+        "2023": false
+      },
+      "NY": {
+        "2023": false
+      },
+      "OH": {
+        "2023": false
+      },
+      "OK": {
+        "2023": false
+      },
+      "OR": {
+        "2023": false
+      },
+      "PA": {
+        "2023": false
+      },
+      "RI": {
+        "2023": false
+      },
+      "SC": {
+        "2023": false
+      },
+      "SD": {
+        "2023": false
+      },
+      "TN": {
+        "2023": false
+      },
+      "TX": {
+        "2023": false
+      },
+      "UT": {
+        "2023": false
+      },
+      "VA": {
+        "2023": false
+      },
+      "VT": {
+        "2023": false
+      },
+      "WA": {
+        "2023": false
+      },
+      "WI": {
+        "2023": false
+      },
+      "WV": {
+        "2023": false
+      },
+      "WY": {
+        "2023": false
+      },
+      "average_home_energy_use_in_state": {
+        "2023": 0
+      },
+      "ca_care": {
+        "2023": 0
+      },
+      "ca_care_amount_if_eligible": {
+        "2023": 0
+      },
+      "ca_care_categorically_eligible": {
+        "2023": false
+      },
+      "ca_care_eligible": {
+        "2023": false
+      },
+      "ca_care_income_eligible": {
+        "2023": false
+      },
+      "ca_care_poverty_line": {
+        "2023": 0
+      },
+      "ca_fera": {
+        "2023": 0
+      },
+      "ca_fera_amount_if_eligible": {
+        "2023": 0
+      },
+      "ca_fera_eligible": {
+        "2023": false
+      },
+      "ccdf_county_cluster": {
+        "2023": 1
+      },
+      "county": {
+        "2023": "DELAWARE_COUNTY_OH"
+      },
+      "county_fips": {
+        "2023": 0
+      },
+      "county_str": {
+        "2023": "DELAWARE_COUNTY_OH"
+      },
+      "current_home_energy_use": {
+        "2023": 0
+      },
+      "equiv_household_net_income": {
+        "2023": 24563.31
+      },
+      "fips": {
+        "2023": 6
+      },
+      "household_benefits": {
+        "2023": 12672.4
+      },
+      "household_count_people": {
+        "2023": 6
+      },
+      "household_id": {
+        "2023": 0
+      },
+      "household_income_ami_ratio": {
+        "2023": 0
+      },
+      "household_income_decile": {
+        "2023": -2147483648
+      },
+      "household_market_income": {
+        "2023": 40000
+      },
+      "household_net_income": {
+        "2023": 60167.58
+      },
+      "household_refundable_tax_credits": {
+        "2023": 10555.178
+      },
+      "household_size": {
+        "2023": 6
+      },
+      "household_tax": {
+        "2023": -7495.1777
+      },
+      "household_tax_before_refundable_credits": {
+        "2023": 3060
+      },
+      "household_vehicles_owned": {
+        "2023": 0
+      },
+      "household_weight": {
+        "2023": 0
+      },
+      "in_nyc": {
+        "2023": false
+      },
+      "is_homeless": {
+        "2023": false
+      },
+      "is_on_tribal_land": {
+        "2023": false
+      },
+      "is_rural": {
+        "2023": false
+      },
+      "medicaid_rating_area": {
+        "2023": 0
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ],
+      "snap_region": {
+        "2023": "CONTIGUOUS_US"
+      },
+      "snap_region_str": {
+        "2023": "CONTIGUOUS_US"
+      },
+      "snap_utility_region": {
+        "2023": "AL"
+      },
+      "snap_utility_region_str": {
+        "2023": "AL"
+      },
+      "state_code": {
+        "2023": "AL"
+      },
+      "state_code_str": {
+        "2023": "AL"
+      },
+      "state_fips": {
+        "2023": 6
+      },
+      "state_group": {
+        "2023": "CONTIGUOUS_US"
+      },
+      "state_group_str": {
+        "2023": "CONTIGUOUS_US"
+      },
+      "state_living_arrangement": {
+        "2023": "FULL_COST"
+      },
+      "state_name": {
+        "2023": "AL"
+      },
+      "three_digit_zip_code": {
+        "2023": "430"
+      },
+      "zip_code": {
+        "2023": "43081"
+      }
+    }
+  },
+  "marital_units": {
+    "your first dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 2
+      },
+      "marital_unit_weight": {
+        "2023": 0
+      },
+      "members": [
+        "your first dependent"
+      ]
+    },
+    "your fourth dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 5
+      },
+      "marital_unit_weight": {
+        "2023": 0
+      },
+      "members": [
+        "your fourth dependent"
+      ]
+    },
+    "your marital unit": {
+      "marital_unit_id": {
+        "2023": 0
+      },
+      "marital_unit_weight": {
+        "2023": 0
+      },
+      "members": [
+        "you",
+        "your partner"
+      ]
+    },
+    "your second dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 3
+      },
+      "marital_unit_weight": {
+        "2023": 0
+      },
+      "members": [
+        "your second dependent"
+      ]
+    },
+    "your third dependent's marital unit": {
+      "marital_unit_id": {
+        "2023": 4
+      },
+      "marital_unit_weight": {
+        "2023": 0
+      },
+      "members": [
+        "your third dependent"
+      ]
+    }
+  },
+  "people": {
+    "you": {
+      "adjusted_gross_income_person": {
+        "2023": 40000
+      },
+      "adult_index": {
+        "2023": 1
+      },
+      "age": {
+        "2023": 40
+      },
+      "age_group": {
+        "2023": "WORKING_AGE"
+      },
+      "alimony_expense": {
+        "2023": 0
+      },
+      "alimony_income": {
+        "2023": 0
+      },
+      "assessed_property_value": {
+        "2023": 0
+      },
+      "business_is_qualified": {
+        "2023": false
+      },
+      "business_is_sstb": {
+        "2023": false
+      },
+      "ca_cvrp": {
+        "2023": 0
+      },
+      "ca_cvrp_vehicle_rebate_amount": {
+        "2023": 0
+      },
+      "ca_is_qualifying_child_for_caleitc": {
+        "2023": false
+      },
+      "capital_gains": {
+        "2023": 0
+      },
+      "capital_losses": {
+        "2023": 0
+      },
+      "casualty_loss": {
+        "2023": 0
+      },
+      "ccdf_age_group": {
+        "2023": "INFANT"
+      },
+      "ccdf_duration_of_care": {
+        "2023": "HOURLY"
+      },
+      "ccdf_market_rate": {
+        "2023": 0
+      },
+      "cdcc_qualified_dependent": {
+        "2023": false
+      },
+      "charitable_cash_donations": {
+        "2023": 0
+      },
+      "charitable_non_cash_donations": {
+        "2023": 0
+      },
+      "child_support_expense": {
+        "2023": 0
+      },
+      "child_support_received": {
+        "2023": 0
+      },
+      "childcare_days_per_week": {
+        "2023": 0
+      },
+      "childcare_hours_per_day": {
+        "2023": 0
+      },
+      "childcare_hours_per_week": {
+        "2023": 0
+      },
+      "childcare_provider_type_group": {
+        "2023": "DCC_SACC"
+      },
+      "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+        "2023": false
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "cmbtp": {
+        "2023": 0
+      },
+      "co_oap": {
+        "2023": 0
+      },
+      "co_oap_eligible": {
+        "2023": false
+      },
+      "co_pension_subtraction_indv": {
+        "2023": 0
+      },
+      "co_pension_subtraction_indv_eligible": {
+        "2023": false
+      },
+      "co_social_security_subtraction_indv": {
+        "2023": 0
+      },
+      "co_social_security_subtraction_indv_eligible": {
+        "2023": 0
+      },
+      "co_state_supplement": {
+        "2023": 0
+      },
+      "co_state_supplement_eligible": {
+        "2023": false
+      },
+      "cost_of_attending_college": {
+        "2023": 0
+      },
+      "count_days_postpartum": {
+        "2023": "Infinity"
+      },
+      "cps_race": {
+        "2023": 0
+      },
+      "ctc_adult_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum_arpa": {
+        "2023": 0
+      },
+      "ctc_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_qualifying_child": {
+        "2023": false
+      },
+      "dc_agi": {
+        "2023": 0
+      },
+      "dc_deduction_indiv": {
+        "2023": 0
+      },
+      "dc_disabled_exclusion_subtraction": {
+        "2023": 0
+      },
+      "dc_income_additions": {
+        "2023": 0
+      },
+      "dc_income_subtractions": {
+        "2023": 0
+      },
+      "dc_self_employment_loss_addition": {
+        "2023": 0
+      },
+      "dc_taxable_income_indiv": {
+        "2023": 0
+      },
+      "debt_relief": {
+        "2023": 0
+      },
+      "disability_benefits": {
+        "2023": 0
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "e00200": {
+        "2023": 40000
+      },
+      "e00300": {
+        "2023": 0
+      },
+      "e02300": {
+        "2023": 0
+      },
+      "e02400": {
+        "2023": 0
+      },
+      "e87530": {
+        "2023": 0
+      },
+      "early_withdrawal_penalty": {
+        "2023": 0
+      },
+      "earned": {
+        "2023": 40000
+      },
+      "earned_income": {
+        "2023": 40000
+      },
+      "educator_expense": {
+        "2023": 0
+      },
+      "employee_medicare_tax": {
+        "2023": 580
+      },
+      "employee_social_security_tax": {
+        "2023": 2480
+      },
+      "employment_income": {
+        "2023": 40000
+      },
+      "farm_income": {
+        "2023": 0
+      },
+      "farm_rent_income": {
+        "2023": 0
+      },
+      "general_assistance": {
+        "2023": 0
+      },
+      "gi_cash_assistance": {
+        "2023": 0
+      },
+      "has_disabled_spouse": {
+        "2023": false
+      },
+      "has_marketplace_health_coverage": {
+        "2023": true
+      },
+      "health_insurance_premiums": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_child_receiving_public_support": {
+        "2023": false
+      },
+      "ia_alternate_tax_indiv": {
+        "2023": 0
+      },
+      "ia_alternate_tax_joint": {
+        "2023": 0
+      },
+      "ia_amt_indiv": {
+        "2023": 0
+      },
+      "ia_amt_joint": {
+        "2023": 0
+      },
+      "ia_base_tax_indiv": {
+        "2023": 0
+      },
+      "ia_base_tax_joint": {
+        "2023": 0
+      },
+      "ia_basic_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_basic_deduction_joint": {
+        "2023": 0
+      },
+      "ia_fedtax_deduction": {
+        "2023": 0
+      },
+      "ia_gross_income": {
+        "2023": 0
+      },
+      "ia_income_adjustments": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_indiv": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_joint": {
+        "2023": 0
+      },
+      "ia_net_income": {
+        "2023": 0
+      },
+      "ia_pension_exclusion": {
+        "2023": 0
+      },
+      "ia_prorate_fraction": {
+        "2023": 0
+      },
+      "ia_qbi_deduction": {
+        "2023": 0
+      },
+      "ia_regular_tax_indiv": {
+        "2023": 0
+      },
+      "ia_regular_tax_joint": {
+        "2023": 0
+      },
+      "ia_standard_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_standard_deduction_joint": {
+        "2023": 0
+      },
+      "ia_taxable_income_indiv": {
+        "2023": 0
+      },
+      "ia_taxable_income_joint": {
+        "2023": 0
+      },
+      "illicit_income": {
+        "2023": 0
+      },
+      "in_is_qualifying_dependent_child": {
+        "2023": false
+      },
+      "incapable_of_self_care": {
+        "2023": false
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "interest_expense": {
+        "2023": 0
+      },
+      "interest_income": {
+        "2023": 0
+      },
+      "ira_contributions": {
+        "2023": 0
+      },
+      "irs_gross_income": {
+        "2023": 40000
+      },
+      "is_adult": {
+        "2023": true
+      },
+      "is_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_breastfeeding": {
+        "2023": false
+      },
+      "is_ca_cvrp_increased_rebate_eligible": {
+        "2023": false
+      },
+      "is_ca_cvrp_normal_rebate_eligible": {
+        "2023": false
+      },
+      "is_ccdf_age_eligible": {
+        "2023": false
+      },
+      "is_ccdf_eligible": {
+        "2023": false
+      },
+      "is_ccdf_home_based": {
+        "2023": false
+      },
+      "is_ccdf_reason_for_care_eligible": {
+        "2023": false
+      },
+      "is_cdcc_eligible": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": false
+      },
+      "is_child_of_tax_head": {
+        "2023": false
+      },
+      "is_citizen": {
+        "2023": false
+      },
+      "is_disabled": {
+        "2023": false
+      },
+      "is_eitc_qualifying_child": {
+        "2023": false
+      },
+      "is_eligible_for_american_opportunity_credit": {
+        "2023": false
+      },
+      "is_enrolled_in_ccdf": {
+        "2023": false
+      },
+      "is_father": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_full_time_college_student": {
+        "2023": false
+      },
+      "is_full_time_student": {
+        "2023": false
+      },
+      "is_fully_disabled_service_connected_veteran": {
+        "2023": false
+      },
+      "is_hispanic": {
+        "2023": false
+      },
+      "is_in_k12_nonpublic_school": {
+        "2023": false
+      },
+      "is_in_k12_school": {
+        "2023": false
+      },
+      "is_in_medicaid_medically_needy_category": {
+        "2023": false
+      },
+      "is_infant_for_medicaid": {
+        "2023": false
+      },
+      "is_infant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_infant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_medicaid_eligible": {
+        "2023": false
+      },
+      "is_medically_needy_for_medicaid": {
+        "2023": false
+      },
+      "is_mother": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_optional_senior_or_disabled_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_permanently_and_totally_disabled": {
+        "2023": false
+      },
+      "is_permanently_disabled_veteran": {
+        "2023": false
+      },
+      "is_person_demographic_tanf_eligible": {
+        "2023": false
+      },
+      "is_pregnant": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_pregnant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_retired": {
+        "2023": false
+      },
+      "is_self_employed": {
+        "2023": false
+      },
+      "is_senior": {
+        "2023": false
+      },
+      "is_severely_disabled": {
+        "2023": false
+      },
+      "is_ssi_aged": {
+        "2023": false
+      },
+      "is_ssi_aged_blind_disabled": {
+        "2023": false
+      },
+      "is_ssi_disabled": {
+        "2023": false
+      },
+      "is_ssi_eligible_individual": {
+        "2023": false
+      },
+      "is_ssi_eligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_ineligible_child": {
+        "2023": false
+      },
+      "is_ssi_ineligible_parent": {
+        "2023": false
+      },
+      "is_ssi_ineligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_recipient_for_medicaid": {
+        "2023": false
+      },
+      "is_surviving_child_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_surviving_spouse_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_tax_unit_dependent": {
+        "2023": false
+      },
+      "is_tax_unit_head": {
+        "2023": true
+      },
+      "is_tax_unit_spouse": {
+        "2023": false
+      },
+      "is_usda_disabled": {
+        "2023": false
+      },
+      "is_usda_elderly": {
+        "2023": false
+      },
+      "is_wa_adult": {
+        "2023": true
+      },
+      "is_wic_at_nutritional_risk": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_young_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "k1bx14": {
+        "2023": 0
+      },
+      "long_term_capital_gains": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_collectibles": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_small_business_stock": {
+        "2023": 0
+      },
+      "ma_covid_19_essential_employee_premium_pay_program": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0.33710158
+      },
+      "market_income": {
+        "2023": 40000
+      },
+      "maximum_state_supplement": {
+        "2023": 0
+      },
+      "md_pension_subtraction_amount": {
+        "2023": 0
+      },
+      "md_socsec_subtraction_amount": {
+        "2023": 0
+      },
+      "medicaid": {
+        "2023": 0
+      },
+      "medicaid_benefit_value": {
+        "2023": 27358.121
+      },
+      "medicaid_category": {
+        "2023": "NONE"
+      },
+      "medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "medical_expense": {
+        "2023": 0
+      },
+      "medical_out_of_pocket_expenses": {
+        "2023": 0
+      },
+      "meets_ssi_resource_test": {
+        "2023": true
+      },
+      "meets_wic_categorical_eligibility": {
+        "2023": true
+      },
+      "military_basic_pay": {
+        "2023": 0
+      },
+      "military_retirement_pay": {
+        "2023": 0
+      },
+      "military_service_income": {
+        "2023": 0
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "mo_adjusted_gross_income": {
+        "2023": 0
+      },
+      "mo_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mo_income_tax_exempt": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_a": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_b": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_c": {
+        "2023": 0
+      },
+      "mo_qualified_health_insurance_premiums": {
+        "2023": 0
+      },
+      "mo_taxable_income": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "never_eligible_for_social_security_benefits": {
+        "2023": false
+      },
+      "nj_agi_additions": {
+        "2023": 0
+      },
+      "nj_agi_subtractions": {
+        "2023": 0
+      },
+      "nj_eligible_pension_income": {
+        "2023": 0
+      },
+      "nj_total_income": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible_child": {
+        "2023": false
+      },
+      "non_public_school_tuition": {
+        "2023": 0
+      },
+      "non_qualified_dividend_income": {
+        "2023": 0
+      },
+      "non_sch_d_capital_gains": {
+        "2023": 0
+      },
+      "oh_has_not_taken_oh_lump_sum_credits": {
+        "2023": false
+      },
+      "or_retirement_credit_eligible": {
+        "2023": false
+      },
+      "own_children_in_household": {
+        "2023": 0
+      },
+      "pa_nontaxable_pension_income": {
+        "2023": 0
+      },
+      "partnership_s_corp_income": {
+        "2023": 0
+      },
+      "payroll_tax_gross_wages": {
+        "2023": 40000
+      },
+      "pell_grant": {
+        "2023": 0
+      },
+      "pell_grant_countable_assets": {
+        "2023": 0
+      },
+      "pell_grant_dependent_allowances": {
+        "2023": 7040
+      },
+      "pell_grant_dependent_available_income": {
+        "2023": 0
+      },
+      "pell_grant_dependent_contribution": {
+        "2023": -3520
+      },
+      "pell_grant_dependent_other_allowances": {
+        "2023": 0
+      },
+      "pell_grant_efc": {
+        "2023": 0
+      },
+      "pell_grant_formula": {
+        "2023": "C"
+      },
+      "pell_grant_head_allowances": {
+        "2023": 0
+      },
+      "pell_grant_head_available_income": {
+        "2023": 0
+      },
+      "pell_grant_head_contribution": {
+        "2023": 0
+      },
+      "pell_grant_months_in_school": {
+        "2023": 0
+      },
+      "pell_grant_simplified_formula_applies": {
+        "2023": true
+      },
+      "pencon": {
+        "2023": 0
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "pension_survivors": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "per_vehicle_payment": {
+        "2023": 0
+      },
+      "person_family_id": {
+        "2023": 0
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_id": {
+        "2023": 0
+      },
+      "person_in_poverty": {
+        "2023": false
+      },
+      "person_marital_unit_id": {
+        "2023": 0
+      },
+      "person_spm_unit_id": {
+        "2023": 0
+      },
+      "person_tax_unit_id": {
+        "2023": 0
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "private_pension_income": {
+        "2023": 0
+      },
+      "public_pension_income": {
+        "2023": 0
+      },
+      "qbid_amount": {
+        "2023": 0
+      },
+      "qualified_adoption_assistance_expense": {
+        "2023": 0
+      },
+      "qualified_business_income": {
+        "2023": 0
+      },
+      "qualified_dividend_income": {
+        "2023": 0
+      },
+      "qualified_tuition_expenses": {
+        "2023": 0
+      },
+      "qualifies_for_elderly_or_disabled_credit": {
+        "2023": false
+      },
+      "race": {
+        "2023": "OTHER"
+      },
+      "real_estate_taxes": {
+        "2023": 0
+      },
+      "receives_or_needs_protective_services": {
+        "2023": false
+      },
+      "receives_wic": {
+        "2023": false
+      },
+      "rent": {
+        "2023": 0
+      },
+      "rental_income": {
+        "2023": 0
+      },
+      "retired_on_total_disability": {
+        "2023": false
+      },
+      "salt_refund_income": {
+        "2023": 0
+      },
+      "sc_gross_earned_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald_person": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_premiums": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald_person": {
+        "2023": 0
+      },
+      "self_employed_pension_contributions": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "self_employment_medicare_tax": {
+        "2023": 0
+      },
+      "self_employment_social_security_tax": {
+        "2023": 0
+      },
+      "self_employment_tax": {
+        "2023": 0
+      },
+      "self_employment_tax_ald_person": {
+        "2023": 0
+      },
+      "sep_simple_qualified_plan_contributions": {
+        "2023": 0
+      },
+      "sey": {
+        "2023": 0
+      },
+      "short_term_capital_gains": {
+        "2023": 0
+      },
+      "social_security": {
+        "2023": 0
+      },
+      "social_security_dependents": {
+        "2023": 0
+      },
+      "social_security_disability": {
+        "2023": 0
+      },
+      "social_security_retirement": {
+        "2023": 0
+      },
+      "social_security_survivors": {
+        "2023": 0
+      },
+      "social_security_taxable_self_employment_income": {
+        "2023": 0
+      },
+      "ssi": {
+        "2023": 0
+      },
+      "ssi_amount_if_eligible": {
+        "2023": 10968
+      },
+      "ssi_category": {
+        "2023": "NONE"
+      },
+      "ssi_claim_is_joint": {
+        "2023": false
+      },
+      "ssi_countable_income": {
+        "2023": 0
+      },
+      "ssi_countable_resources": {
+        "2023": 0
+      },
+      "ssi_earned_income": {
+        "2023": 40000
+      },
+      "ssi_earned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_ineligible_child_allocation": {
+        "2023": 0
+      },
+      "ssi_ineligible_parent_allocation": {
+        "2023": 0
+      },
+      "ssi_reported": {
+        "2023": 0
+      },
+      "ssi_unearned_income": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_parent": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "state_or_federal_salary": {
+        "2023": 0
+      },
+      "state_supplement": {
+        "2023": 0
+      },
+      "strike_benefits": {
+        "2023": 0
+      },
+      "student_loan_interest": {
+        "2023": 0
+      },
+      "tanf_person": {
+        "2023": 0
+      },
+      "tanf_reported": {
+        "2023": 0
+      },
+      "tax_exempt_interest_income": {
+        "2023": 0
+      },
+      "tax_exempt_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_private_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_public_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_unemployment_compensation": {
+        "2023": 0
+      },
+      "taxable_earnings_for_social_security": {
+        "2023": 40000
+      },
+      "taxable_federal_pension_income": {
+        "2023": 0
+      },
+      "taxable_interest_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_private_pension_income": {
+        "2023": 0
+      },
+      "taxable_public_pension_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security": {
+        "2023": 0
+      },
+      "taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "total_disability_payments": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "unadjusted_basis_qualified_property": {
+        "2023": 0
+      },
+      "uncapped_ssi": {
+        "2023": 0
+      },
+      "under_12_months_postpartum": {
+        "2023": false
+      },
+      "under_60_days_postpartum": {
+        "2023": false
+      },
+      "unemployment_compensation": {
+        "2023": 0
+      },
+      "us_bonds_for_higher_ed": {
+        "2023": 0
+      },
+      "vehicles_owned": {
+        "2023": 0
+      },
+      "veterans_benefits": {
+        "2023": 0
+      },
+      "w2_wages_from_qualified_business": {
+        "2023": 0
+      },
+      "wic": {
+        "2023": 0
+      },
+      "wic_category": {
+        "2023": "NONE"
+      },
+      "wic_category_str": {
+        "2023": "NONE"
+      },
+      "workers_compensation": {
+        "2023": 0
+      },
+      "would_claim_wic": {
+        "2023": true
+      }
+    },
+    "your first dependent": {
+      "adjusted_gross_income_person": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_group": {
+        "2023": "CHILD"
+      },
+      "alimony_expense": {
+        "2023": 0
+      },
+      "alimony_income": {
+        "2023": 0
+      },
+      "assessed_property_value": {
+        "2023": 0
+      },
+      "business_is_qualified": {
+        "2023": false
+      },
+      "business_is_sstb": {
+        "2023": false
+      },
+      "ca_cvrp": {
+        "2023": 0
+      },
+      "ca_cvrp_vehicle_rebate_amount": {
+        "2023": 0
+      },
+      "ca_is_qualifying_child_for_caleitc": {
+        "2023": true
+      },
+      "capital_gains": {
+        "2023": 0
+      },
+      "capital_losses": {
+        "2023": 0
+      },
+      "casualty_loss": {
+        "2023": 0
+      },
+      "ccdf_age_group": {
+        "2023": "SCHOOL_AGE"
+      },
+      "ccdf_duration_of_care": {
+        "2023": "HOURLY"
+      },
+      "ccdf_market_rate": {
+        "2023": 0
+      },
+      "cdcc_qualified_dependent": {
+        "2023": true
+      },
+      "charitable_cash_donations": {
+        "2023": 0
+      },
+      "charitable_non_cash_donations": {
+        "2023": 0
+      },
+      "child_support_expense": {
+        "2023": 0
+      },
+      "child_support_received": {
+        "2023": 0
+      },
+      "childcare_days_per_week": {
+        "2023": 0
+      },
+      "childcare_hours_per_day": {
+        "2023": 0
+      },
+      "childcare_hours_per_week": {
+        "2023": 0
+      },
+      "childcare_provider_type_group": {
+        "2023": "DCC_SACC"
+      },
+      "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+        "2023": false
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "cmbtp": {
+        "2023": 0
+      },
+      "co_oap": {
+        "2023": 0
+      },
+      "co_oap_eligible": {
+        "2023": false
+      },
+      "co_pension_subtraction_indv": {
+        "2023": 0
+      },
+      "co_pension_subtraction_indv_eligible": {
+        "2023": false
+      },
+      "co_social_security_subtraction_indv": {
+        "2023": 0
+      },
+      "co_social_security_subtraction_indv_eligible": {
+        "2023": 0
+      },
+      "co_state_supplement": {
+        "2023": 0
+      },
+      "co_state_supplement_eligible": {
+        "2023": false
+      },
+      "cost_of_attending_college": {
+        "2023": 0
+      },
+      "count_days_postpartum": {
+        "2023": "Infinity"
+      },
+      "cps_race": {
+        "2023": 0
+      },
+      "ctc_adult_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_child_individual_maximum_arpa": {
+        "2023": 0
+      },
+      "ctc_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_qualifying_child": {
+        "2023": true
+      },
+      "dc_agi": {
+        "2023": 0
+      },
+      "dc_deduction_indiv": {
+        "2023": 0
+      },
+      "dc_disabled_exclusion_subtraction": {
+        "2023": 0
+      },
+      "dc_income_additions": {
+        "2023": 0
+      },
+      "dc_income_subtractions": {
+        "2023": 0
+      },
+      "dc_self_employment_loss_addition": {
+        "2023": 0
+      },
+      "dc_taxable_income_indiv": {
+        "2023": 0
+      },
+      "debt_relief": {
+        "2023": 0
+      },
+      "disability_benefits": {
+        "2023": 0
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "e00200": {
+        "2023": 0
+      },
+      "e00300": {
+        "2023": 0
+      },
+      "e02300": {
+        "2023": 0
+      },
+      "e02400": {
+        "2023": 0
+      },
+      "e87530": {
+        "2023": 0
+      },
+      "early_withdrawal_penalty": {
+        "2023": 0
+      },
+      "earned": {
+        "2023": 0
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "educator_expense": {
+        "2023": 0
+      },
+      "employee_medicare_tax": {
+        "2023": 0
+      },
+      "employee_social_security_tax": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "farm_income": {
+        "2023": 0
+      },
+      "farm_rent_income": {
+        "2023": 0
+      },
+      "general_assistance": {
+        "2023": 0
+      },
+      "gi_cash_assistance": {
+        "2023": 0
+      },
+      "has_disabled_spouse": {
+        "2023": false
+      },
+      "has_marketplace_health_coverage": {
+        "2023": true
+      },
+      "health_insurance_premiums": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_child_receiving_public_support": {
+        "2023": false
+      },
+      "ia_alternate_tax_indiv": {
+        "2023": 0
+      },
+      "ia_alternate_tax_joint": {
+        "2023": 0
+      },
+      "ia_amt_indiv": {
+        "2023": 0
+      },
+      "ia_amt_joint": {
+        "2023": 0
+      },
+      "ia_base_tax_indiv": {
+        "2023": 0
+      },
+      "ia_base_tax_joint": {
+        "2023": 0
+      },
+      "ia_basic_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_basic_deduction_joint": {
+        "2023": 0
+      },
+      "ia_fedtax_deduction": {
+        "2023": 0
+      },
+      "ia_gross_income": {
+        "2023": 0
+      },
+      "ia_income_adjustments": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_indiv": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_joint": {
+        "2023": 0
+      },
+      "ia_net_income": {
+        "2023": 0
+      },
+      "ia_pension_exclusion": {
+        "2023": 0
+      },
+      "ia_prorate_fraction": {
+        "2023": 0
+      },
+      "ia_qbi_deduction": {
+        "2023": 0
+      },
+      "ia_regular_tax_indiv": {
+        "2023": 0
+      },
+      "ia_regular_tax_joint": {
+        "2023": 0
+      },
+      "ia_standard_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_standard_deduction_joint": {
+        "2023": 0
+      },
+      "ia_taxable_income_indiv": {
+        "2023": 0
+      },
+      "ia_taxable_income_joint": {
+        "2023": 0
+      },
+      "illicit_income": {
+        "2023": 0
+      },
+      "in_is_qualifying_dependent_child": {
+        "2023": false
+      },
+      "incapable_of_self_care": {
+        "2023": false
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "interest_expense": {
+        "2023": 0
+      },
+      "interest_income": {
+        "2023": 0
+      },
+      "ira_contributions": {
+        "2023": 0
+      },
+      "irs_gross_income": {
+        "2023": 0
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_breastfeeding": {
+        "2023": false
+      },
+      "is_ca_cvrp_increased_rebate_eligible": {
+        "2023": false
+      },
+      "is_ca_cvrp_normal_rebate_eligible": {
+        "2023": false
+      },
+      "is_ccdf_age_eligible": {
+        "2023": true
+      },
+      "is_ccdf_eligible": {
+        "2023": false
+      },
+      "is_ccdf_home_based": {
+        "2023": false
+      },
+      "is_ccdf_reason_for_care_eligible": {
+        "2023": false
+      },
+      "is_cdcc_eligible": {
+        "2023": true
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_of_tax_head": {
+        "2023": true
+      },
+      "is_citizen": {
+        "2023": false
+      },
+      "is_disabled": {
+        "2023": false
+      },
+      "is_eitc_qualifying_child": {
+        "2023": true
+      },
+      "is_eligible_for_american_opportunity_credit": {
+        "2023": false
+      },
+      "is_enrolled_in_ccdf": {
+        "2023": false
+      },
+      "is_father": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_full_time_college_student": {
+        "2023": false
+      },
+      "is_full_time_student": {
+        "2023": true
+      },
+      "is_fully_disabled_service_connected_veteran": {
+        "2023": false
+      },
+      "is_hispanic": {
+        "2023": false
+      },
+      "is_in_k12_nonpublic_school": {
+        "2023": false
+      },
+      "is_in_k12_school": {
+        "2023": true
+      },
+      "is_in_medicaid_medically_needy_category": {
+        "2023": false
+      },
+      "is_infant_for_medicaid": {
+        "2023": false
+      },
+      "is_infant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_infant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_medicaid_eligible": {
+        "2023": true
+      },
+      "is_medically_needy_for_medicaid": {
+        "2023": false
+      },
+      "is_mother": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_optional_senior_or_disabled_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_permanently_and_totally_disabled": {
+        "2023": false
+      },
+      "is_permanently_disabled_veteran": {
+        "2023": false
+      },
+      "is_person_demographic_tanf_eligible": {
+        "2023": true
+      },
+      "is_pregnant": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_pregnant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_retired": {
+        "2023": false
+      },
+      "is_self_employed": {
+        "2023": false
+      },
+      "is_senior": {
+        "2023": false
+      },
+      "is_severely_disabled": {
+        "2023": false
+      },
+      "is_ssi_aged": {
+        "2023": false
+      },
+      "is_ssi_aged_blind_disabled": {
+        "2023": false
+      },
+      "is_ssi_disabled": {
+        "2023": false
+      },
+      "is_ssi_eligible_individual": {
+        "2023": false
+      },
+      "is_ssi_eligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_ineligible_child": {
+        "2023": true
+      },
+      "is_ssi_ineligible_parent": {
+        "2023": false
+      },
+      "is_ssi_ineligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_recipient_for_medicaid": {
+        "2023": false
+      },
+      "is_surviving_child_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_surviving_spouse_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      },
+      "is_tax_unit_head": {
+        "2023": false
+      },
+      "is_tax_unit_spouse": {
+        "2023": false
+      },
+      "is_usda_disabled": {
+        "2023": false
+      },
+      "is_usda_elderly": {
+        "2023": false
+      },
+      "is_wa_adult": {
+        "2023": false
+      },
+      "is_wic_at_nutritional_risk": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_young_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "k1bx14": {
+        "2023": 0
+      },
+      "long_term_capital_gains": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_collectibles": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_small_business_stock": {
+        "2023": 0
+      },
+      "ma_covid_19_essential_employee_premium_pay_program": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "maximum_state_supplement": {
+        "2023": 0
+      },
+      "md_pension_subtraction_amount": {
+        "2023": 0
+      },
+      "md_socsec_subtraction_amount": {
+        "2023": 0
+      },
+      "medicaid": {
+        "2023": 27358.121
+      },
+      "medicaid_benefit_value": {
+        "2023": 27358.121
+      },
+      "medicaid_category": {
+        "2023": "OLDER_CHILD"
+      },
+      "medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "medical_expense": {
+        "2023": 0
+      },
+      "medical_out_of_pocket_expenses": {
+        "2023": 0
+      },
+      "meets_ssi_resource_test": {
+        "2023": true
+      },
+      "meets_wic_categorical_eligibility": {
+        "2023": true
+      },
+      "military_basic_pay": {
+        "2023": 0
+      },
+      "military_retirement_pay": {
+        "2023": 0
+      },
+      "military_service_income": {
+        "2023": 0
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "mo_adjusted_gross_income": {
+        "2023": 0
+      },
+      "mo_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mo_income_tax_exempt": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_a": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_b": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_c": {
+        "2023": 0
+      },
+      "mo_qualified_health_insurance_premiums": {
+        "2023": 0
+      },
+      "mo_taxable_income": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "never_eligible_for_social_security_benefits": {
+        "2023": false
+      },
+      "nj_agi_additions": {
+        "2023": 0
+      },
+      "nj_agi_subtractions": {
+        "2023": 0
+      },
+      "nj_eligible_pension_income": {
+        "2023": 0
+      },
+      "nj_total_income": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible_child": {
+        "2023": false
+      },
+      "non_public_school_tuition": {
+        "2023": 0
+      },
+      "non_qualified_dividend_income": {
+        "2023": 0
+      },
+      "non_sch_d_capital_gains": {
+        "2023": 0
+      },
+      "oh_has_not_taken_oh_lump_sum_credits": {
+        "2023": false
+      },
+      "or_retirement_credit_eligible": {
+        "2023": false
+      },
+      "own_children_in_household": {
+        "2023": 0
+      },
+      "pa_nontaxable_pension_income": {
+        "2023": 0
+      },
+      "partnership_s_corp_income": {
+        "2023": 0
+      },
+      "payroll_tax_gross_wages": {
+        "2023": 0
+      },
+      "pell_grant": {
+        "2023": 0
+      },
+      "pell_grant_countable_assets": {
+        "2023": 0
+      },
+      "pell_grant_dependent_allowances": {
+        "2023": 7040
+      },
+      "pell_grant_dependent_available_income": {
+        "2023": 0
+      },
+      "pell_grant_dependent_contribution": {
+        "2023": -3520
+      },
+      "pell_grant_dependent_other_allowances": {
+        "2023": 0
+      },
+      "pell_grant_efc": {
+        "2023": 0
+      },
+      "pell_grant_formula": {
+        "2023": "A"
+      },
+      "pell_grant_head_allowances": {
+        "2023": 0
+      },
+      "pell_grant_head_available_income": {
+        "2023": 0
+      },
+      "pell_grant_head_contribution": {
+        "2023": 0
+      },
+      "pell_grant_months_in_school": {
+        "2023": 0
+      },
+      "pell_grant_simplified_formula_applies": {
+        "2023": true
+      },
+      "pencon": {
+        "2023": 0
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "pension_survivors": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "per_vehicle_payment": {
+        "2023": 0
+      },
+      "person_family_id": {
+        "2023": 0
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_id": {
+        "2023": 2
+      },
+      "person_in_poverty": {
+        "2023": false
+      },
+      "person_marital_unit_id": {
+        "2023": 0
+      },
+      "person_spm_unit_id": {
+        "2023": 0
+      },
+      "person_tax_unit_id": {
+        "2023": 0
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "private_pension_income": {
+        "2023": 0
+      },
+      "public_pension_income": {
+        "2023": 0
+      },
+      "qbid_amount": {
+        "2023": 0
+      },
+      "qualified_adoption_assistance_expense": {
+        "2023": 0
+      },
+      "qualified_business_income": {
+        "2023": 0
+      },
+      "qualified_dividend_income": {
+        "2023": 0
+      },
+      "qualified_tuition_expenses": {
+        "2023": 0
+      },
+      "qualifies_for_elderly_or_disabled_credit": {
+        "2023": false
+      },
+      "race": {
+        "2023": "OTHER"
+      },
+      "real_estate_taxes": {
+        "2023": 0
+      },
+      "receives_or_needs_protective_services": {
+        "2023": false
+      },
+      "receives_wic": {
+        "2023": false
+      },
+      "rent": {
+        "2023": 0
+      },
+      "rental_income": {
+        "2023": 0
+      },
+      "retired_on_total_disability": {
+        "2023": false
+      },
+      "salt_refund_income": {
+        "2023": 0
+      },
+      "sc_gross_earned_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald_person": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_premiums": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald_person": {
+        "2023": 0
+      },
+      "self_employed_pension_contributions": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "self_employment_medicare_tax": {
+        "2023": 0
+      },
+      "self_employment_social_security_tax": {
+        "2023": 0
+      },
+      "self_employment_tax": {
+        "2023": 0
+      },
+      "self_employment_tax_ald_person": {
+        "2023": 0
+      },
+      "sep_simple_qualified_plan_contributions": {
+        "2023": 0
+      },
+      "sey": {
+        "2023": 0
+      },
+      "short_term_capital_gains": {
+        "2023": 0
+      },
+      "social_security": {
+        "2023": 0
+      },
+      "social_security_dependents": {
+        "2023": 0
+      },
+      "social_security_disability": {
+        "2023": 0
+      },
+      "social_security_retirement": {
+        "2023": 0
+      },
+      "social_security_survivors": {
+        "2023": 0
+      },
+      "social_security_taxable_self_employment_income": {
+        "2023": 0
+      },
+      "ssi": {
+        "2023": 0
+      },
+      "ssi_amount_if_eligible": {
+        "2023": 10968
+      },
+      "ssi_category": {
+        "2023": "NONE"
+      },
+      "ssi_claim_is_joint": {
+        "2023": false
+      },
+      "ssi_countable_income": {
+        "2023": 0
+      },
+      "ssi_countable_resources": {
+        "2023": 0
+      },
+      "ssi_earned_income": {
+        "2023": 0
+      },
+      "ssi_earned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_ineligible_child_allocation": {
+        "2023": 5484
+      },
+      "ssi_ineligible_parent_allocation": {
+        "2023": 0
+      },
+      "ssi_reported": {
+        "2023": 0
+      },
+      "ssi_unearned_income": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_parent": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "state_or_federal_salary": {
+        "2023": 0
+      },
+      "state_supplement": {
+        "2023": 0
+      },
+      "strike_benefits": {
+        "2023": 0
+      },
+      "student_loan_interest": {
+        "2023": 0
+      },
+      "tanf_person": {
+        "2023": 0
+      },
+      "tanf_reported": {
+        "2023": 0
+      },
+      "tax_exempt_interest_income": {
+        "2023": 0
+      },
+      "tax_exempt_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_private_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_public_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_unemployment_compensation": {
+        "2023": 0
+      },
+      "taxable_earnings_for_social_security": {
+        "2023": 0
+      },
+      "taxable_federal_pension_income": {
+        "2023": 0
+      },
+      "taxable_interest_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_private_pension_income": {
+        "2023": 0
+      },
+      "taxable_public_pension_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security": {
+        "2023": 0
+      },
+      "taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "total_disability_payments": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "unadjusted_basis_qualified_property": {
+        "2023": 0
+      },
+      "uncapped_ssi": {
+        "2023": 0
+      },
+      "under_12_months_postpartum": {
+        "2023": false
+      },
+      "under_60_days_postpartum": {
+        "2023": false
+      },
+      "unemployment_compensation": {
+        "2023": 0
+      },
+      "us_bonds_for_higher_ed": {
+        "2023": 0
+      },
+      "vehicles_owned": {
+        "2023": 0
+      },
+      "veterans_benefits": {
+        "2023": 0
+      },
+      "w2_wages_from_qualified_business": {
+        "2023": 0
+      },
+      "wic": {
+        "2023": 0
+      },
+      "wic_category": {
+        "2023": "NONE"
+      },
+      "wic_category_str": {
+        "2023": "NONE"
+      },
+      "workers_compensation": {
+        "2023": 0
+      },
+      "would_claim_wic": {
+        "2023": true
+      }
+    },
+    "your fourth dependent": {
+      "adjusted_gross_income_person": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_group": {
+        "2023": "CHILD"
+      },
+      "alimony_expense": {
+        "2023": 0
+      },
+      "alimony_income": {
+        "2023": 0
+      },
+      "assessed_property_value": {
+        "2023": 0
+      },
+      "business_is_qualified": {
+        "2023": false
+      },
+      "business_is_sstb": {
+        "2023": false
+      },
+      "ca_cvrp": {
+        "2023": 0
+      },
+      "ca_cvrp_vehicle_rebate_amount": {
+        "2023": 0
+      },
+      "ca_is_qualifying_child_for_caleitc": {
+        "2023": true
+      },
+      "capital_gains": {
+        "2023": 0
+      },
+      "capital_losses": {
+        "2023": 0
+      },
+      "casualty_loss": {
+        "2023": 0
+      },
+      "ccdf_age_group": {
+        "2023": "SCHOOL_AGE"
+      },
+      "ccdf_duration_of_care": {
+        "2023": "HOURLY"
+      },
+      "ccdf_market_rate": {
+        "2023": 0
+      },
+      "cdcc_qualified_dependent": {
+        "2023": true
+      },
+      "charitable_cash_donations": {
+        "2023": 0
+      },
+      "charitable_non_cash_donations": {
+        "2023": 0
+      },
+      "child_support_expense": {
+        "2023": 0
+      },
+      "child_support_received": {
+        "2023": 0
+      },
+      "childcare_days_per_week": {
+        "2023": 0
+      },
+      "childcare_hours_per_day": {
+        "2023": 0
+      },
+      "childcare_hours_per_week": {
+        "2023": 0
+      },
+      "childcare_provider_type_group": {
+        "2023": "DCC_SACC"
+      },
+      "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+        "2023": false
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "cmbtp": {
+        "2023": 0
+      },
+      "co_oap": {
+        "2023": 0
+      },
+      "co_oap_eligible": {
+        "2023": false
+      },
+      "co_pension_subtraction_indv": {
+        "2023": 0
+      },
+      "co_pension_subtraction_indv_eligible": {
+        "2023": false
+      },
+      "co_social_security_subtraction_indv": {
+        "2023": 0
+      },
+      "co_social_security_subtraction_indv_eligible": {
+        "2023": 0
+      },
+      "co_state_supplement": {
+        "2023": 0
+      },
+      "co_state_supplement_eligible": {
+        "2023": false
+      },
+      "cost_of_attending_college": {
+        "2023": 0
+      },
+      "count_days_postpartum": {
+        "2023": "Infinity"
+      },
+      "cps_race": {
+        "2023": 0
+      },
+      "ctc_adult_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_child_individual_maximum_arpa": {
+        "2023": 0
+      },
+      "ctc_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_qualifying_child": {
+        "2023": true
+      },
+      "dc_agi": {
+        "2023": 0
+      },
+      "dc_deduction_indiv": {
+        "2023": 0
+      },
+      "dc_disabled_exclusion_subtraction": {
+        "2023": 0
+      },
+      "dc_income_additions": {
+        "2023": 0
+      },
+      "dc_income_subtractions": {
+        "2023": 0
+      },
+      "dc_self_employment_loss_addition": {
+        "2023": 0
+      },
+      "dc_taxable_income_indiv": {
+        "2023": 0
+      },
+      "debt_relief": {
+        "2023": 0
+      },
+      "disability_benefits": {
+        "2023": 0
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "e00200": {
+        "2023": 0
+      },
+      "e00300": {
+        "2023": 0
+      },
+      "e02300": {
+        "2023": 0
+      },
+      "e02400": {
+        "2023": 0
+      },
+      "e87530": {
+        "2023": 0
+      },
+      "early_withdrawal_penalty": {
+        "2023": 0
+      },
+      "earned": {
+        "2023": 0
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "educator_expense": {
+        "2023": 0
+      },
+      "employee_medicare_tax": {
+        "2023": 0
+      },
+      "employee_social_security_tax": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "farm_income": {
+        "2023": 0
+      },
+      "farm_rent_income": {
+        "2023": 0
+      },
+      "general_assistance": {
+        "2023": 0
+      },
+      "gi_cash_assistance": {
+        "2023": 0
+      },
+      "has_disabled_spouse": {
+        "2023": false
+      },
+      "has_marketplace_health_coverage": {
+        "2023": true
+      },
+      "health_insurance_premiums": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_child_receiving_public_support": {
+        "2023": false
+      },
+      "ia_alternate_tax_indiv": {
+        "2023": 0
+      },
+      "ia_alternate_tax_joint": {
+        "2023": 0
+      },
+      "ia_amt_indiv": {
+        "2023": 0
+      },
+      "ia_amt_joint": {
+        "2023": 0
+      },
+      "ia_base_tax_indiv": {
+        "2023": 0
+      },
+      "ia_base_tax_joint": {
+        "2023": 0
+      },
+      "ia_basic_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_basic_deduction_joint": {
+        "2023": 0
+      },
+      "ia_fedtax_deduction": {
+        "2023": 0
+      },
+      "ia_gross_income": {
+        "2023": 0
+      },
+      "ia_income_adjustments": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_indiv": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_joint": {
+        "2023": 0
+      },
+      "ia_net_income": {
+        "2023": 0
+      },
+      "ia_pension_exclusion": {
+        "2023": 0
+      },
+      "ia_prorate_fraction": {
+        "2023": 0
+      },
+      "ia_qbi_deduction": {
+        "2023": 0
+      },
+      "ia_regular_tax_indiv": {
+        "2023": 0
+      },
+      "ia_regular_tax_joint": {
+        "2023": 0
+      },
+      "ia_standard_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_standard_deduction_joint": {
+        "2023": 0
+      },
+      "ia_taxable_income_indiv": {
+        "2023": 0
+      },
+      "ia_taxable_income_joint": {
+        "2023": 0
+      },
+      "illicit_income": {
+        "2023": 0
+      },
+      "in_is_qualifying_dependent_child": {
+        "2023": false
+      },
+      "incapable_of_self_care": {
+        "2023": false
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "interest_expense": {
+        "2023": 0
+      },
+      "interest_income": {
+        "2023": 0
+      },
+      "ira_contributions": {
+        "2023": 0
+      },
+      "irs_gross_income": {
+        "2023": 0
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_breastfeeding": {
+        "2023": false
+      },
+      "is_ca_cvrp_increased_rebate_eligible": {
+        "2023": false
+      },
+      "is_ca_cvrp_normal_rebate_eligible": {
+        "2023": false
+      },
+      "is_ccdf_age_eligible": {
+        "2023": true
+      },
+      "is_ccdf_eligible": {
+        "2023": false
+      },
+      "is_ccdf_home_based": {
+        "2023": false
+      },
+      "is_ccdf_reason_for_care_eligible": {
+        "2023": false
+      },
+      "is_cdcc_eligible": {
+        "2023": true
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_of_tax_head": {
+        "2023": true
+      },
+      "is_citizen": {
+        "2023": false
+      },
+      "is_disabled": {
+        "2023": false
+      },
+      "is_eitc_qualifying_child": {
+        "2023": true
+      },
+      "is_eligible_for_american_opportunity_credit": {
+        "2023": false
+      },
+      "is_enrolled_in_ccdf": {
+        "2023": false
+      },
+      "is_father": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_full_time_college_student": {
+        "2023": false
+      },
+      "is_full_time_student": {
+        "2023": true
+      },
+      "is_fully_disabled_service_connected_veteran": {
+        "2023": false
+      },
+      "is_hispanic": {
+        "2023": false
+      },
+      "is_in_k12_nonpublic_school": {
+        "2023": false
+      },
+      "is_in_k12_school": {
+        "2023": true
+      },
+      "is_in_medicaid_medically_needy_category": {
+        "2023": false
+      },
+      "is_infant_for_medicaid": {
+        "2023": false
+      },
+      "is_infant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_infant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_medicaid_eligible": {
+        "2023": true
+      },
+      "is_medically_needy_for_medicaid": {
+        "2023": false
+      },
+      "is_mother": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_optional_senior_or_disabled_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_permanently_and_totally_disabled": {
+        "2023": false
+      },
+      "is_permanently_disabled_veteran": {
+        "2023": false
+      },
+      "is_person_demographic_tanf_eligible": {
+        "2023": true
+      },
+      "is_pregnant": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_pregnant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_retired": {
+        "2023": false
+      },
+      "is_self_employed": {
+        "2023": false
+      },
+      "is_senior": {
+        "2023": false
+      },
+      "is_severely_disabled": {
+        "2023": false
+      },
+      "is_ssi_aged": {
+        "2023": false
+      },
+      "is_ssi_aged_blind_disabled": {
+        "2023": false
+      },
+      "is_ssi_disabled": {
+        "2023": false
+      },
+      "is_ssi_eligible_individual": {
+        "2023": false
+      },
+      "is_ssi_eligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_ineligible_child": {
+        "2023": true
+      },
+      "is_ssi_ineligible_parent": {
+        "2023": false
+      },
+      "is_ssi_ineligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_recipient_for_medicaid": {
+        "2023": false
+      },
+      "is_surviving_child_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_surviving_spouse_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      },
+      "is_tax_unit_head": {
+        "2023": false
+      },
+      "is_tax_unit_spouse": {
+        "2023": false
+      },
+      "is_usda_disabled": {
+        "2023": false
+      },
+      "is_usda_elderly": {
+        "2023": false
+      },
+      "is_wa_adult": {
+        "2023": false
+      },
+      "is_wic_at_nutritional_risk": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_young_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "k1bx14": {
+        "2023": 0
+      },
+      "long_term_capital_gains": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_collectibles": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_small_business_stock": {
+        "2023": 0
+      },
+      "ma_covid_19_essential_employee_premium_pay_program": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "maximum_state_supplement": {
+        "2023": 0
+      },
+      "md_pension_subtraction_amount": {
+        "2023": 0
+      },
+      "md_socsec_subtraction_amount": {
+        "2023": 0
+      },
+      "medicaid": {
+        "2023": 27358.121
+      },
+      "medicaid_benefit_value": {
+        "2023": 27358.121
+      },
+      "medicaid_category": {
+        "2023": "OLDER_CHILD"
+      },
+      "medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "medical_expense": {
+        "2023": 0
+      },
+      "medical_out_of_pocket_expenses": {
+        "2023": 0
+      },
+      "meets_ssi_resource_test": {
+        "2023": true
+      },
+      "meets_wic_categorical_eligibility": {
+        "2023": true
+      },
+      "military_basic_pay": {
+        "2023": 0
+      },
+      "military_retirement_pay": {
+        "2023": 0
+      },
+      "military_service_income": {
+        "2023": 0
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "mo_adjusted_gross_income": {
+        "2023": 0
+      },
+      "mo_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mo_income_tax_exempt": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_a": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_b": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_c": {
+        "2023": 0
+      },
+      "mo_qualified_health_insurance_premiums": {
+        "2023": 0
+      },
+      "mo_taxable_income": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "never_eligible_for_social_security_benefits": {
+        "2023": false
+      },
+      "nj_agi_additions": {
+        "2023": 0
+      },
+      "nj_agi_subtractions": {
+        "2023": 0
+      },
+      "nj_eligible_pension_income": {
+        "2023": 0
+      },
+      "nj_total_income": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible_child": {
+        "2023": false
+      },
+      "non_public_school_tuition": {
+        "2023": 0
+      },
+      "non_qualified_dividend_income": {
+        "2023": 0
+      },
+      "non_sch_d_capital_gains": {
+        "2023": 0
+      },
+      "oh_has_not_taken_oh_lump_sum_credits": {
+        "2023": false
+      },
+      "or_retirement_credit_eligible": {
+        "2023": false
+      },
+      "own_children_in_household": {
+        "2023": 0
+      },
+      "pa_nontaxable_pension_income": {
+        "2023": 0
+      },
+      "partnership_s_corp_income": {
+        "2023": 0
+      },
+      "payroll_tax_gross_wages": {
+        "2023": 0
+      },
+      "pell_grant": {
+        "2023": 0
+      },
+      "pell_grant_countable_assets": {
+        "2023": 0
+      },
+      "pell_grant_dependent_allowances": {
+        "2023": 7040
+      },
+      "pell_grant_dependent_available_income": {
+        "2023": 0
+      },
+      "pell_grant_dependent_contribution": {
+        "2023": -3520
+      },
+      "pell_grant_dependent_other_allowances": {
+        "2023": 0
+      },
+      "pell_grant_efc": {
+        "2023": 0
+      },
+      "pell_grant_formula": {
+        "2023": "A"
+      },
+      "pell_grant_head_allowances": {
+        "2023": 0
+      },
+      "pell_grant_head_available_income": {
+        "2023": 0
+      },
+      "pell_grant_head_contribution": {
+        "2023": 0
+      },
+      "pell_grant_months_in_school": {
+        "2023": 0
+      },
+      "pell_grant_simplified_formula_applies": {
+        "2023": true
+      },
+      "pencon": {
+        "2023": 0
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "pension_survivors": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "per_vehicle_payment": {
+        "2023": 0
+      },
+      "person_family_id": {
+        "2023": 0
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_id": {
+        "2023": 4
+      },
+      "person_in_poverty": {
+        "2023": false
+      },
+      "person_marital_unit_id": {
+        "2023": 0
+      },
+      "person_spm_unit_id": {
+        "2023": 0
+      },
+      "person_tax_unit_id": {
+        "2023": 0
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "private_pension_income": {
+        "2023": 0
+      },
+      "public_pension_income": {
+        "2023": 0
+      },
+      "qbid_amount": {
+        "2023": 0
+      },
+      "qualified_adoption_assistance_expense": {
+        "2023": 0
+      },
+      "qualified_business_income": {
+        "2023": 0
+      },
+      "qualified_dividend_income": {
+        "2023": 0
+      },
+      "qualified_tuition_expenses": {
+        "2023": 0
+      },
+      "qualifies_for_elderly_or_disabled_credit": {
+        "2023": false
+      },
+      "race": {
+        "2023": "OTHER"
+      },
+      "real_estate_taxes": {
+        "2023": 0
+      },
+      "receives_or_needs_protective_services": {
+        "2023": false
+      },
+      "receives_wic": {
+        "2023": false
+      },
+      "rent": {
+        "2023": 0
+      },
+      "rental_income": {
+        "2023": 0
+      },
+      "retired_on_total_disability": {
+        "2023": false
+      },
+      "salt_refund_income": {
+        "2023": 0
+      },
+      "sc_gross_earned_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald_person": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_premiums": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald_person": {
+        "2023": 0
+      },
+      "self_employed_pension_contributions": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "self_employment_medicare_tax": {
+        "2023": 0
+      },
+      "self_employment_social_security_tax": {
+        "2023": 0
+      },
+      "self_employment_tax": {
+        "2023": 0
+      },
+      "self_employment_tax_ald_person": {
+        "2023": 0
+      },
+      "sep_simple_qualified_plan_contributions": {
+        "2023": 0
+      },
+      "sey": {
+        "2023": 0
+      },
+      "short_term_capital_gains": {
+        "2023": 0
+      },
+      "social_security": {
+        "2023": 0
+      },
+      "social_security_dependents": {
+        "2023": 0
+      },
+      "social_security_disability": {
+        "2023": 0
+      },
+      "social_security_retirement": {
+        "2023": 0
+      },
+      "social_security_survivors": {
+        "2023": 0
+      },
+      "social_security_taxable_self_employment_income": {
+        "2023": 0
+      },
+      "ssi": {
+        "2023": 0
+      },
+      "ssi_amount_if_eligible": {
+        "2023": 10968
+      },
+      "ssi_category": {
+        "2023": "NONE"
+      },
+      "ssi_claim_is_joint": {
+        "2023": false
+      },
+      "ssi_countable_income": {
+        "2023": 0
+      },
+      "ssi_countable_resources": {
+        "2023": 0
+      },
+      "ssi_earned_income": {
+        "2023": 0
+      },
+      "ssi_earned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_ineligible_child_allocation": {
+        "2023": 5484
+      },
+      "ssi_ineligible_parent_allocation": {
+        "2023": 0
+      },
+      "ssi_reported": {
+        "2023": 0
+      },
+      "ssi_unearned_income": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_parent": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "state_or_federal_salary": {
+        "2023": 0
+      },
+      "state_supplement": {
+        "2023": 0
+      },
+      "strike_benefits": {
+        "2023": 0
+      },
+      "student_loan_interest": {
+        "2023": 0
+      },
+      "tanf_person": {
+        "2023": 0
+      },
+      "tanf_reported": {
+        "2023": 0
+      },
+      "tax_exempt_interest_income": {
+        "2023": 0
+      },
+      "tax_exempt_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_private_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_public_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_unemployment_compensation": {
+        "2023": 0
+      },
+      "taxable_earnings_for_social_security": {
+        "2023": 0
+      },
+      "taxable_federal_pension_income": {
+        "2023": 0
+      },
+      "taxable_interest_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_private_pension_income": {
+        "2023": 0
+      },
+      "taxable_public_pension_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security": {
+        "2023": 0
+      },
+      "taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "total_disability_payments": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "unadjusted_basis_qualified_property": {
+        "2023": 0
+      },
+      "uncapped_ssi": {
+        "2023": 0
+      },
+      "under_12_months_postpartum": {
+        "2023": false
+      },
+      "under_60_days_postpartum": {
+        "2023": false
+      },
+      "unemployment_compensation": {
+        "2023": 0
+      },
+      "us_bonds_for_higher_ed": {
+        "2023": 0
+      },
+      "vehicles_owned": {
+        "2023": 0
+      },
+      "veterans_benefits": {
+        "2023": 0
+      },
+      "w2_wages_from_qualified_business": {
+        "2023": 0
+      },
+      "wic": {
+        "2023": 0
+      },
+      "wic_category": {
+        "2023": "NONE"
+      },
+      "wic_category_str": {
+        "2023": "NONE"
+      },
+      "workers_compensation": {
+        "2023": 0
+      },
+      "would_claim_wic": {
+        "2023": true
+      }
+    },
+    "your partner": {
+      "adjusted_gross_income_person": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 2
+      },
+      "age": {
+        "2023": 40
+      },
+      "age_group": {
+        "2023": "WORKING_AGE"
+      },
+      "alimony_expense": {
+        "2023": 0
+      },
+      "alimony_income": {
+        "2023": 0
+      },
+      "assessed_property_value": {
+        "2023": 0
+      },
+      "business_is_qualified": {
+        "2023": false
+      },
+      "business_is_sstb": {
+        "2023": false
+      },
+      "ca_cvrp": {
+        "2023": 0
+      },
+      "ca_cvrp_vehicle_rebate_amount": {
+        "2023": 0
+      },
+      "ca_is_qualifying_child_for_caleitc": {
+        "2023": false
+      },
+      "capital_gains": {
+        "2023": 0
+      },
+      "capital_losses": {
+        "2023": 0
+      },
+      "casualty_loss": {
+        "2023": 0
+      },
+      "ccdf_age_group": {
+        "2023": "INFANT"
+      },
+      "ccdf_duration_of_care": {
+        "2023": "HOURLY"
+      },
+      "ccdf_market_rate": {
+        "2023": 0
+      },
+      "cdcc_qualified_dependent": {
+        "2023": false
+      },
+      "charitable_cash_donations": {
+        "2023": 0
+      },
+      "charitable_non_cash_donations": {
+        "2023": 0
+      },
+      "child_support_expense": {
+        "2023": 0
+      },
+      "child_support_received": {
+        "2023": 0
+      },
+      "childcare_days_per_week": {
+        "2023": 0
+      },
+      "childcare_hours_per_day": {
+        "2023": 0
+      },
+      "childcare_hours_per_week": {
+        "2023": 0
+      },
+      "childcare_provider_type_group": {
+        "2023": "DCC_SACC"
+      },
+      "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+        "2023": false
+      },
+      "cliff_evaluated": {
+        "2023": false
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "cmbtp": {
+        "2023": 0
+      },
+      "co_oap": {
+        "2023": 0
+      },
+      "co_oap_eligible": {
+        "2023": false
+      },
+      "co_pension_subtraction_indv": {
+        "2023": 0
+      },
+      "co_pension_subtraction_indv_eligible": {
+        "2023": false
+      },
+      "co_social_security_subtraction_indv": {
+        "2023": 0
+      },
+      "co_social_security_subtraction_indv_eligible": {
+        "2023": 0
+      },
+      "co_state_supplement": {
+        "2023": 0
+      },
+      "co_state_supplement_eligible": {
+        "2023": false
+      },
+      "cost_of_attending_college": {
+        "2023": 0
+      },
+      "count_days_postpartum": {
+        "2023": "Infinity"
+      },
+      "cps_race": {
+        "2023": 0
+      },
+      "ctc_adult_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum_arpa": {
+        "2023": 0
+      },
+      "ctc_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_qualifying_child": {
+        "2023": false
+      },
+      "dc_agi": {
+        "2023": 0
+      },
+      "dc_deduction_indiv": {
+        "2023": 0
+      },
+      "dc_disabled_exclusion_subtraction": {
+        "2023": 0
+      },
+      "dc_income_additions": {
+        "2023": 0
+      },
+      "dc_income_subtractions": {
+        "2023": 0
+      },
+      "dc_self_employment_loss_addition": {
+        "2023": 0
+      },
+      "dc_taxable_income_indiv": {
+        "2023": 0
+      },
+      "debt_relief": {
+        "2023": 0
+      },
+      "disability_benefits": {
+        "2023": 0
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "e00200": {
+        "2023": 0
+      },
+      "e00300": {
+        "2023": 0
+      },
+      "e02300": {
+        "2023": 0
+      },
+      "e02400": {
+        "2023": 0
+      },
+      "e87530": {
+        "2023": 0
+      },
+      "early_withdrawal_penalty": {
+        "2023": 0
+      },
+      "earned": {
+        "2023": 0
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "educator_expense": {
+        "2023": 0
+      },
+      "employee_medicare_tax": {
+        "2023": 0
+      },
+      "employee_social_security_tax": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "farm_income": {
+        "2023": 0
+      },
+      "farm_rent_income": {
+        "2023": 0
+      },
+      "general_assistance": {
+        "2023": 0
+      },
+      "gi_cash_assistance": {
+        "2023": 0
+      },
+      "has_disabled_spouse": {
+        "2023": false
+      },
+      "has_marketplace_health_coverage": {
+        "2023": true
+      },
+      "health_insurance_premiums": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_child_receiving_public_support": {
+        "2023": false
+      },
+      "ia_alternate_tax_indiv": {
+        "2023": 0
+      },
+      "ia_alternate_tax_joint": {
+        "2023": 0
+      },
+      "ia_amt_indiv": {
+        "2023": 0
+      },
+      "ia_amt_joint": {
+        "2023": 0
+      },
+      "ia_base_tax_indiv": {
+        "2023": 0
+      },
+      "ia_base_tax_joint": {
+        "2023": 0
+      },
+      "ia_basic_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_basic_deduction_joint": {
+        "2023": 0
+      },
+      "ia_fedtax_deduction": {
+        "2023": 0
+      },
+      "ia_gross_income": {
+        "2023": 0
+      },
+      "ia_income_adjustments": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_indiv": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_joint": {
+        "2023": 0
+      },
+      "ia_net_income": {
+        "2023": 0
+      },
+      "ia_pension_exclusion": {
+        "2023": 0
+      },
+      "ia_prorate_fraction": {
+        "2023": 0
+      },
+      "ia_qbi_deduction": {
+        "2023": 0
+      },
+      "ia_regular_tax_indiv": {
+        "2023": 0
+      },
+      "ia_regular_tax_joint": {
+        "2023": 0
+      },
+      "ia_standard_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_standard_deduction_joint": {
+        "2023": 0
+      },
+      "ia_taxable_income_indiv": {
+        "2023": 0
+      },
+      "ia_taxable_income_joint": {
+        "2023": 0
+      },
+      "illicit_income": {
+        "2023": 0
+      },
+      "in_is_qualifying_dependent_child": {
+        "2023": false
+      },
+      "incapable_of_self_care": {
+        "2023": false
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "interest_expense": {
+        "2023": 0
+      },
+      "interest_income": {
+        "2023": 0
+      },
+      "ira_contributions": {
+        "2023": 0
+      },
+      "irs_gross_income": {
+        "2023": 0
+      },
+      "is_adult": {
+        "2023": true
+      },
+      "is_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_breastfeeding": {
+        "2023": false
+      },
+      "is_ca_cvrp_increased_rebate_eligible": {
+        "2023": false
+      },
+      "is_ca_cvrp_normal_rebate_eligible": {
+        "2023": false
+      },
+      "is_ccdf_age_eligible": {
+        "2023": false
+      },
+      "is_ccdf_eligible": {
+        "2023": false
+      },
+      "is_ccdf_home_based": {
+        "2023": false
+      },
+      "is_ccdf_reason_for_care_eligible": {
+        "2023": false
+      },
+      "is_cdcc_eligible": {
+        "2023": false
+      },
+      "is_child": {
+        "2023": false
+      },
+      "is_child_of_tax_head": {
+        "2023": false
+      },
+      "is_citizen": {
+        "2023": false
+      },
+      "is_disabled": {
+        "2023": false
+      },
+      "is_eitc_qualifying_child": {
+        "2023": false
+      },
+      "is_eligible_for_american_opportunity_credit": {
+        "2023": false
+      },
+      "is_enrolled_in_ccdf": {
+        "2023": false
+      },
+      "is_father": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_full_time_college_student": {
+        "2023": false
+      },
+      "is_full_time_student": {
+        "2023": false
+      },
+      "is_fully_disabled_service_connected_veteran": {
+        "2023": false
+      },
+      "is_hispanic": {
+        "2023": false
+      },
+      "is_in_k12_nonpublic_school": {
+        "2023": false
+      },
+      "is_in_k12_school": {
+        "2023": false
+      },
+      "is_in_medicaid_medically_needy_category": {
+        "2023": false
+      },
+      "is_infant_for_medicaid": {
+        "2023": false
+      },
+      "is_infant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_infant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_medicaid_eligible": {
+        "2023": false
+      },
+      "is_medically_needy_for_medicaid": {
+        "2023": false
+      },
+      "is_mother": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_optional_senior_or_disabled_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_permanently_and_totally_disabled": {
+        "2023": false
+      },
+      "is_permanently_disabled_veteran": {
+        "2023": false
+      },
+      "is_person_demographic_tanf_eligible": {
+        "2023": false
+      },
+      "is_pregnant": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_pregnant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_retired": {
+        "2023": false
+      },
+      "is_self_employed": {
+        "2023": false
+      },
+      "is_senior": {
+        "2023": false
+      },
+      "is_severely_disabled": {
+        "2023": false
+      },
+      "is_ssi_aged": {
+        "2023": false
+      },
+      "is_ssi_aged_blind_disabled": {
+        "2023": false
+      },
+      "is_ssi_disabled": {
+        "2023": false
+      },
+      "is_ssi_eligible_individual": {
+        "2023": false
+      },
+      "is_ssi_eligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_ineligible_child": {
+        "2023": false
+      },
+      "is_ssi_ineligible_parent": {
+        "2023": false
+      },
+      "is_ssi_ineligible_spouse": {
+        "2023": true
+      },
+      "is_ssi_recipient_for_medicaid": {
+        "2023": false
+      },
+      "is_surviving_child_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_surviving_spouse_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_tax_unit_dependent": {
+        "2023": false
+      },
+      "is_tax_unit_head": {
+        "2023": false
+      },
+      "is_tax_unit_spouse": {
+        "2023": true
+      },
+      "is_usda_disabled": {
+        "2023": false
+      },
+      "is_usda_elderly": {
+        "2023": false
+      },
+      "is_wa_adult": {
+        "2023": true
+      },
+      "is_wic_at_nutritional_risk": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_young_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "k1bx14": {
+        "2023": 0
+      },
+      "long_term_capital_gains": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_collectibles": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_small_business_stock": {
+        "2023": 0
+      },
+      "ma_covid_19_essential_employee_premium_pay_program": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "maximum_state_supplement": {
+        "2023": 0
+      },
+      "md_pension_subtraction_amount": {
+        "2023": 0
+      },
+      "md_socsec_subtraction_amount": {
+        "2023": 0
+      },
+      "medicaid": {
+        "2023": 0
+      },
+      "medicaid_benefit_value": {
+        "2023": 27358.121
+      },
+      "medicaid_category": {
+        "2023": "NONE"
+      },
+      "medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "medical_expense": {
+        "2023": 0
+      },
+      "medical_out_of_pocket_expenses": {
+        "2023": 0
+      },
+      "meets_ssi_resource_test": {
+        "2023": true
+      },
+      "meets_wic_categorical_eligibility": {
+        "2023": true
+      },
+      "military_basic_pay": {
+        "2023": 0
+      },
+      "military_retirement_pay": {
+        "2023": 0
+      },
+      "military_service_income": {
+        "2023": 0
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "mo_adjusted_gross_income": {
+        "2023": 0
+      },
+      "mo_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mo_income_tax_exempt": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_a": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_b": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_c": {
+        "2023": 0
+      },
+      "mo_qualified_health_insurance_premiums": {
+        "2023": 0
+      },
+      "mo_taxable_income": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "never_eligible_for_social_security_benefits": {
+        "2023": false
+      },
+      "nj_agi_additions": {
+        "2023": 0
+      },
+      "nj_agi_subtractions": {
+        "2023": 0
+      },
+      "nj_eligible_pension_income": {
+        "2023": 0
+      },
+      "nj_total_income": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible_child": {
+        "2023": false
+      },
+      "non_public_school_tuition": {
+        "2023": 0
+      },
+      "non_qualified_dividend_income": {
+        "2023": 0
+      },
+      "non_sch_d_capital_gains": {
+        "2023": 0
+      },
+      "oh_has_not_taken_oh_lump_sum_credits": {
+        "2023": false
+      },
+      "or_retirement_credit_eligible": {
+        "2023": false
+      },
+      "own_children_in_household": {
+        "2023": 0
+      },
+      "pa_nontaxable_pension_income": {
+        "2023": 0
+      },
+      "partnership_s_corp_income": {
+        "2023": 0
+      },
+      "payroll_tax_gross_wages": {
+        "2023": 0
+      },
+      "pell_grant": {
+        "2023": 0
+      },
+      "pell_grant_countable_assets": {
+        "2023": 0
+      },
+      "pell_grant_dependent_allowances": {
+        "2023": 7040
+      },
+      "pell_grant_dependent_available_income": {
+        "2023": 0
+      },
+      "pell_grant_dependent_contribution": {
+        "2023": -3520
+      },
+      "pell_grant_dependent_other_allowances": {
+        "2023": 0
+      },
+      "pell_grant_efc": {
+        "2023": 0
+      },
+      "pell_grant_formula": {
+        "2023": "C"
+      },
+      "pell_grant_head_allowances": {
+        "2023": 0
+      },
+      "pell_grant_head_available_income": {
+        "2023": 0
+      },
+      "pell_grant_head_contribution": {
+        "2023": 0
+      },
+      "pell_grant_months_in_school": {
+        "2023": 0
+      },
+      "pell_grant_simplified_formula_applies": {
+        "2023": true
+      },
+      "pencon": {
+        "2023": 0
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "pension_survivors": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "per_vehicle_payment": {
+        "2023": 0
+      },
+      "person_family_id": {
+        "2023": 0
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_id": {
+        "2023": 1
+      },
+      "person_in_poverty": {
+        "2023": false
+      },
+      "person_marital_unit_id": {
+        "2023": 0
+      },
+      "person_spm_unit_id": {
+        "2023": 0
+      },
+      "person_tax_unit_id": {
+        "2023": 0
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "private_pension_income": {
+        "2023": 0
+      },
+      "public_pension_income": {
+        "2023": 0
+      },
+      "qbid_amount": {
+        "2023": 0
+      },
+      "qualified_adoption_assistance_expense": {
+        "2023": 0
+      },
+      "qualified_business_income": {
+        "2023": 0
+      },
+      "qualified_dividend_income": {
+        "2023": 0
+      },
+      "qualified_tuition_expenses": {
+        "2023": 0
+      },
+      "qualifies_for_elderly_or_disabled_credit": {
+        "2023": false
+      },
+      "race": {
+        "2023": "OTHER"
+      },
+      "real_estate_taxes": {
+        "2023": 0
+      },
+      "receives_or_needs_protective_services": {
+        "2023": false
+      },
+      "receives_wic": {
+        "2023": false
+      },
+      "rent": {
+        "2023": 0
+      },
+      "rental_income": {
+        "2023": 0
+      },
+      "retired_on_total_disability": {
+        "2023": false
+      },
+      "salt_refund_income": {
+        "2023": 0
+      },
+      "sc_gross_earned_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald_person": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_premiums": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald_person": {
+        "2023": 0
+      },
+      "self_employed_pension_contributions": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "self_employment_medicare_tax": {
+        "2023": 0
+      },
+      "self_employment_social_security_tax": {
+        "2023": 0
+      },
+      "self_employment_tax": {
+        "2023": 0
+      },
+      "self_employment_tax_ald_person": {
+        "2023": 0
+      },
+      "sep_simple_qualified_plan_contributions": {
+        "2023": 0
+      },
+      "sey": {
+        "2023": 0
+      },
+      "short_term_capital_gains": {
+        "2023": 0
+      },
+      "social_security": {
+        "2023": 0
+      },
+      "social_security_dependents": {
+        "2023": 0
+      },
+      "social_security_disability": {
+        "2023": 0
+      },
+      "social_security_retirement": {
+        "2023": 0
+      },
+      "social_security_survivors": {
+        "2023": 0
+      },
+      "social_security_taxable_self_employment_income": {
+        "2023": 0
+      },
+      "ssi": {
+        "2023": 0
+      },
+      "ssi_amount_if_eligible": {
+        "2023": 10968
+      },
+      "ssi_category": {
+        "2023": "NONE"
+      },
+      "ssi_claim_is_joint": {
+        "2023": false
+      },
+      "ssi_countable_income": {
+        "2023": 0
+      },
+      "ssi_countable_resources": {
+        "2023": 0
+      },
+      "ssi_earned_income": {
+        "2023": 0
+      },
+      "ssi_earned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_ineligible_child_allocation": {
+        "2023": 0
+      },
+      "ssi_ineligible_parent_allocation": {
+        "2023": 0
+      },
+      "ssi_reported": {
+        "2023": 0
+      },
+      "ssi_unearned_income": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_parent": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "state_or_federal_salary": {
+        "2023": 0
+      },
+      "state_supplement": {
+        "2023": 0
+      },
+      "strike_benefits": {
+        "2023": 0
+      },
+      "student_loan_interest": {
+        "2023": 0
+      },
+      "tanf_person": {
+        "2023": 0
+      },
+      "tanf_reported": {
+        "2023": 0
+      },
+      "tax_exempt_interest_income": {
+        "2023": 0
+      },
+      "tax_exempt_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_private_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_public_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_unemployment_compensation": {
+        "2023": 0
+      },
+      "taxable_earnings_for_social_security": {
+        "2023": 0
+      },
+      "taxable_federal_pension_income": {
+        "2023": 0
+      },
+      "taxable_interest_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_private_pension_income": {
+        "2023": 0
+      },
+      "taxable_public_pension_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security": {
+        "2023": 0
+      },
+      "taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "total_disability_payments": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "unadjusted_basis_qualified_property": {
+        "2023": 0
+      },
+      "uncapped_ssi": {
+        "2023": 0
+      },
+      "under_12_months_postpartum": {
+        "2023": false
+      },
+      "under_60_days_postpartum": {
+        "2023": false
+      },
+      "unemployment_compensation": {
+        "2023": 0
+      },
+      "us_bonds_for_higher_ed": {
+        "2023": 0
+      },
+      "vehicles_owned": {
+        "2023": 0
+      },
+      "veterans_benefits": {
+        "2023": 0
+      },
+      "w2_wages_from_qualified_business": {
+        "2023": 0
+      },
+      "wic": {
+        "2023": 0
+      },
+      "wic_category": {
+        "2023": "NONE"
+      },
+      "wic_category_str": {
+        "2023": "NONE"
+      },
+      "workers_compensation": {
+        "2023": 0
+      },
+      "would_claim_wic": {
+        "2023": true
+      }
+    },
+    "your second dependent": {
+      "adjusted_gross_income_person": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_group": {
+        "2023": "CHILD"
+      },
+      "alimony_expense": {
+        "2023": 0
+      },
+      "alimony_income": {
+        "2023": 0
+      },
+      "assessed_property_value": {
+        "2023": 0
+      },
+      "business_is_qualified": {
+        "2023": false
+      },
+      "business_is_sstb": {
+        "2023": false
+      },
+      "ca_cvrp": {
+        "2023": 0
+      },
+      "ca_cvrp_vehicle_rebate_amount": {
+        "2023": 0
+      },
+      "ca_is_qualifying_child_for_caleitc": {
+        "2023": true
+      },
+      "capital_gains": {
+        "2023": 0
+      },
+      "capital_losses": {
+        "2023": 0
+      },
+      "casualty_loss": {
+        "2023": 0
+      },
+      "ccdf_age_group": {
+        "2023": "SCHOOL_AGE"
+      },
+      "ccdf_duration_of_care": {
+        "2023": "HOURLY"
+      },
+      "ccdf_market_rate": {
+        "2023": 0
+      },
+      "cdcc_qualified_dependent": {
+        "2023": true
+      },
+      "charitable_cash_donations": {
+        "2023": 0
+      },
+      "charitable_non_cash_donations": {
+        "2023": 0
+      },
+      "child_support_expense": {
+        "2023": 0
+      },
+      "child_support_received": {
+        "2023": 0
+      },
+      "childcare_days_per_week": {
+        "2023": 0
+      },
+      "childcare_hours_per_day": {
+        "2023": 0
+      },
+      "childcare_hours_per_week": {
+        "2023": 0
+      },
+      "childcare_provider_type_group": {
+        "2023": "DCC_SACC"
+      },
+      "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+        "2023": false
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "cmbtp": {
+        "2023": 0
+      },
+      "co_oap": {
+        "2023": 0
+      },
+      "co_oap_eligible": {
+        "2023": false
+      },
+      "co_pension_subtraction_indv": {
+        "2023": 0
+      },
+      "co_pension_subtraction_indv_eligible": {
+        "2023": false
+      },
+      "co_social_security_subtraction_indv": {
+        "2023": 0
+      },
+      "co_social_security_subtraction_indv_eligible": {
+        "2023": 0
+      },
+      "co_state_supplement": {
+        "2023": 0
+      },
+      "co_state_supplement_eligible": {
+        "2023": false
+      },
+      "cost_of_attending_college": {
+        "2023": 0
+      },
+      "count_days_postpartum": {
+        "2023": "Infinity"
+      },
+      "cps_race": {
+        "2023": 0
+      },
+      "ctc_adult_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_child_individual_maximum_arpa": {
+        "2023": 0
+      },
+      "ctc_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_qualifying_child": {
+        "2023": true
+      },
+      "dc_agi": {
+        "2023": 0
+      },
+      "dc_deduction_indiv": {
+        "2023": 0
+      },
+      "dc_disabled_exclusion_subtraction": {
+        "2023": 0
+      },
+      "dc_income_additions": {
+        "2023": 0
+      },
+      "dc_income_subtractions": {
+        "2023": 0
+      },
+      "dc_self_employment_loss_addition": {
+        "2023": 0
+      },
+      "dc_taxable_income_indiv": {
+        "2023": 0
+      },
+      "debt_relief": {
+        "2023": 0
+      },
+      "disability_benefits": {
+        "2023": 0
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "e00200": {
+        "2023": 0
+      },
+      "e00300": {
+        "2023": 0
+      },
+      "e02300": {
+        "2023": 0
+      },
+      "e02400": {
+        "2023": 0
+      },
+      "e87530": {
+        "2023": 0
+      },
+      "early_withdrawal_penalty": {
+        "2023": 0
+      },
+      "earned": {
+        "2023": 0
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "educator_expense": {
+        "2023": 0
+      },
+      "employee_medicare_tax": {
+        "2023": 0
+      },
+      "employee_social_security_tax": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "farm_income": {
+        "2023": 0
+      },
+      "farm_rent_income": {
+        "2023": 0
+      },
+      "general_assistance": {
+        "2023": 0
+      },
+      "gi_cash_assistance": {
+        "2023": 0
+      },
+      "has_disabled_spouse": {
+        "2023": false
+      },
+      "has_marketplace_health_coverage": {
+        "2023": true
+      },
+      "health_insurance_premiums": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_child_receiving_public_support": {
+        "2023": false
+      },
+      "ia_alternate_tax_indiv": {
+        "2023": 0
+      },
+      "ia_alternate_tax_joint": {
+        "2023": 0
+      },
+      "ia_amt_indiv": {
+        "2023": 0
+      },
+      "ia_amt_joint": {
+        "2023": 0
+      },
+      "ia_base_tax_indiv": {
+        "2023": 0
+      },
+      "ia_base_tax_joint": {
+        "2023": 0
+      },
+      "ia_basic_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_basic_deduction_joint": {
+        "2023": 0
+      },
+      "ia_fedtax_deduction": {
+        "2023": 0
+      },
+      "ia_gross_income": {
+        "2023": 0
+      },
+      "ia_income_adjustments": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_indiv": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_joint": {
+        "2023": 0
+      },
+      "ia_net_income": {
+        "2023": 0
+      },
+      "ia_pension_exclusion": {
+        "2023": 0
+      },
+      "ia_prorate_fraction": {
+        "2023": 0
+      },
+      "ia_qbi_deduction": {
+        "2023": 0
+      },
+      "ia_regular_tax_indiv": {
+        "2023": 0
+      },
+      "ia_regular_tax_joint": {
+        "2023": 0
+      },
+      "ia_standard_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_standard_deduction_joint": {
+        "2023": 0
+      },
+      "ia_taxable_income_indiv": {
+        "2023": 0
+      },
+      "ia_taxable_income_joint": {
+        "2023": 0
+      },
+      "illicit_income": {
+        "2023": 0
+      },
+      "in_is_qualifying_dependent_child": {
+        "2023": false
+      },
+      "incapable_of_self_care": {
+        "2023": false
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "interest_expense": {
+        "2023": 0
+      },
+      "interest_income": {
+        "2023": 0
+      },
+      "ira_contributions": {
+        "2023": 0
+      },
+      "irs_gross_income": {
+        "2023": 0
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_breastfeeding": {
+        "2023": false
+      },
+      "is_ca_cvrp_increased_rebate_eligible": {
+        "2023": false
+      },
+      "is_ca_cvrp_normal_rebate_eligible": {
+        "2023": false
+      },
+      "is_ccdf_age_eligible": {
+        "2023": true
+      },
+      "is_ccdf_eligible": {
+        "2023": false
+      },
+      "is_ccdf_home_based": {
+        "2023": false
+      },
+      "is_ccdf_reason_for_care_eligible": {
+        "2023": false
+      },
+      "is_cdcc_eligible": {
+        "2023": true
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_of_tax_head": {
+        "2023": true
+      },
+      "is_citizen": {
+        "2023": false
+      },
+      "is_disabled": {
+        "2023": false
+      },
+      "is_eitc_qualifying_child": {
+        "2023": true
+      },
+      "is_eligible_for_american_opportunity_credit": {
+        "2023": false
+      },
+      "is_enrolled_in_ccdf": {
+        "2023": false
+      },
+      "is_father": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_full_time_college_student": {
+        "2023": false
+      },
+      "is_full_time_student": {
+        "2023": true
+      },
+      "is_fully_disabled_service_connected_veteran": {
+        "2023": false
+      },
+      "is_hispanic": {
+        "2023": false
+      },
+      "is_in_k12_nonpublic_school": {
+        "2023": false
+      },
+      "is_in_k12_school": {
+        "2023": true
+      },
+      "is_in_medicaid_medically_needy_category": {
+        "2023": false
+      },
+      "is_infant_for_medicaid": {
+        "2023": false
+      },
+      "is_infant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_infant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_medicaid_eligible": {
+        "2023": true
+      },
+      "is_medically_needy_for_medicaid": {
+        "2023": false
+      },
+      "is_mother": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_optional_senior_or_disabled_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_permanently_and_totally_disabled": {
+        "2023": false
+      },
+      "is_permanently_disabled_veteran": {
+        "2023": false
+      },
+      "is_person_demographic_tanf_eligible": {
+        "2023": true
+      },
+      "is_pregnant": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_pregnant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_retired": {
+        "2023": false
+      },
+      "is_self_employed": {
+        "2023": false
+      },
+      "is_senior": {
+        "2023": false
+      },
+      "is_severely_disabled": {
+        "2023": false
+      },
+      "is_ssi_aged": {
+        "2023": false
+      },
+      "is_ssi_aged_blind_disabled": {
+        "2023": false
+      },
+      "is_ssi_disabled": {
+        "2023": false
+      },
+      "is_ssi_eligible_individual": {
+        "2023": false
+      },
+      "is_ssi_eligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_ineligible_child": {
+        "2023": true
+      },
+      "is_ssi_ineligible_parent": {
+        "2023": false
+      },
+      "is_ssi_ineligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_recipient_for_medicaid": {
+        "2023": false
+      },
+      "is_surviving_child_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_surviving_spouse_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      },
+      "is_tax_unit_head": {
+        "2023": false
+      },
+      "is_tax_unit_spouse": {
+        "2023": false
+      },
+      "is_usda_disabled": {
+        "2023": false
+      },
+      "is_usda_elderly": {
+        "2023": false
+      },
+      "is_wa_adult": {
+        "2023": false
+      },
+      "is_wic_at_nutritional_risk": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_young_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "k1bx14": {
+        "2023": 0
+      },
+      "long_term_capital_gains": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_collectibles": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_small_business_stock": {
+        "2023": 0
+      },
+      "ma_covid_19_essential_employee_premium_pay_program": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "maximum_state_supplement": {
+        "2023": 0
+      },
+      "md_pension_subtraction_amount": {
+        "2023": 0
+      },
+      "md_socsec_subtraction_amount": {
+        "2023": 0
+      },
+      "medicaid": {
+        "2023": 27358.121
+      },
+      "medicaid_benefit_value": {
+        "2023": 27358.121
+      },
+      "medicaid_category": {
+        "2023": "OLDER_CHILD"
+      },
+      "medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "medical_expense": {
+        "2023": 0
+      },
+      "medical_out_of_pocket_expenses": {
+        "2023": 0
+      },
+      "meets_ssi_resource_test": {
+        "2023": true
+      },
+      "meets_wic_categorical_eligibility": {
+        "2023": true
+      },
+      "military_basic_pay": {
+        "2023": 0
+      },
+      "military_retirement_pay": {
+        "2023": 0
+      },
+      "military_service_income": {
+        "2023": 0
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "mo_adjusted_gross_income": {
+        "2023": 0
+      },
+      "mo_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mo_income_tax_exempt": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_a": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_b": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_c": {
+        "2023": 0
+      },
+      "mo_qualified_health_insurance_premiums": {
+        "2023": 0
+      },
+      "mo_taxable_income": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "never_eligible_for_social_security_benefits": {
+        "2023": false
+      },
+      "nj_agi_additions": {
+        "2023": 0
+      },
+      "nj_agi_subtractions": {
+        "2023": 0
+      },
+      "nj_eligible_pension_income": {
+        "2023": 0
+      },
+      "nj_total_income": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible_child": {
+        "2023": false
+      },
+      "non_public_school_tuition": {
+        "2023": 0
+      },
+      "non_qualified_dividend_income": {
+        "2023": 0
+      },
+      "non_sch_d_capital_gains": {
+        "2023": 0
+      },
+      "oh_has_not_taken_oh_lump_sum_credits": {
+        "2023": false
+      },
+      "or_retirement_credit_eligible": {
+        "2023": false
+      },
+      "own_children_in_household": {
+        "2023": 0
+      },
+      "pa_nontaxable_pension_income": {
+        "2023": 0
+      },
+      "partnership_s_corp_income": {
+        "2023": 0
+      },
+      "payroll_tax_gross_wages": {
+        "2023": 0
+      },
+      "pell_grant": {
+        "2023": 0
+      },
+      "pell_grant_countable_assets": {
+        "2023": 0
+      },
+      "pell_grant_dependent_allowances": {
+        "2023": 7040
+      },
+      "pell_grant_dependent_available_income": {
+        "2023": 0
+      },
+      "pell_grant_dependent_contribution": {
+        "2023": -3520
+      },
+      "pell_grant_dependent_other_allowances": {
+        "2023": 0
+      },
+      "pell_grant_efc": {
+        "2023": 0
+      },
+      "pell_grant_formula": {
+        "2023": "A"
+      },
+      "pell_grant_head_allowances": {
+        "2023": 0
+      },
+      "pell_grant_head_available_income": {
+        "2023": 0
+      },
+      "pell_grant_head_contribution": {
+        "2023": 0
+      },
+      "pell_grant_months_in_school": {
+        "2023": 0
+      },
+      "pell_grant_simplified_formula_applies": {
+        "2023": true
+      },
+      "pencon": {
+        "2023": 0
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "pension_survivors": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "per_vehicle_payment": {
+        "2023": 0
+      },
+      "person_family_id": {
+        "2023": 0
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_id": {
+        "2023": 5
+      },
+      "person_in_poverty": {
+        "2023": false
+      },
+      "person_marital_unit_id": {
+        "2023": 0
+      },
+      "person_spm_unit_id": {
+        "2023": 0
+      },
+      "person_tax_unit_id": {
+        "2023": 0
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "private_pension_income": {
+        "2023": 0
+      },
+      "public_pension_income": {
+        "2023": 0
+      },
+      "qbid_amount": {
+        "2023": 0
+      },
+      "qualified_adoption_assistance_expense": {
+        "2023": 0
+      },
+      "qualified_business_income": {
+        "2023": 0
+      },
+      "qualified_dividend_income": {
+        "2023": 0
+      },
+      "qualified_tuition_expenses": {
+        "2023": 0
+      },
+      "qualifies_for_elderly_or_disabled_credit": {
+        "2023": false
+      },
+      "race": {
+        "2023": "OTHER"
+      },
+      "real_estate_taxes": {
+        "2023": 0
+      },
+      "receives_or_needs_protective_services": {
+        "2023": false
+      },
+      "receives_wic": {
+        "2023": false
+      },
+      "rent": {
+        "2023": 0
+      },
+      "rental_income": {
+        "2023": 0
+      },
+      "retired_on_total_disability": {
+        "2023": false
+      },
+      "salt_refund_income": {
+        "2023": 0
+      },
+      "sc_gross_earned_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald_person": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_premiums": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald_person": {
+        "2023": 0
+      },
+      "self_employed_pension_contributions": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "self_employment_medicare_tax": {
+        "2023": 0
+      },
+      "self_employment_social_security_tax": {
+        "2023": 0
+      },
+      "self_employment_tax": {
+        "2023": 0
+      },
+      "self_employment_tax_ald_person": {
+        "2023": 0
+      },
+      "sep_simple_qualified_plan_contributions": {
+        "2023": 0
+      },
+      "sey": {
+        "2023": 0
+      },
+      "short_term_capital_gains": {
+        "2023": 0
+      },
+      "social_security": {
+        "2023": 0
+      },
+      "social_security_dependents": {
+        "2023": 0
+      },
+      "social_security_disability": {
+        "2023": 0
+      },
+      "social_security_retirement": {
+        "2023": 0
+      },
+      "social_security_survivors": {
+        "2023": 0
+      },
+      "social_security_taxable_self_employment_income": {
+        "2023": 0
+      },
+      "ssi": {
+        "2023": 0
+      },
+      "ssi_amount_if_eligible": {
+        "2023": 10968
+      },
+      "ssi_category": {
+        "2023": "NONE"
+      },
+      "ssi_claim_is_joint": {
+        "2023": false
+      },
+      "ssi_countable_income": {
+        "2023": 0
+      },
+      "ssi_countable_resources": {
+        "2023": 0
+      },
+      "ssi_earned_income": {
+        "2023": 0
+      },
+      "ssi_earned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_ineligible_child_allocation": {
+        "2023": 5484
+      },
+      "ssi_ineligible_parent_allocation": {
+        "2023": 0
+      },
+      "ssi_reported": {
+        "2023": 0
+      },
+      "ssi_unearned_income": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_parent": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "state_or_federal_salary": {
+        "2023": 0
+      },
+      "state_supplement": {
+        "2023": 0
+      },
+      "strike_benefits": {
+        "2023": 0
+      },
+      "student_loan_interest": {
+        "2023": 0
+      },
+      "tanf_person": {
+        "2023": 0
+      },
+      "tanf_reported": {
+        "2023": 0
+      },
+      "tax_exempt_interest_income": {
+        "2023": 0
+      },
+      "tax_exempt_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_private_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_public_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_unemployment_compensation": {
+        "2023": 0
+      },
+      "taxable_earnings_for_social_security": {
+        "2023": 0
+      },
+      "taxable_federal_pension_income": {
+        "2023": 0
+      },
+      "taxable_interest_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_private_pension_income": {
+        "2023": 0
+      },
+      "taxable_public_pension_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security": {
+        "2023": 0
+      },
+      "taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "total_disability_payments": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "unadjusted_basis_qualified_property": {
+        "2023": 0
+      },
+      "uncapped_ssi": {
+        "2023": 0
+      },
+      "under_12_months_postpartum": {
+        "2023": false
+      },
+      "under_60_days_postpartum": {
+        "2023": false
+      },
+      "unemployment_compensation": {
+        "2023": 0
+      },
+      "us_bonds_for_higher_ed": {
+        "2023": 0
+      },
+      "vehicles_owned": {
+        "2023": 0
+      },
+      "veterans_benefits": {
+        "2023": 0
+      },
+      "w2_wages_from_qualified_business": {
+        "2023": 0
+      },
+      "wic": {
+        "2023": 0
+      },
+      "wic_category": {
+        "2023": "NONE"
+      },
+      "wic_category_str": {
+        "2023": "NONE"
+      },
+      "workers_compensation": {
+        "2023": 0
+      },
+      "would_claim_wic": {
+        "2023": true
+      }
+    },
+    "your third dependent": {
+      "adjusted_gross_income_person": {
+        "2023": 0
+      },
+      "adult_index": {
+        "2023": 0
+      },
+      "age": {
+        "2023": 10
+      },
+      "age_group": {
+        "2023": "CHILD"
+      },
+      "alimony_expense": {
+        "2023": 0
+      },
+      "alimony_income": {
+        "2023": 0
+      },
+      "assessed_property_value": {
+        "2023": 0
+      },
+      "business_is_qualified": {
+        "2023": false
+      },
+      "business_is_sstb": {
+        "2023": false
+      },
+      "ca_cvrp": {
+        "2023": 0
+      },
+      "ca_cvrp_vehicle_rebate_amount": {
+        "2023": 0
+      },
+      "ca_is_qualifying_child_for_caleitc": {
+        "2023": true
+      },
+      "capital_gains": {
+        "2023": 0
+      },
+      "capital_losses": {
+        "2023": 0
+      },
+      "casualty_loss": {
+        "2023": 0
+      },
+      "ccdf_age_group": {
+        "2023": "SCHOOL_AGE"
+      },
+      "ccdf_duration_of_care": {
+        "2023": "HOURLY"
+      },
+      "ccdf_market_rate": {
+        "2023": 0
+      },
+      "cdcc_qualified_dependent": {
+        "2023": true
+      },
+      "charitable_cash_donations": {
+        "2023": 0
+      },
+      "charitable_non_cash_donations": {
+        "2023": 0
+      },
+      "child_support_expense": {
+        "2023": 0
+      },
+      "child_support_received": {
+        "2023": 0
+      },
+      "childcare_days_per_week": {
+        "2023": 0
+      },
+      "childcare_hours_per_day": {
+        "2023": 0
+      },
+      "childcare_hours_per_week": {
+        "2023": 0
+      },
+      "childcare_provider_type_group": {
+        "2023": "DCC_SACC"
+      },
+      "claimed_ma_covid_19_essential_employee_premium_pay_program_2020": {
+        "2023": false
+      },
+      "cliff_evaluated": {
+        "2023": true
+      },
+      "cliff_gap": {
+        "2023": 0
+      },
+      "cmbtp": {
+        "2023": 0
+      },
+      "co_oap": {
+        "2023": 0
+      },
+      "co_oap_eligible": {
+        "2023": false
+      },
+      "co_pension_subtraction_indv": {
+        "2023": 0
+      },
+      "co_pension_subtraction_indv_eligible": {
+        "2023": false
+      },
+      "co_social_security_subtraction_indv": {
+        "2023": 0
+      },
+      "co_social_security_subtraction_indv_eligible": {
+        "2023": 0
+      },
+      "co_state_supplement": {
+        "2023": 0
+      },
+      "co_state_supplement_eligible": {
+        "2023": false
+      },
+      "cost_of_attending_college": {
+        "2023": 0
+      },
+      "count_days_postpartum": {
+        "2023": "Infinity"
+      },
+      "cps_race": {
+        "2023": 0
+      },
+      "ctc_adult_individual_maximum": {
+        "2023": 0
+      },
+      "ctc_child_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_child_individual_maximum_arpa": {
+        "2023": 0
+      },
+      "ctc_individual_maximum": {
+        "2023": 2000
+      },
+      "ctc_qualifying_child": {
+        "2023": true
+      },
+      "dc_agi": {
+        "2023": 0
+      },
+      "dc_deduction_indiv": {
+        "2023": 0
+      },
+      "dc_disabled_exclusion_subtraction": {
+        "2023": 0
+      },
+      "dc_income_additions": {
+        "2023": 0
+      },
+      "dc_income_subtractions": {
+        "2023": 0
+      },
+      "dc_self_employment_loss_addition": {
+        "2023": 0
+      },
+      "dc_taxable_income_indiv": {
+        "2023": 0
+      },
+      "debt_relief": {
+        "2023": 0
+      },
+      "disability_benefits": {
+        "2023": 0
+      },
+      "dividend_income": {
+        "2023": 0
+      },
+      "e00200": {
+        "2023": 0
+      },
+      "e00300": {
+        "2023": 0
+      },
+      "e02300": {
+        "2023": 0
+      },
+      "e02400": {
+        "2023": 0
+      },
+      "e87530": {
+        "2023": 0
+      },
+      "early_withdrawal_penalty": {
+        "2023": 0
+      },
+      "earned": {
+        "2023": 0
+      },
+      "earned_income": {
+        "2023": 0
+      },
+      "educator_expense": {
+        "2023": 0
+      },
+      "employee_medicare_tax": {
+        "2023": 0
+      },
+      "employee_social_security_tax": {
+        "2023": 0
+      },
+      "employment_income": {
+        "2023": 0
+      },
+      "farm_income": {
+        "2023": 0
+      },
+      "farm_rent_income": {
+        "2023": 0
+      },
+      "general_assistance": {
+        "2023": 0
+      },
+      "gi_cash_assistance": {
+        "2023": 0
+      },
+      "has_disabled_spouse": {
+        "2023": false
+      },
+      "has_marketplace_health_coverage": {
+        "2023": true
+      },
+      "health_insurance_premiums": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_child_receiving_public_support": {
+        "2023": false
+      },
+      "ia_alternate_tax_indiv": {
+        "2023": 0
+      },
+      "ia_alternate_tax_joint": {
+        "2023": 0
+      },
+      "ia_amt_indiv": {
+        "2023": 0
+      },
+      "ia_amt_joint": {
+        "2023": 0
+      },
+      "ia_base_tax_indiv": {
+        "2023": 0
+      },
+      "ia_base_tax_joint": {
+        "2023": 0
+      },
+      "ia_basic_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_basic_deduction_joint": {
+        "2023": 0
+      },
+      "ia_fedtax_deduction": {
+        "2023": 0
+      },
+      "ia_gross_income": {
+        "2023": 0
+      },
+      "ia_income_adjustments": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_indiv": {
+        "2023": 0
+      },
+      "ia_itemized_deductions_joint": {
+        "2023": 0
+      },
+      "ia_net_income": {
+        "2023": 0
+      },
+      "ia_pension_exclusion": {
+        "2023": 0
+      },
+      "ia_prorate_fraction": {
+        "2023": 0
+      },
+      "ia_qbi_deduction": {
+        "2023": 0
+      },
+      "ia_regular_tax_indiv": {
+        "2023": 0
+      },
+      "ia_regular_tax_joint": {
+        "2023": 0
+      },
+      "ia_standard_deduction_indiv": {
+        "2023": 0
+      },
+      "ia_standard_deduction_joint": {
+        "2023": 0
+      },
+      "ia_taxable_income_indiv": {
+        "2023": 0
+      },
+      "ia_taxable_income_joint": {
+        "2023": 0
+      },
+      "illicit_income": {
+        "2023": 0
+      },
+      "in_is_qualifying_dependent_child": {
+        "2023": false
+      },
+      "incapable_of_self_care": {
+        "2023": false
+      },
+      "income_decile": {
+        "2023": -2147483648
+      },
+      "interest_expense": {
+        "2023": 0
+      },
+      "interest_income": {
+        "2023": 0
+      },
+      "ira_contributions": {
+        "2023": 0
+      },
+      "irs_gross_income": {
+        "2023": 0
+      },
+      "is_adult": {
+        "2023": false
+      },
+      "is_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_blind": {
+        "2023": false
+      },
+      "is_breastfeeding": {
+        "2023": false
+      },
+      "is_ca_cvrp_increased_rebate_eligible": {
+        "2023": false
+      },
+      "is_ca_cvrp_normal_rebate_eligible": {
+        "2023": false
+      },
+      "is_ccdf_age_eligible": {
+        "2023": true
+      },
+      "is_ccdf_eligible": {
+        "2023": false
+      },
+      "is_ccdf_home_based": {
+        "2023": false
+      },
+      "is_ccdf_reason_for_care_eligible": {
+        "2023": false
+      },
+      "is_cdcc_eligible": {
+        "2023": true
+      },
+      "is_child": {
+        "2023": true
+      },
+      "is_child_of_tax_head": {
+        "2023": true
+      },
+      "is_citizen": {
+        "2023": false
+      },
+      "is_disabled": {
+        "2023": false
+      },
+      "is_eitc_qualifying_child": {
+        "2023": true
+      },
+      "is_eligible_for_american_opportunity_credit": {
+        "2023": false
+      },
+      "is_enrolled_in_ccdf": {
+        "2023": false
+      },
+      "is_father": {
+        "2023": false
+      },
+      "is_female": {
+        "2023": false
+      },
+      "is_full_time_college_student": {
+        "2023": false
+      },
+      "is_full_time_student": {
+        "2023": true
+      },
+      "is_fully_disabled_service_connected_veteran": {
+        "2023": false
+      },
+      "is_hispanic": {
+        "2023": false
+      },
+      "is_in_k12_nonpublic_school": {
+        "2023": false
+      },
+      "is_in_k12_school": {
+        "2023": true
+      },
+      "is_in_medicaid_medically_needy_category": {
+        "2023": false
+      },
+      "is_infant_for_medicaid": {
+        "2023": false
+      },
+      "is_infant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_infant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_male": {
+        "2023": true
+      },
+      "is_medicaid_eligible": {
+        "2023": true
+      },
+      "is_medically_needy_for_medicaid": {
+        "2023": false
+      },
+      "is_mother": {
+        "2023": false
+      },
+      "is_older_child_for_medicaid": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_older_child_for_medicaid_nfc": {
+        "2023": true
+      },
+      "is_on_cliff": {
+        "2023": false
+      },
+      "is_optional_senior_or_disabled_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_parent_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_permanently_and_totally_disabled": {
+        "2023": false
+      },
+      "is_permanently_disabled_veteran": {
+        "2023": false
+      },
+      "is_person_demographic_tanf_eligible": {
+        "2023": true
+      },
+      "is_pregnant": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid": {
+        "2023": false
+      },
+      "is_pregnant_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_pregnant_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_retired": {
+        "2023": false
+      },
+      "is_self_employed": {
+        "2023": false
+      },
+      "is_senior": {
+        "2023": false
+      },
+      "is_severely_disabled": {
+        "2023": false
+      },
+      "is_ssi_aged": {
+        "2023": false
+      },
+      "is_ssi_aged_blind_disabled": {
+        "2023": false
+      },
+      "is_ssi_disabled": {
+        "2023": false
+      },
+      "is_ssi_eligible_individual": {
+        "2023": false
+      },
+      "is_ssi_eligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_ineligible_child": {
+        "2023": true
+      },
+      "is_ssi_ineligible_parent": {
+        "2023": false
+      },
+      "is_ssi_ineligible_spouse": {
+        "2023": false
+      },
+      "is_ssi_recipient_for_medicaid": {
+        "2023": false
+      },
+      "is_surviving_child_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_surviving_spouse_of_disabled_veteran": {
+        "2023": false
+      },
+      "is_tax_unit_dependent": {
+        "2023": true
+      },
+      "is_tax_unit_head": {
+        "2023": false
+      },
+      "is_tax_unit_spouse": {
+        "2023": false
+      },
+      "is_usda_disabled": {
+        "2023": false
+      },
+      "is_usda_elderly": {
+        "2023": false
+      },
+      "is_wa_adult": {
+        "2023": false
+      },
+      "is_wic_at_nutritional_risk": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_fc": {
+        "2023": false
+      },
+      "is_young_adult_for_medicaid_nfc": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid": {
+        "2023": false
+      },
+      "is_young_child_for_medicaid_fc": {
+        "2023": true
+      },
+      "is_young_child_for_medicaid_nfc": {
+        "2023": false
+      },
+      "k1bx14": {
+        "2023": 0
+      },
+      "long_term_capital_gains": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_collectibles": {
+        "2023": 0
+      },
+      "long_term_capital_gains_on_small_business_stock": {
+        "2023": 0
+      },
+      "ma_covid_19_essential_employee_premium_pay_program": {
+        "2023": 0
+      },
+      "marginal_tax_rate": {
+        "2023": 0
+      },
+      "market_income": {
+        "2023": 0
+      },
+      "maximum_state_supplement": {
+        "2023": 0
+      },
+      "md_pension_subtraction_amount": {
+        "2023": 0
+      },
+      "md_socsec_subtraction_amount": {
+        "2023": 0
+      },
+      "medicaid": {
+        "2023": 27358.121
+      },
+      "medicaid_benefit_value": {
+        "2023": 27358.121
+      },
+      "medicaid_category": {
+        "2023": "OLDER_CHILD"
+      },
+      "medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "medical_expense": {
+        "2023": 0
+      },
+      "medical_out_of_pocket_expenses": {
+        "2023": 0
+      },
+      "meets_ssi_resource_test": {
+        "2023": true
+      },
+      "meets_wic_categorical_eligibility": {
+        "2023": true
+      },
+      "military_basic_pay": {
+        "2023": 0
+      },
+      "military_retirement_pay": {
+        "2023": 0
+      },
+      "military_service_income": {
+        "2023": 0
+      },
+      "miscellaneous_income": {
+        "2023": 0
+      },
+      "mo_adjusted_gross_income": {
+        "2023": 0
+      },
+      "mo_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mo_income_tax_exempt": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_a": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_b": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction_section_c": {
+        "2023": 0
+      },
+      "mo_qualified_health_insurance_premiums": {
+        "2023": 0
+      },
+      "mo_taxable_income": {
+        "2023": 0
+      },
+      "net_income": {
+        "2023": 0
+      },
+      "never_eligible_for_social_security_benefits": {
+        "2023": false
+      },
+      "nj_agi_additions": {
+        "2023": 0
+      },
+      "nj_agi_subtractions": {
+        "2023": 0
+      },
+      "nj_eligible_pension_income": {
+        "2023": 0
+      },
+      "nj_total_income": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible_child": {
+        "2023": false
+      },
+      "non_public_school_tuition": {
+        "2023": 0
+      },
+      "non_qualified_dividend_income": {
+        "2023": 0
+      },
+      "non_sch_d_capital_gains": {
+        "2023": 0
+      },
+      "oh_has_not_taken_oh_lump_sum_credits": {
+        "2023": false
+      },
+      "or_retirement_credit_eligible": {
+        "2023": false
+      },
+      "own_children_in_household": {
+        "2023": 0
+      },
+      "pa_nontaxable_pension_income": {
+        "2023": 0
+      },
+      "partnership_s_corp_income": {
+        "2023": 0
+      },
+      "payroll_tax_gross_wages": {
+        "2023": 0
+      },
+      "pell_grant": {
+        "2023": 0
+      },
+      "pell_grant_countable_assets": {
+        "2023": 0
+      },
+      "pell_grant_dependent_allowances": {
+        "2023": 7040
+      },
+      "pell_grant_dependent_available_income": {
+        "2023": 0
+      },
+      "pell_grant_dependent_contribution": {
+        "2023": -3520
+      },
+      "pell_grant_dependent_other_allowances": {
+        "2023": 0
+      },
+      "pell_grant_efc": {
+        "2023": 0
+      },
+      "pell_grant_formula": {
+        "2023": "A"
+      },
+      "pell_grant_head_allowances": {
+        "2023": 0
+      },
+      "pell_grant_head_available_income": {
+        "2023": 0
+      },
+      "pell_grant_head_contribution": {
+        "2023": 0
+      },
+      "pell_grant_months_in_school": {
+        "2023": 0
+      },
+      "pell_grant_simplified_formula_applies": {
+        "2023": true
+      },
+      "pencon": {
+        "2023": 0
+      },
+      "pension_contributions": {
+        "2023": 0
+      },
+      "pension_income": {
+        "2023": 0
+      },
+      "pension_survivors": {
+        "2023": 0
+      },
+      "people": {
+        "2023": 1
+      },
+      "per_vehicle_payment": {
+        "2023": 0
+      },
+      "person_family_id": {
+        "2023": 0
+      },
+      "person_household_id": {
+        "2023": 0
+      },
+      "person_id": {
+        "2023": 3
+      },
+      "person_in_poverty": {
+        "2023": false
+      },
+      "person_marital_unit_id": {
+        "2023": 0
+      },
+      "person_spm_unit_id": {
+        "2023": 0
+      },
+      "person_tax_unit_id": {
+        "2023": 0
+      },
+      "person_weight": {
+        "2023": 0
+      },
+      "private_pension_income": {
+        "2023": 0
+      },
+      "public_pension_income": {
+        "2023": 0
+      },
+      "qbid_amount": {
+        "2023": 0
+      },
+      "qualified_adoption_assistance_expense": {
+        "2023": 0
+      },
+      "qualified_business_income": {
+        "2023": 0
+      },
+      "qualified_dividend_income": {
+        "2023": 0
+      },
+      "qualified_tuition_expenses": {
+        "2023": 0
+      },
+      "qualifies_for_elderly_or_disabled_credit": {
+        "2023": false
+      },
+      "race": {
+        "2023": "OTHER"
+      },
+      "real_estate_taxes": {
+        "2023": 0
+      },
+      "receives_or_needs_protective_services": {
+        "2023": false
+      },
+      "receives_wic": {
+        "2023": false
+      },
+      "rent": {
+        "2023": 0
+      },
+      "rental_income": {
+        "2023": 0
+      },
+      "retired_on_total_disability": {
+        "2023": false
+      },
+      "salt_refund_income": {
+        "2023": 0
+      },
+      "sc_gross_earned_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald_person": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_premiums": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald_person": {
+        "2023": 0
+      },
+      "self_employed_pension_contributions": {
+        "2023": 0
+      },
+      "self_employment_income": {
+        "2023": 0
+      },
+      "self_employment_medicare_tax": {
+        "2023": 0
+      },
+      "self_employment_social_security_tax": {
+        "2023": 0
+      },
+      "self_employment_tax": {
+        "2023": 0
+      },
+      "self_employment_tax_ald_person": {
+        "2023": 0
+      },
+      "sep_simple_qualified_plan_contributions": {
+        "2023": 0
+      },
+      "sey": {
+        "2023": 0
+      },
+      "short_term_capital_gains": {
+        "2023": 0
+      },
+      "social_security": {
+        "2023": 0
+      },
+      "social_security_dependents": {
+        "2023": 0
+      },
+      "social_security_disability": {
+        "2023": 0
+      },
+      "social_security_retirement": {
+        "2023": 0
+      },
+      "social_security_survivors": {
+        "2023": 0
+      },
+      "social_security_taxable_self_employment_income": {
+        "2023": 0
+      },
+      "ssi": {
+        "2023": 0
+      },
+      "ssi_amount_if_eligible": {
+        "2023": 10968
+      },
+      "ssi_category": {
+        "2023": "NONE"
+      },
+      "ssi_claim_is_joint": {
+        "2023": false
+      },
+      "ssi_countable_income": {
+        "2023": 0
+      },
+      "ssi_countable_resources": {
+        "2023": 0
+      },
+      "ssi_earned_income": {
+        "2023": 0
+      },
+      "ssi_earned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "ssi_ineligible_child_allocation": {
+        "2023": 5484
+      },
+      "ssi_ineligible_parent_allocation": {
+        "2023": 0
+      },
+      "ssi_reported": {
+        "2023": 0
+      },
+      "ssi_unearned_income": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_parent": {
+        "2023": 0
+      },
+      "ssi_unearned_income_deemed_from_ineligible_spouse": {
+        "2023": 0
+      },
+      "state_or_federal_salary": {
+        "2023": 0
+      },
+      "state_supplement": {
+        "2023": 0
+      },
+      "strike_benefits": {
+        "2023": 0
+      },
+      "student_loan_interest": {
+        "2023": 0
+      },
+      "tanf_person": {
+        "2023": 0
+      },
+      "tanf_reported": {
+        "2023": 0
+      },
+      "tax_exempt_interest_income": {
+        "2023": 0
+      },
+      "tax_exempt_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_private_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_public_pension_income": {
+        "2023": 0
+      },
+      "tax_exempt_unemployment_compensation": {
+        "2023": 0
+      },
+      "taxable_earnings_for_social_security": {
+        "2023": 0
+      },
+      "taxable_federal_pension_income": {
+        "2023": 0
+      },
+      "taxable_interest_income": {
+        "2023": 0
+      },
+      "taxable_pension_income": {
+        "2023": 0
+      },
+      "taxable_private_pension_income": {
+        "2023": 0
+      },
+      "taxable_public_pension_income": {
+        "2023": 0
+      },
+      "taxable_self_employment_income": {
+        "2023": 0
+      },
+      "taxable_social_security": {
+        "2023": 0
+      },
+      "taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "total_disability_payments": {
+        "2023": 0
+      },
+      "total_income": {
+        "2023": 0
+      },
+      "unadjusted_basis_qualified_property": {
+        "2023": 0
+      },
+      "uncapped_ssi": {
+        "2023": 0
+      },
+      "under_12_months_postpartum": {
+        "2023": false
+      },
+      "under_60_days_postpartum": {
+        "2023": false
+      },
+      "unemployment_compensation": {
+        "2023": 0
+      },
+      "us_bonds_for_higher_ed": {
+        "2023": 0
+      },
+      "vehicles_owned": {
+        "2023": 0
+      },
+      "veterans_benefits": {
+        "2023": 0
+      },
+      "w2_wages_from_qualified_business": {
+        "2023": 0
+      },
+      "wic": {
+        "2023": 0
+      },
+      "wic_category": {
+        "2023": "NONE"
+      },
+      "wic_category_str": {
+        "2023": "NONE"
+      },
+      "workers_compensation": {
+        "2023": 0
+      },
+      "would_claim_wic": {
+        "2023": true
+      }
+    }
+  },
+  "spm_units": {
+    "your household": {
+      "acp": {
+        "2023": 0
+      },
+      "ami": {
+        "2023": 0
+      },
+      "broadband_cost": {
+        "2023": 0
+      },
+      "broadband_cost_after_lifeline": {
+        "2023": 0
+      },
+      "ccdf_income": {
+        "2023": 40000
+      },
+      "ccdf_income_to_smi_ratio": {
+        "2023": 0.3616502
+      },
+      "childcare_expenses": {
+        "2023": 0
+      },
+      "co_tanf": {
+        "2023": 0
+      },
+      "co_tanf_count_children": {
+        "2023": 0
+      },
+      "co_tanf_countable_earned_income_grant_standard": {
+        "2023": 0
+      },
+      "co_tanf_countable_earned_income_need": {
+        "2023": 0
+      },
+      "co_tanf_countable_gross_earned_income": {
+        "2023": 40000
+      },
+      "co_tanf_countable_gross_unearned_income": {
+        "2023": 0
+      },
+      "co_tanf_eligible": {
+        "2023": false
+      },
+      "co_tanf_grant_standard": {
+        "2023": 0
+      },
+      "co_tanf_income_eligible": {
+        "2023": false
+      },
+      "co_tanf_need_standard": {
+        "2023": 0
+      },
+      "count_distinct_utility_expenses": {
+        "2023": 0
+      },
+      "dc_tanf": {
+        "2023": 0
+      },
+      "dc_tanf_countable_earned_income": {
+        "2023": 0
+      },
+      "dc_tanf_countable_gross_unearned_income": {
+        "2023": 0
+      },
+      "dc_tanf_countable_income": {
+        "2023": 0
+      },
+      "dc_tanf_countable_resources": {
+        "2023": 0
+      },
+      "dc_tanf_eligible": {
+        "2023": false
+      },
+      "dc_tanf_grant_standard": {
+        "2023": 0
+      },
+      "dc_tanf_gross_earned_income": {
+        "2023": 0
+      },
+      "dc_tanf_income_eligible": {
+        "2023": false
+      },
+      "dc_tanf_need_standard": {
+        "2023": 0
+      },
+      "dc_tanf_resources_eligible": {
+        "2023": false
+      },
+      "deep_poverty_gap": {
+        "2023": 0
+      },
+      "deep_poverty_line": {
+        "2023": 0
+      },
+      "ebb": {
+        "2023": 0
+      },
+      "electricity_expense": {
+        "2023": 0
+      },
+      "enrolled_in_ebb": {
+        "2023": false
+      },
+      "experienced_covid_income_loss": {
+        "2023": false
+      },
+      "fcc_fpg_ratio": {
+        "2023": 0.99304867
+      },
+      "fdpir": {
+        "2023": 0
+      },
+      "free_school_meals": {
+        "2023": 3830.4
+      },
+      "free_school_meals_reported": {
+        "2023": 0
+      },
+      "gas_expense": {
+        "2023": 0
+      },
+      "has_all_usda_elderly_disabled": {
+        "2023": false
+      },
+      "has_heating_cooling_expense": {
+        "2023": false
+      },
+      "has_phone_expense": {
+        "2023": false
+      },
+      "has_usda_elderly_disabled": {
+        "2023": false
+      },
+      "heating_cooling_expense": {
+        "2023": 0
+      },
+      "hhs_smi": {
+        "2023": 110604.12
+      },
+      "housing_assistance": {
+        "2023": 0
+      },
+      "housing_cost": {
+        "2023": 0
+      },
+      "housing_designated_welfare": {
+        "2023": 0
+      },
+      "hud_adjusted_income": {
+        "2023": 38080
+      },
+      "hud_annual_income": {
+        "2023": 40000
+      },
+      "hud_gross_rent": {
+        "2023": 0
+      },
+      "hud_hap": {
+        "2023": 0
+      },
+      "hud_income_level": {
+        "2023": "ESPECIALLY_LOW"
+      },
+      "hud_max_subsidy": {
+        "2023": 0
+      },
+      "hud_minimum_rent": {
+        "2023": 0
+      },
+      "hud_ttp": {
+        "2023": 11424
+      },
+      "hud_ttp_adjusted_income_share": {
+        "2023": 11424
+      },
+      "hud_ttp_income_share": {
+        "2023": 4000
+      },
+      "hud_utility_allowance": {
+        "2023": 0
+      },
+      "in_deep_poverty": {
+        "2023": false
+      },
+      "in_poverty": {
+        "2023": false
+      },
+      "is_acp_eligible": {
+        "2023": true
+      },
+      "is_ccdf_asset_eligible": {
+        "2023": true
+      },
+      "is_ccdf_continuous_income_eligible": {
+        "2023": false
+      },
+      "is_ccdf_income_eligible": {
+        "2023": true
+      },
+      "is_ccdf_initial_income_eligible": {
+        "2023": false
+      },
+      "is_demographic_tanf_eligible": {
+        "2023": true
+      },
+      "is_ebb_eligible": {
+        "2023": false
+      },
+      "is_eligible_for_housing_assistance": {
+        "2023": true
+      },
+      "is_hud_elderly_disabled_family": {
+        "2023": false
+      },
+      "is_lifeline_eligible": {
+        "2023": true
+      },
+      "is_snap_eligible": {
+        "2023": true
+      },
+      "is_tanf_continuous_eligible": {
+        "2023": false
+      },
+      "is_tanf_eligible": {
+        "2023": false
+      },
+      "is_tanf_enrolled": {
+        "2023": false
+      },
+      "is_tanf_initial_eligible": {
+        "2023": false
+      },
+      "is_tanf_non_cash_eligible": {
+        "2023": true
+      },
+      "is_tanf_non_cash_hheod": {
+        "2023": false
+      },
+      "lifeline": {
+        "2023": 0
+      },
+      "md_tanf_count_children": {
+        "2023": 0
+      },
+      "md_tanf_eligible": {
+        "2023": false
+      },
+      "md_tanf_gross_earned_income_deduction": {
+        "2023": 0
+      },
+      "md_tanf_maximum_benefit": {
+        "2023": 0
+      },
+      "meets_ccdf_activity_test": {
+        "2023": false
+      },
+      "meets_school_meal_categorical_eligibility": {
+        "2023": true
+      },
+      "meets_snap_asset_test": {
+        "2023": true
+      },
+      "meets_snap_categorical_eligibility": {
+        "2023": true
+      },
+      "meets_snap_gross_income_test": {
+        "2023": true
+      },
+      "meets_snap_net_income_test": {
+        "2023": true
+      },
+      "meets_tanf_non_cash_asset_test": {
+        "2023": true
+      },
+      "meets_tanf_non_cash_gross_income_test": {
+        "2023": true
+      },
+      "meets_tanf_non_cash_net_income_test": {
+        "2023": true
+      },
+      "meets_wic_income_test": {
+        "2023": true
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ],
+      "mo_tanf_income_limit": {
+        "2023": 0
+      },
+      "nj_tanf_countable_gross_unearned_income": {
+        "2023": 0
+      },
+      "nj_tanf_countable_resources": {
+        "2023": 0
+      },
+      "nj_tanf_gross_earned_income": {
+        "2023": 0
+      },
+      "nj_tanf_maximum_allowable_income": {
+        "2023": 0
+      },
+      "nj_tanf_maximum_benefit": {
+        "2023": 0
+      },
+      "nj_tanf_resources_eligible": {
+        "2023": false
+      },
+      "ny_tanf": {
+        "2023": 0
+      },
+      "ny_tanf_countable_earned_income": {
+        "2023": 0
+      },
+      "ny_tanf_countable_gross_unearned_income": {
+        "2023": 0
+      },
+      "ny_tanf_countable_resources": {
+        "2023": 0
+      },
+      "ny_tanf_eligible": {
+        "2023": false
+      },
+      "ny_tanf_grant_standard": {
+        "2023": 0
+      },
+      "ny_tanf_gross_earned_income": {
+        "2023": 0
+      },
+      "ny_tanf_income_eligible": {
+        "2023": false
+      },
+      "ny_tanf_need_standard": {
+        "2023": 0
+      },
+      "ny_tanf_resources_eligible": {
+        "2023": false
+      },
+      "ok_tanf": {
+        "2023": 0
+      },
+      "pa_tanf_age_eligible": {
+        "2023": false
+      },
+      "pa_tanf_age_eligible_on_pregnant_women_limitation": {
+        "2023": false
+      },
+      "pa_tanf_countable_resources": {
+        "2023": 0
+      },
+      "pa_tanf_resources_eligible": {
+        "2023": false
+      },
+      "pha_payment_standard": {
+        "2023": 0
+      },
+      "phone_cost": {
+        "2023": 0
+      },
+      "phone_expense": {
+        "2023": 0
+      },
+      "poverty_gap": {
+        "2023": 0
+      },
+      "poverty_line": {
+        "2023": 0
+      },
+      "receives_housing_assistance": {
+        "2023": false
+      },
+      "reduced_price_school_meals": {
+        "2023": 0
+      },
+      "school_meal_countable_income": {
+        "2023": 40000
+      },
+      "school_meal_daily_subsidy": {
+        "2023": 6.04
+      },
+      "school_meal_fpg_ratio": {
+        "2023": 0.99304867
+      },
+      "school_meal_net_subsidy": {
+        "2023": 3830.4
+      },
+      "school_meal_paid_daily_subsidy": {
+        "2023": 0.72
+      },
+      "school_meal_tier": {
+        "2023": "FREE"
+      },
+      "sewage_expense": {
+        "2023": 0
+      },
+      "snap": {
+        "2023": 8842
+      },
+      "snap_assets": {
+        "2023": 0
+      },
+      "snap_child_support_deduction": {
+        "2023": 0
+      },
+      "snap_child_support_gross_income_deduction": {
+        "2023": 0
+      },
+      "snap_deductions": {
+        "2023": 11096
+      },
+      "snap_dependent_care_deduction": {
+        "2023": 0
+      },
+      "snap_earned_income": {
+        "2023": 40000
+      },
+      "snap_earned_income_deduction": {
+        "2023": 8000
+      },
+      "snap_emergency_allotment": {
+        "2023": 1445.2001
+      },
+      "snap_excess_medical_expense_deduction": {
+        "2023": 0
+      },
+      "snap_excess_shelter_expense_deduction": {
+        "2023": 0
+      },
+      "snap_expected_contribution": {
+        "2023": 8671.2
+      },
+      "snap_gross_income": {
+        "2023": 40000
+      },
+      "snap_gross_income_fpg_ratio": {
+        "2023": 0.99304867
+      },
+      "snap_max_allotment": {
+        "2023": 16068
+      },
+      "snap_min_allotment": {
+        "2023": 0
+      },
+      "snap_net_income": {
+        "2023": 28904
+      },
+      "snap_net_income_fpg_ratio": {
+        "2023": 0.717577
+      },
+      "snap_net_income_pre_shelter": {
+        "2023": 28904
+      },
+      "snap_normal_allotment": {
+        "2023": 7396.8
+      },
+      "snap_reported": {
+        "2023": 0
+      },
+      "snap_standard_deduction": {
+        "2023": 3096
+      },
+      "snap_unearned_income": {
+        "2023": 0
+      },
+      "snap_utility_allowance": {
+        "2023": 0
+      },
+      "snap_utility_allowance_type": {
+        "2023": "NONE"
+      },
+      "spm_unit_assets": {
+        "2023": 0
+      },
+      "spm_unit_benefits": {
+        "2023": 12672.4
+      },
+      "spm_unit_capped_housing_subsidy": {
+        "2023": 0
+      },
+      "spm_unit_capped_housing_subsidy_reported": {
+        "2023": 0
+      },
+      "spm_unit_capped_work_childcare_expenses": {
+        "2023": 0
+      },
+      "spm_unit_ccdf_subsidy": {
+        "2023": 0
+      },
+      "spm_unit_count_adults": {
+        "2023": 2
+      },
+      "spm_unit_count_children": {
+        "2023": 4
+      },
+      "spm_unit_energy_subsidy": {
+        "2023": 0
+      },
+      "spm_unit_energy_subsidy_reported": {
+        "2023": 0
+      },
+      "spm_unit_federal_tax": {
+        "2023": -10555.178
+      },
+      "spm_unit_federal_tax_reported": {
+        "2023": 0
+      },
+      "spm_unit_fpg": {
+        "2023": 40280
+      },
+      "spm_unit_id": {
+        "2023": 0
+      },
+      "spm_unit_income_decile": {
+        "2023": -2147483648
+      },
+      "spm_unit_is_in_deep_spm_poverty": {
+        "2023": false
+      },
+      "spm_unit_is_in_spm_poverty": {
+        "2023": false
+      },
+      "spm_unit_market_income": {
+        "2023": 40000
+      },
+      "spm_unit_medical_expenses": {
+        "2023": 0
+      },
+      "spm_unit_net_income": {
+        "2023": 60167.58
+      },
+      "spm_unit_net_income_reported": {
+        "2023": 0
+      },
+      "spm_unit_oecd_equiv_net_income": {
+        "2023": 24563.31
+      },
+      "spm_unit_payroll_tax": {
+        "2023": 3060
+      },
+      "spm_unit_payroll_tax_reported": {
+        "2023": 0
+      },
+      "spm_unit_pell_grant": {
+        "2023": 0
+      },
+      "spm_unit_school_lunch_subsidy": {
+        "2023": 0
+      },
+      "spm_unit_self_employment_tax": {
+        "2023": 0
+      },
+      "spm_unit_size": {
+        "2023": 6
+      },
+      "spm_unit_snap": {
+        "2023": 0
+      },
+      "spm_unit_spm_threshold": {
+        "2023": 0
+      },
+      "spm_unit_state_fips": {
+        "2023": 6
+      },
+      "spm_unit_state_tax": {
+        "2023": 0
+      },
+      "spm_unit_state_tax_reported": {
+        "2023": 0
+      },
+      "spm_unit_taxes": {
+        "2023": -7495.1777
+      },
+      "spm_unit_total_ccdf_copay": {
+        "2023": 52
+      },
+      "spm_unit_total_income_reported": {
+        "2023": 0
+      },
+      "spm_unit_weight": {
+        "2023": 0
+      },
+      "spm_unit_wic": {
+        "2023": 0
+      },
+      "spm_unit_wic_reported": {
+        "2023": 0
+      },
+      "tanf": {
+        "2023": 0
+      },
+      "tanf_amount_if_eligible": {
+        "2023": 0
+      },
+      "tanf_countable_income": {
+        "2023": 40000
+      },
+      "tanf_gross_earned_income": {
+        "2023": 40000
+      },
+      "tanf_gross_unearned_income": {
+        "2023": 0
+      },
+      "tanf_initial_employment_deduction": {
+        "2023": 0
+      },
+      "tanf_max_amount": {
+        "2023": 0
+      },
+      "trash_expense": {
+        "2023": 0
+      },
+      "tx_tanf_income_limit": {
+        "2023": 0
+      },
+      "utility_expense": {
+        "2023": 0
+      },
+      "wa_tanf_countable_resources": {
+        "2023": 0
+      },
+      "wa_tanf_resources_eligible": {
+        "2023": false
+      },
+      "water_expense": {
+        "2023": 0
+      },
+      "wic_fpg": {
+        "2023": 40280
+      }
+    }
+  },
+  "tax_units": {
+    "your tax unit": {
+      "a_lineno": {
+        "2023": 0
+      },
+      "above_the_line_deductions": {
+        "2023": 0
+      },
+      "additional_medicare_tax": {
+        "2023": 0
+      },
+      "additional_standard_deduction": {
+        "2023": 0
+      },
+      "adjusted_gross_income": {
+        "2023": 40000
+      },
+      "adjusted_net_capital_gain": {
+        "2023": 0
+      },
+      "advanced_main_air_circulating_fan_expenditures": {
+        "2023": 0
+      },
+      "age_head": {
+        "2023": 40
+      },
+      "age_spouse": {
+        "2023": 40
+      },
+      "aged_blind_count": {
+        "2023": 0
+      },
+      "aged_blind_extra_standard_deduction": {
+        "2023": 0
+      },
+      "aged_head": {
+        "2023": false
+      },
+      "aged_spouse": {
+        "2023": false
+      },
+      "air_sealing_ventilation_expenditures": {
+        "2023": 0
+      },
+      "al_agi": {
+        "2023": 0
+      },
+      "al_dependent_exemption": {
+        "2023": 1000
+      },
+      "al_income_tax_before_credits": {
+        "2023": 0
+      },
+      "al_personal_exemption": {
+        "2023": 3000
+      },
+      "al_standard_deduction": {
+        "2023": 8500
+      },
+      "al_taxable_income": {
+        "2023": 0
+      },
+      "alternative_minimum_tax": {
+        "2023": 0
+      },
+      "american_opportunity_credit": {
+        "2023": 0
+      },
+      "amt_form_completed": {
+        "2023": false
+      },
+      "amt_income": {
+        "2023": 40000
+      },
+      "amt_non_agi_income": {
+        "2023": 0
+      },
+      "ar_income_tax": {
+        "2023": 0
+      },
+      "ar_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "ar_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ar_non_refundable_credits": {
+        "2023": 0
+      },
+      "ar_refundable_credits": {
+        "2023": 0
+      },
+      "ar_standard_deduction": {
+        "2023": 0
+      },
+      "ar_taxable_income": {
+        "2023": 0
+      },
+      "az_agi": {
+        "2023": 0
+      },
+      "az_family_tax_credit": {
+        "2023": 0
+      },
+      "az_family_tax_credit_eligible": {
+        "2023": false
+      },
+      "az_income_tax": {
+        "2023": 0
+      },
+      "az_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "az_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "az_increased_excise_tax_credit": {
+        "2023": 0
+      },
+      "az_increased_excise_tax_credit_eligible": {
+        "2023": false
+      },
+      "az_non_refundable_credits": {
+        "2023": 0
+      },
+      "az_refundable_credits": {
+        "2023": 0
+      },
+      "az_standard_deduction": {
+        "2023": 0
+      },
+      "az_taxable_income": {
+        "2023": 0
+      },
+      "basic_income": {
+        "2023": 0
+      },
+      "basic_income_before_phase_out": {
+        "2023": 0
+      },
+      "basic_income_eligible": {
+        "2023": true
+      },
+      "basic_income_phase_out": {
+        "2023": 0
+      },
+      "basic_standard_deduction": {
+        "2023": 27700
+      },
+      "benefit_value_total": {
+        "2023": 0
+      },
+      "biomass_stove_boiler_expenditures": {
+        "2023": 0
+      },
+      "blind_head": {
+        "2023": false
+      },
+      "blind_spouse": {
+        "2023": false
+      },
+      "bonus_guaranteed_deduction": {
+        "2023": 0
+      },
+      "c01000": {
+        "2023": 0
+      },
+      "c04600": {
+        "2023": 0
+      },
+      "c05700": {
+        "2023": 0
+      },
+      "c07100": {
+        "2023": 2375
+      },
+      "c07200": {
+        "2023": 0
+      },
+      "c07230": {
+        "2023": 0
+      },
+      "c07240": {
+        "2023": 0
+      },
+      "c07260": {
+        "2023": 0
+      },
+      "c07300": {
+        "2023": 0
+      },
+      "c07400": {
+        "2023": 0
+      },
+      "c07600": {
+        "2023": 0
+      },
+      "c08000": {
+        "2023": 0
+      },
+      "c09600": {
+        "2023": 0
+      },
+      "c10960": {
+        "2023": 0
+      },
+      "c11070": {
+        "2023": 5625
+      },
+      "c23650": {
+        "2023": 0
+      },
+      "c59660": {
+        "2023": 4930.1777
+      },
+      "c62100": {
+        "2023": 40000
+      },
+      "c87668": {
+        "2023": 0
+      },
+      "ca_agi": {
+        "2023": 0
+      },
+      "ca_agi_additions": {
+        "2023": 0
+      },
+      "ca_agi_subtractions": {
+        "2023": 0
+      },
+      "ca_cdcc": {
+        "2023": 0
+      },
+      "ca_eitc": {
+        "2023": 0
+      },
+      "ca_eitc_eligible": {
+        "2023": false
+      },
+      "ca_exemptions": {
+        "2023": 0
+      },
+      "ca_income_tax": {
+        "2023": 0
+      },
+      "ca_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ca_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ca_itemized_deductions": {
+        "2023": 0
+      },
+      "ca_mental_health_services_tax": {
+        "2023": 0
+      },
+      "ca_nonrefundable_credits": {
+        "2023": 0
+      },
+      "ca_refundable_credits": {
+        "2023": 0
+      },
+      "ca_renter_credit": {
+        "2023": 0
+      },
+      "ca_standard_deduction": {
+        "2023": 0
+      },
+      "ca_taxable_income": {
+        "2023": 0
+      },
+      "ca_use_tax": {
+        "2023": 0
+      },
+      "ca_yctc": {
+        "2023": 0
+      },
+      "capital_gains_28_percent_rate_gain": {
+        "2023": 0
+      },
+      "capital_gains_excluded_from_taxable_income": {
+        "2023": 0
+      },
+      "capital_gains_tax": {
+        "2023": 0
+      },
+      "capped_advanced_main_air_circulating_fan_credit": {
+        "2023": 0
+      },
+      "capped_electric_heat_pump_clothes_dryer_rebate": {
+        "2023": 0
+      },
+      "capped_electric_load_service_center_upgrade_rebate": {
+        "2023": 0
+      },
+      "capped_electric_stove_cooktop_range_or_oven_rebate": {
+        "2023": 0
+      },
+      "capped_electric_wiring_rebate": {
+        "2023": 0
+      },
+      "capped_energy_efficient_central_air_conditioner_credit": {
+        "2023": 0
+      },
+      "capped_energy_efficient_door_credit": {
+        "2023": 0
+      },
+      "capped_energy_efficient_insulation_credit": {
+        "2023": 0
+      },
+      "capped_energy_efficient_roof_credit": {
+        "2023": 0
+      },
+      "capped_energy_efficient_window_credit": {
+        "2023": 0
+      },
+      "capped_heat_pump_heat_pump_water_heater_biomass_stove_boiler_credit": {
+        "2023": 0
+      },
+      "capped_heat_pump_rebate": {
+        "2023": 0
+      },
+      "capped_heat_pump_water_heater_rebate": {
+        "2023": 0
+      },
+      "capped_home_energy_audit_credit": {
+        "2023": 0
+      },
+      "capped_insulation_air_sealing_ventilation_rebate": {
+        "2023": 0
+      },
+      "capped_property_taxes": {
+        "2023": 0
+      },
+      "capped_qualified_furnace_or_hot_water_boiler_credit": {
+        "2023": 0
+      },
+      "care_deduction": {
+        "2023": 0
+      },
+      "casualty_loss_deduction": {
+        "2023": 0
+      },
+      "cdcc": {
+        "2023": 0
+      },
+      "cdcc_rate": {
+        "2023": 0.22
+      },
+      "cdcc_relevant_expenses": {
+        "2023": 0
+      },
+      "charitable_deduction": {
+        "2023": 0
+      },
+      "charity_credit": {
+        "2023": 0
+      },
+      "co_additions": {
+        "2023": 0
+      },
+      "co_cdcc": {
+        "2023": 0
+      },
+      "co_charitable_contribution_subtraction": {
+        "2023": 0
+      },
+      "co_charitable_contribution_subtraction_eligible": {
+        "2023": false
+      },
+      "co_collegeinvest_subtraction": {
+        "2023": 0
+      },
+      "co_ctc": {
+        "2023": 0
+      },
+      "co_eitc": {
+        "2023": 0
+      },
+      "co_federal_deduction_addback": {
+        "2023": 0
+      },
+      "co_federal_deduction_addback_required": {
+        "2023": false
+      },
+      "co_federal_taxable_income": {
+        "2023": 0
+      },
+      "co_income_qualified_senior_housing_credit": {
+        "2023": 0
+      },
+      "co_income_qualified_senior_housing_credit_eligible": {
+        "2023": false
+      },
+      "co_income_tax": {
+        "2023": 0
+      },
+      "co_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "co_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "co_low_income_cdcc": {
+        "2023": 0
+      },
+      "co_low_income_cdcc_eligible": {
+        "2023": false
+      },
+      "co_military_retirement_subtraction": {
+        "2023": 0
+      },
+      "co_modified_agi": {
+        "2023": 0
+      },
+      "co_non_refundable_credits": {
+        "2023": 0
+      },
+      "co_pension_subtraction": {
+        "2023": 0
+      },
+      "co_property_tax_exemption": {
+        "2023": 0
+      },
+      "co_qualified_business_income_deduction_addback": {
+        "2023": 0
+      },
+      "co_qualified_business_income_deduction_addback_required": {
+        "2023": false
+      },
+      "co_refundable_credits": {
+        "2023": 0
+      },
+      "co_sales_tax_refund": {
+        "2023": 0
+      },
+      "co_sales_tax_refund_eligible": {
+        "2023": false
+      },
+      "co_subtractions": {
+        "2023": 0
+      },
+      "co_taxable_income": {
+        "2023": 0
+      },
+      "cohabitating_spouses": {
+        "2023": false
+      },
+      "combined": {
+        "2023": -7495.1777
+      },
+      "count_cdcc_eligible": {
+        "2023": 4
+      },
+      "ct_agi": {
+        "2023": 0
+      },
+      "ct_agi_additions": {
+        "2023": 0
+      },
+      "ct_agi_subtractions": {
+        "2023": 0
+      },
+      "ct_income_tax": {
+        "2023": 0
+      },
+      "ct_income_tax_after_personal_credits": {
+        "2023": 0
+      },
+      "ct_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ct_income_tax_higher_tax_recapture": {
+        "2023": 0
+      },
+      "ct_income_tax_lower_tax_recapture": {
+        "2023": 0
+      },
+      "ct_income_tax_phase_out_add_back": {
+        "2023": 0
+      },
+      "ct_income_tax_recapture": {
+        "2023": 0
+      },
+      "ct_non_refundable_credits": {
+        "2023": 0
+      },
+      "ct_personal_credit_rate": {
+        "2023": 0
+      },
+      "ct_personal_exemptions": {
+        "2023": 0
+      },
+      "ct_refundable_credits": {
+        "2023": 0
+      },
+      "ct_taxable_income": {
+        "2023": 0
+      },
+      "ctc": {
+        "2023": 8000
+      },
+      "ctc_arpa_addition": {
+        "2023": 0
+      },
+      "ctc_arpa_max_addition": {
+        "2023": 0
+      },
+      "ctc_arpa_phase_out": {
+        "2023": 0
+      },
+      "ctc_arpa_phase_out_cap": {
+        "2023": 0
+      },
+      "ctc_arpa_phase_out_threshold": {
+        "2023": 150000
+      },
+      "ctc_arpa_uncapped_phase_out": {
+        "2023": 0
+      },
+      "ctc_limiting_tax_liability": {
+        "2023": 1230
+      },
+      "ctc_maximum": {
+        "2023": 8000
+      },
+      "ctc_maximum_with_arpa_addition": {
+        "2023": 8000
+      },
+      "ctc_new": {
+        "2023": 0
+      },
+      "ctc_phase_out": {
+        "2023": 0
+      },
+      "ctc_phase_out_threshold": {
+        "2023": 400000
+      },
+      "ctc_qualifying_children": {
+        "2023": 4
+      },
+      "ctc_refundable_maximum": {
+        "2023": 6400
+      },
+      "ctc_value": {
+        "2023": 1230
+      },
+      "data_source": {
+        "2023": false
+      },
+      "dc_cdcc": {
+        "2023": 0
+      },
+      "dc_deduction_joint": {
+        "2023": 0
+      },
+      "dc_eitc": {
+        "2023": 0
+      },
+      "dc_eitc_with_qualifying_child": {
+        "2023": 0
+      },
+      "dc_eitc_without_qualifying_child": {
+        "2023": 0
+      },
+      "dc_files_separately": {
+        "2023": false
+      },
+      "dc_income_tax": {
+        "2023": 0
+      },
+      "dc_income_tax_before_credits": {
+        "2023": 0
+      },
+      "dc_income_tax_before_credits_indiv": {
+        "2023": 0
+      },
+      "dc_income_tax_before_credits_joint": {
+        "2023": 0
+      },
+      "dc_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "dc_itemized_deductions": {
+        "2023": 0
+      },
+      "dc_kccatc": {
+        "2023": 0
+      },
+      "dc_non_refundable_credits": {
+        "2023": 0
+      },
+      "dc_ptc": {
+        "2023": 0
+      },
+      "dc_refundable_credits": {
+        "2023": 0
+      },
+      "dc_standard_deduction": {
+        "2023": 0
+      },
+      "dc_taxable_income_joint": {
+        "2023": 0
+      },
+      "de_additional_standard_deduction": {
+        "2023": 0
+      },
+      "de_additions": {
+        "2023": 0
+      },
+      "de_aged_personal_credit": {
+        "2023": 0
+      },
+      "de_agi": {
+        "2023": 0
+      },
+      "de_cdcc": {
+        "2023": 0
+      },
+      "de_claims_refundable_eitc": {
+        "2023": false
+      },
+      "de_eitc": {
+        "2023": 0
+      },
+      "de_elderly_or_disabled_income_exclusion": {
+        "2023": 0
+      },
+      "de_elderly_or_disabled_income_exclusion_eligible": {
+        "2023": false
+      },
+      "de_income_tax": {
+        "2023": 0
+      },
+      "de_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "de_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "de_income_tax_if_claiming_non_refundable_eitc": {
+        "2023": 0
+      },
+      "de_income_tax_if_claiming_refundable_eitc": {
+        "2023": 0
+      },
+      "de_non_refundable_credits": {
+        "2023": 0
+      },
+      "de_non_refundable_eitc": {
+        "2023": 0
+      },
+      "de_non_refundable_eitc_if_claimed": {
+        "2023": 0
+      },
+      "de_personal_credit": {
+        "2023": 0
+      },
+      "de_pre_exclusions_agi": {
+        "2023": 0
+      },
+      "de_refundable_credits": {
+        "2023": 0
+      },
+      "de_refundable_eitc": {
+        "2023": 0
+      },
+      "de_refundable_eitc_if_claimed": {
+        "2023": 0
+      },
+      "de_standard_deduction": {
+        "2023": 0
+      },
+      "de_subtractions": {
+        "2023": 0
+      },
+      "de_taxable_income": {
+        "2023": 0
+      },
+      "disabled_head": {
+        "2023": false
+      },
+      "disabled_spouse": {
+        "2023": false
+      },
+      "domestic_production_ald": {
+        "2023": 0
+      },
+      "dsi": {
+        "2023": false
+      },
+      "dsi_spouse": {
+        "2023": false
+      },
+      "dwks10": {
+        "2023": 0
+      },
+      "dwks13": {
+        "2023": 0
+      },
+      "dwks14": {
+        "2023": 0
+      },
+      "dwks19": {
+        "2023": 0
+      },
+      "dwks6": {
+        "2023": 0
+      },
+      "dwks9": {
+        "2023": 0
+      },
+      "e07240": {
+        "2023": 0
+      },
+      "e07400": {
+        "2023": 0
+      },
+      "e07600": {
+        "2023": 0
+      },
+      "earned_income_tax_credit": {
+        "2023": 4930.1777
+      },
+      "ecpa_adult_dependent_credit": {
+        "2023": 0
+      },
+      "ecpa_filer_credit": {
+        "2023": 0
+      },
+      "education_credit_phase_out": {
+        "2023": 0
+      },
+      "education_tax_credits": {
+        "2023": 0
+      },
+      "eitc": {
+        "2023": 4930.1777
+      },
+      "eitc_agi_limit": {
+        "2023": 63410.152
+      },
+      "eitc_child_count": {
+        "2023": 4
+      },
+      "eitc_demographic_eligible": {
+        "2023": true
+      },
+      "eitc_eligible": {
+        "2023": true
+      },
+      "eitc_investment_income_eligible": {
+        "2023": true
+      },
+      "eitc_maximum": {
+        "2023": 7430
+      },
+      "eitc_phase_in_rate": {
+        "2023": 0.45
+      },
+      "eitc_phase_out_rate": {
+        "2023": 0.2106
+      },
+      "eitc_phase_out_start": {
+        "2023": 28130
+      },
+      "eitc_phased_in": {
+        "2023": 7430
+      },
+      "eitc_reduction": {
+        "2023": 2499.822
+      },
+      "eitc_relevant_investment_income": {
+        "2023": 0
+      },
+      "elderly_dependents": {
+        "2023": 0
+      },
+      "elderly_disabled_credit": {
+        "2023": 0
+      },
+      "electric_heat_pump_clothes_dryer_expenditures": {
+        "2023": 0
+      },
+      "electric_load_service_center_upgrade_expenditures": {
+        "2023": 0
+      },
+      "electric_stove_cooktop_range_or_oven_expenditures": {
+        "2023": 0
+      },
+      "electric_wiring_expenditures": {
+        "2023": 0
+      },
+      "employee_payroll_tax": {
+        "2023": 3060
+      },
+      "energy_efficient_central_air_conditioner_expenditures": {
+        "2023": 0
+      },
+      "energy_efficient_door_expenditures": {
+        "2023": 0
+      },
+      "energy_efficient_home_improvement_credit": {
+        "2023": 0
+      },
+      "energy_efficient_insulation_expenditures": {
+        "2023": 0
+      },
+      "energy_efficient_roof_expenditures": {
+        "2023": 0
+      },
+      "energy_efficient_window_expenditures": {
+        "2023": 0
+      },
+      "excess_payroll_tax_withheld": {
+        "2023": 0
+      },
+      "exemption_phase_out_start": {
+        "2023": "Infinity"
+      },
+      "exemptions": {
+        "2023": 6
+      },
+      "f2441": {
+        "2023": 2
+      },
+      "f6251": {
+        "2023": false
+      },
+      "federal_eitc_without_age_minimum": {
+        "2023": 4930.1777
+      },
+      "federal_state_income_tax": {
+        "2023": -10555.178
+      },
+      "ffpos": {
+        "2023": 0
+      },
+      "filer_cmbtp": {
+        "2023": 0
+      },
+      "filer_e00200": {
+        "2023": 40000
+      },
+      "filer_e00300": {
+        "2023": 0
+      },
+      "filer_e02300": {
+        "2023": 0
+      },
+      "filer_e18400": {
+        "2023": 0
+      },
+      "filer_earned": {
+        "2023": 40000
+      },
+      "filer_k1bx14": {
+        "2023": 0
+      },
+      "filer_pencon": {
+        "2023": 0
+      },
+      "filer_sey": {
+        "2023": 0
+      },
+      "filing_status": {
+        "2023": "JOINT"
+      },
+      "flat_tax": {
+        "2023": 0
+      },
+      "foreign_earned_income_exclusion": {
+        "2023": 0
+      },
+      "foreign_tax_credit": {
+        "2023": 0
+      },
+      "fstax": {
+        "2023": 0
+      },
+      "fuel_cell_property_capacity": {
+        "2023": 0
+      },
+      "fuel_cell_property_expenditures": {
+        "2023": 0
+      },
+      "ga_agi": {
+        "2023": 0
+      },
+      "ga_agi_additions": {
+        "2023": 0
+      },
+      "ga_agi_subtractions": {
+        "2023": 0
+      },
+      "ga_cdcc": {
+        "2023": 0
+      },
+      "ga_deductions": {
+        "2023": 0
+      },
+      "ga_exemptions": {
+        "2023": 0
+      },
+      "ga_income_tax": {
+        "2023": 0
+      },
+      "ga_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ga_low_income_credit": {
+        "2023": 0
+      },
+      "ga_refundable_credits": {
+        "2023": 0
+      },
+      "ga_taxable_income": {
+        "2023": 0
+      },
+      "geothermal_heat_pump_property_expenditures": {
+        "2023": 0
+      },
+      "h_seq": {
+        "2023": 0
+      },
+      "hasqdivltcg": {
+        "2023": false
+      },
+      "head_earned": {
+        "2023": 40000
+      },
+      "head_is_disabled": {
+        "2023": false
+      },
+      "head_spouse_count": {
+        "2023": 2
+      },
+      "health_savings_account_ald": {
+        "2023": 0
+      },
+      "heat_pump_expenditures": {
+        "2023": 0
+      },
+      "heat_pump_water_heater_expenditures": {
+        "2023": 0
+      },
+      "hi_agi": {
+        "2023": 0
+      },
+      "hi_eitc": {
+        "2023": 0
+      },
+      "hi_food_excise_credit": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_minor_child_amount": {
+        "2023": 0
+      },
+      "hi_food_excise_credit_minor_child_count": {
+        "2023": 0
+      },
+      "hi_food_excise_exemption_amount": {
+        "2023": 0
+      },
+      "hi_income_tax_before_credits": {
+        "2023": 0
+      },
+      "hi_standard_deduction": {
+        "2023": 0
+      },
+      "hi_tax_credit_for_low_income_household_renters": {
+        "2023": 0
+      },
+      "hi_tax_credit_for_low_income_household_renters_eligible": {
+        "2023": false
+      },
+      "hi_taxable_income": {
+        "2023": 0
+      },
+      "high_efficiency_electric_home_rebate": {
+        "2023": 0
+      },
+      "high_efficiency_electric_home_rebate_percent_covered": {
+        "2023": 1
+      },
+      "home_energy_audit_expenditures": {
+        "2023": 0
+      },
+      "household_state_income_tax": {
+        "2023": 0
+      },
+      "ia_alternate_tax_unit": {
+        "2023": 0
+      },
+      "ia_cdcc": {
+        "2023": 0
+      },
+      "ia_eitc": {
+        "2023": 0
+      },
+      "ia_exemption_credit": {
+        "2023": 0
+      },
+      "ia_files_separately": {
+        "2023": false
+      },
+      "ia_income_tax": {
+        "2023": 0
+      },
+      "ia_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ia_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ia_income_tax_indiv": {
+        "2023": 0
+      },
+      "ia_income_tax_joint": {
+        "2023": 0
+      },
+      "ia_is_tax_exempt": {
+        "2023": false
+      },
+      "ia_itemized_deductions_unit": {
+        "2023": 0
+      },
+      "ia_modified_income": {
+        "2023": 0
+      },
+      "ia_nonrefundable_credits": {
+        "2023": 0
+      },
+      "ia_reduced_tax": {
+        "2023": 0
+      },
+      "ia_refundable_credits": {
+        "2023": 0
+      },
+      "ia_reportable_social_security": {
+        "2023": 0
+      },
+      "id_ctc": {
+        "2023": 0
+      },
+      "id_income_tax": {
+        "2023": 0
+      },
+      "id_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "id_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "id_non_refundable_credits": {
+        "2023": 0
+      },
+      "id_refundable_credits": {
+        "2023": 0
+      },
+      "id_taxable_income": {
+        "2023": 0
+      },
+      "iitax": {
+        "2023": -10555.178
+      },
+      "il_aged_blind_exemption": {
+        "2023": 0
+      },
+      "il_base_income": {
+        "2023": 40000
+      },
+      "il_base_income_additions": {
+        "2023": 0
+      },
+      "il_base_income_subtractions": {
+        "2023": 0
+      },
+      "il_dependent_exemption": {
+        "2023": 9500
+      },
+      "il_eitc": {
+        "2023": 887.432
+      },
+      "il_income_tax": {
+        "2023": 0
+      },
+      "il_income_tax_before_nonrefundable_credits": {
+        "2023": 0
+      },
+      "il_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "il_is_exemption_eligible": {
+        "2023": false
+      },
+      "il_k12_education_expense_credit": {
+        "2023": 0
+      },
+      "il_nonrefundable_credits": {
+        "2023": 0
+      },
+      "il_pass_through_entity_tax_credit": {
+        "2023": 0
+      },
+      "il_pass_through_withholding": {
+        "2023": 0
+      },
+      "il_personal_exemption": {
+        "2023": 4750
+      },
+      "il_personal_exemption_eligibility_status": {
+        "2023": "BOTH_ELIGIBLE"
+      },
+      "il_property_tax_credit": {
+        "2023": 0
+      },
+      "il_refundable_credits": {
+        "2023": 0
+      },
+      "il_schedule_m_additions": {
+        "2023": 0
+      },
+      "il_schedule_m_subtractions": {
+        "2023": 0
+      },
+      "il_taxable_income": {
+        "2023": 40000
+      },
+      "il_total_exemptions": {
+        "2023": 0
+      },
+      "il_total_tax": {
+        "2023": 0
+      },
+      "il_use_tax": {
+        "2023": 18
+      },
+      "in_add_backs": {
+        "2023": 0
+      },
+      "in_additional_exemptions": {
+        "2023": 0
+      },
+      "in_aged_blind_exemptions": {
+        "2023": 0
+      },
+      "in_aged_low_agi_exemptions": {
+        "2023": 0
+      },
+      "in_agi": {
+        "2023": 0
+      },
+      "in_agi_tax": {
+        "2023": 0
+      },
+      "in_base_exemptions": {
+        "2023": 0
+      },
+      "in_bonus_depreciation_add_back": {
+        "2023": 0
+      },
+      "in_deductions": {
+        "2023": 0
+      },
+      "in_eitc": {
+        "2023": 0
+      },
+      "in_eitc_eligible": {
+        "2023": false
+      },
+      "in_exemptions": {
+        "2023": 0
+      },
+      "in_homeowners_property_tax_deduction": {
+        "2023": 0
+      },
+      "in_income_tax": {
+        "2023": 0
+      },
+      "in_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "in_military_service_deduction": {
+        "2023": 0
+      },
+      "in_nol": {
+        "2023": 0
+      },
+      "in_nol_add_back": {
+        "2023": 0
+      },
+      "in_nonpublic_school_deduction": {
+        "2023": 0
+      },
+      "in_oos_municipal_obligation_interest_add_back": {
+        "2023": 0
+      },
+      "in_other_add_backs": {
+        "2023": 0
+      },
+      "in_other_deductions": {
+        "2023": 0
+      },
+      "in_qualifying_child_count": {
+        "2023": 0
+      },
+      "in_refundable_credits": {
+        "2023": 0
+      },
+      "in_renters_deduction": {
+        "2023": 0
+      },
+      "in_section_179_expense_add_back": {
+        "2023": 0
+      },
+      "in_tax_add_back": {
+        "2023": 0
+      },
+      "in_unemployment_compensation_deduction": {
+        "2023": 0
+      },
+      "in_unified_elderly_tax_credit": {
+        "2023": 0
+      },
+      "in_use_tax": {
+        "2023": 0
+      },
+      "income_tax": {
+        "2023": -10555.178
+      },
+      "income_tax_before_credits": {
+        "2023": 1230
+      },
+      "income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "income_tax_capped_non_refundable_credits": {
+        "2023": 1230
+      },
+      "income_tax_main_rates": {
+        "2023": 1230
+      },
+      "income_tax_non_refundable_credits": {
+        "2023": 2375
+      },
+      "income_tax_refundable_credits": {
+        "2023": 10555.178
+      },
+      "income_tax_unavailable_non_refundable_credits": {
+        "2023": 1145
+      },
+      "interest_deduction": {
+        "2023": 0
+      },
+      "investment_in_529_plan": {
+        "2023": 0
+      },
+      "investment_income_form_4952": {
+        "2023": 0
+      },
+      "is_eligible_md_poverty_line_credit": {
+        "2023": false
+      },
+      "is_ma_income_tax_exempt": {
+        "2023": true
+      },
+      "is_ptc_eligible": {
+        "2023": false
+      },
+      "itemized_deductions_less_salt": {
+        "2023": 0
+      },
+      "itemized_taxable_income_deductions": {
+        "2023": 0
+      },
+      "k12_tuition_and_fees": {
+        "2023": 0
+      },
+      "ks_agi": {
+        "2023": 0
+      },
+      "ks_agi_additions": {
+        "2023": 0
+      },
+      "ks_agi_subtractions": {
+        "2023": 0
+      },
+      "ks_cdcc": {
+        "2023": 0
+      },
+      "ks_count_exemptions": {
+        "2023": 0
+      },
+      "ks_exemptions": {
+        "2023": 0
+      },
+      "ks_fstc": {
+        "2023": 0
+      },
+      "ks_income_tax": {
+        "2023": 0
+      },
+      "ks_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ks_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ks_itemized_deductions": {
+        "2023": 0
+      },
+      "ks_nonrefundable_credits": {
+        "2023": 0
+      },
+      "ks_nonrefundable_eitc": {
+        "2023": 0
+      },
+      "ks_refundable_credits": {
+        "2023": 0
+      },
+      "ks_refundable_eitc": {
+        "2023": 0
+      },
+      "ks_standard_deduction": {
+        "2023": 0
+      },
+      "ks_taxable_income": {
+        "2023": 0
+      },
+      "ks_total_eitc": {
+        "2023": 0
+      },
+      "ky_cdcc": {
+        "2023": 0
+      },
+      "ky_income_tax": {
+        "2023": 0
+      },
+      "ky_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ky_refundable_credits": {
+        "2023": 0
+      },
+      "ky_standard_deduction": {
+        "2023": 0
+      },
+      "ky_taxable_income": {
+        "2023": 0
+      },
+      "la_cdcc": {
+        "2023": 0
+      },
+      "la_cdcc_non_refundable": {
+        "2023": 0
+      },
+      "la_cdcc_refundable": {
+        "2023": 0
+      },
+      "la_cdcc_refundable_eligible": {
+        "2023": false
+      },
+      "la_eitc": {
+        "2023": 0
+      },
+      "la_income_tax": {
+        "2023": 0
+      },
+      "la_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "la_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "la_non_refundable_credits": {
+        "2023": 0
+      },
+      "la_refundable_credits": {
+        "2023": 0
+      },
+      "la_taxable_income": {
+        "2023": 0
+      },
+      "lifetime_learning_credit": {
+        "2023": 0
+      },
+      "limited_capital_loss": {
+        "2023": 0
+      },
+      "local_income_tax": {
+        "2023": 0
+      },
+      "local_sales_tax": {
+        "2023": 0
+      },
+      "loss_ald": {
+        "2023": 0
+      },
+      "ma_agi": {
+        "2023": 0
+      },
+      "ma_dependent_care_credit": {
+        "2023": 0
+      },
+      "ma_dependent_credit": {
+        "2023": 0
+      },
+      "ma_dependent_or_dependent_care_credit": {
+        "2023": 0
+      },
+      "ma_eitc": {
+        "2023": 0
+      },
+      "ma_gross_income": {
+        "2023": 0
+      },
+      "ma_income_tax": {
+        "2023": 0
+      },
+      "ma_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ma_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ma_income_tax_exemption_threshold": {
+        "2023": 0
+      },
+      "ma_limited_income_tax_credit": {
+        "2023": 0
+      },
+      "ma_non_refundable_credits": {
+        "2023": 0
+      },
+      "ma_part_a_agi": {
+        "2023": 0
+      },
+      "ma_part_a_cg_excess_exemption": {
+        "2023": 0
+      },
+      "ma_part_a_div_excess_exemption": {
+        "2023": 0
+      },
+      "ma_part_a_gross_income": {
+        "2023": 0
+      },
+      "ma_part_a_taxable_capital_gains_income": {
+        "2023": 0
+      },
+      "ma_part_a_taxable_dividend_income": {
+        "2023": 0
+      },
+      "ma_part_a_taxable_income": {
+        "2023": 0
+      },
+      "ma_part_b_agi": {
+        "2023": 0
+      },
+      "ma_part_b_excess_exemption": {
+        "2023": 0
+      },
+      "ma_part_b_gross_income": {
+        "2023": 0
+      },
+      "ma_part_b_taxable_income": {
+        "2023": 0
+      },
+      "ma_part_b_taxable_income_before_exemption": {
+        "2023": 0
+      },
+      "ma_part_b_taxable_income_deductions": {
+        "2023": 0
+      },
+      "ma_part_b_taxable_income_exemption": {
+        "2023": 0
+      },
+      "ma_part_c_agi": {
+        "2023": 0
+      },
+      "ma_part_c_gross_income": {
+        "2023": 0
+      },
+      "ma_part_c_taxable_income": {
+        "2023": 0
+      },
+      "ma_refundable_credits": {
+        "2023": 0
+      },
+      "ma_scb_total_income": {
+        "2023": 0
+      },
+      "ma_senior_circuit_breaker": {
+        "2023": 0
+      },
+      "mars": {
+        "2023": "JOINT"
+      },
+      "md_aged_blind_exemptions": {
+        "2023": 0
+      },
+      "md_aged_dependent_exemption": {
+        "2023": 0
+      },
+      "md_aged_exemption": {
+        "2023": 0
+      },
+      "md_agi": {
+        "2023": 0
+      },
+      "md_blind_exemption": {
+        "2023": 0
+      },
+      "md_cdcc": {
+        "2023": 0
+      },
+      "md_ctc": {
+        "2023": 0
+      },
+      "md_ctc_eligible": {
+        "2023": false
+      },
+      "md_deductions": {
+        "2023": 0
+      },
+      "md_dependent_care_subtraction": {
+        "2023": 0
+      },
+      "md_eitc": {
+        "2023": 0
+      },
+      "md_exemptions": {
+        "2023": 0
+      },
+      "md_income_tax": {
+        "2023": 0
+      },
+      "md_income_tax_before_credits": {
+        "2023": 0
+      },
+      "md_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "md_local_income_tax_before_credits": {
+        "2023": 0
+      },
+      "md_non_refundable_credits": {
+        "2023": 0
+      },
+      "md_non_refundable_eitc": {
+        "2023": 0
+      },
+      "md_non_single_childless_non_refundable_eitc": {
+        "2023": 0
+      },
+      "md_non_single_childless_refundable_eitc": {
+        "2023": 0
+      },
+      "md_pension_subtraction": {
+        "2023": 0
+      },
+      "md_personal_exemption": {
+        "2023": 0
+      },
+      "md_poverty_line_credit": {
+        "2023": 0
+      },
+      "md_qualifies_for_single_childless_eitc": {
+        "2023": false
+      },
+      "md_refundable_cdcc": {
+        "2023": 0
+      },
+      "md_refundable_credits": {
+        "2023": 0
+      },
+      "md_refundable_eitc": {
+        "2023": 0
+      },
+      "md_senior_tax_credit": {
+        "2023": 0
+      },
+      "md_senior_tax_credit_eligible": {
+        "2023": false
+      },
+      "md_single_childless_eitc": {
+        "2023": 0
+      },
+      "md_socsec_subtraction": {
+        "2023": 0
+      },
+      "md_standard_deduction": {
+        "2023": 0
+      },
+      "md_tax_unit_earned_income": {
+        "2023": 0
+      },
+      "md_taxable_income": {
+        "2023": 0
+      },
+      "md_total_additions": {
+        "2023": 0
+      },
+      "md_total_personal_exemptions": {
+        "2023": 0
+      },
+      "md_total_subtractions": {
+        "2023": 0
+      },
+      "md_two_income_subtraction": {
+        "2023": 0
+      },
+      "me_agi": {
+        "2023": 0
+      },
+      "me_agi_additions": {
+        "2023": 0
+      },
+      "me_agi_subtractions": {
+        "2023": 0
+      },
+      "me_child_care_credit": {
+        "2023": 0
+      },
+      "me_deduction_phaseout_percentage": {
+        "2023": 0
+      },
+      "me_deductions": {
+        "2023": 0
+      },
+      "me_dependent_exemption": {
+        "2023": 0
+      },
+      "me_eitc": {
+        "2023": 0
+      },
+      "me_exemptions": {
+        "2023": 0
+      },
+      "me_income_tax": {
+        "2023": 0
+      },
+      "me_income_tax_before_credits": {
+        "2023": 0
+      },
+      "me_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "me_itemized_deductions_pre_phaseout": {
+        "2023": 0
+      },
+      "me_non_refundable_child_care_credit": {
+        "2023": 0
+      },
+      "me_non_refundable_credits": {
+        "2023": 0
+      },
+      "me_pension_income_deduction": {
+        "2023": 0
+      },
+      "me_personal_exemption_deduction": {
+        "2023": 0
+      },
+      "me_refundable_child_care_credit": {
+        "2023": 0
+      },
+      "me_refundable_credits": {
+        "2023": 0
+      },
+      "me_step_4_share_of_child_care_expenses": {
+        "2023": 0
+      },
+      "me_taxable_income": {
+        "2023": 0
+      },
+      "medicaid_income": {
+        "2023": 40000
+      },
+      "medical_expense_deduction": {
+        "2023": 0
+      },
+      "members": [
+        "you",
+        "your partner",
+        "your first dependent",
+        "your second dependent",
+        "your third dependent",
+        "your fourth dependent"
+      ],
+      "mi_eitc": {
+        "2023": 0
+      },
+      "mi_exemptions": {
+        "2023": 0
+      },
+      "mi_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mi_taxable_income": {
+        "2023": 0
+      },
+      "military_disabled_head": {
+        "2023": false
+      },
+      "military_disabled_spouse": {
+        "2023": false
+      },
+      "min_head_spouse_earned": {
+        "2023": 0
+      },
+      "misc_deduction": {
+        "2023": 0
+      },
+      "mn_additions": {
+        "2023": 0
+      },
+      "mn_amt": {
+        "2023": 0
+      },
+      "mn_amt_taxable_income": {
+        "2023": 0
+      },
+      "mn_basic_tax": {
+        "2023": 0
+      },
+      "mn_cdcc": {
+        "2023": 0
+      },
+      "mn_charity_subtraction": {
+        "2023": 0
+      },
+      "mn_deductions": {
+        "2023": 0
+      },
+      "mn_elderly_disabled_subtraction": {
+        "2023": 0
+      },
+      "mn_exemptions": {
+        "2023": 0
+      },
+      "mn_income_tax": {
+        "2023": 0
+      },
+      "mn_income_tax_before_credits": {
+        "2023": 0
+      },
+      "mn_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "mn_itemized_deductions": {
+        "2023": 0
+      },
+      "mn_itemizing": {
+        "2023": false
+      },
+      "mn_marriage_credit": {
+        "2023": 0
+      },
+      "mn_nonrefundable_credits": {
+        "2023": 0
+      },
+      "mn_refundable_credits": {
+        "2023": 0
+      },
+      "mn_social_security_subtraction": {
+        "2023": 0
+      },
+      "mn_standard_deduction": {
+        "2023": 0
+      },
+      "mn_subtractions": {
+        "2023": 0
+      },
+      "mn_taxable_income": {
+        "2023": 0
+      },
+      "mn_wfc": {
+        "2023": 0
+      },
+      "mn_wfc_eligible": {
+        "2023": false
+      },
+      "mo_federal_income_tax_deduction": {
+        "2023": 0
+      },
+      "mo_income_tax": {
+        "2023": 0
+      },
+      "mo_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "mo_itemized_deductions": {
+        "2023": 0
+      },
+      "mo_net_state_income_taxes": {
+        "2023": 0
+      },
+      "mo_non_refundable_credits": {
+        "2023": 0
+      },
+      "mo_pension_and_ss_or_ssd_deduction": {
+        "2023": 0
+      },
+      "mo_property_tax_credit": {
+        "2023": 0
+      },
+      "mo_ptc_gross_income": {
+        "2023": 0
+      },
+      "mo_ptc_income_offset": {
+        "2023": 0
+      },
+      "mo_ptc_net_income": {
+        "2023": 0
+      },
+      "mo_ptc_taxunit_eligible": {
+        "2023": 0
+      },
+      "mo_refundable_credits": {
+        "2023": 0
+      },
+      "mo_wftc": {
+        "2023": 0
+      },
+      "ms_aged_exemption": {
+        "2023": 0
+      },
+      "ms_blind_exemption": {
+        "2023": 0
+      },
+      "ms_dependents_exemption": {
+        "2023": 0
+      },
+      "ms_itemized_deductions": {
+        "2023": 0
+      },
+      "ms_regular_exemption": {
+        "2023": 0
+      },
+      "ms_standard_deduction": {
+        "2023": 0
+      },
+      "ms_total_exemptions": {
+        "2023": 0
+      },
+      "mt_aged_exemption_count": {
+        "2023": 0
+      },
+      "mt_agi": {
+        "2023": 0
+      },
+      "mt_dependent_exemption_count": {
+        "2023": 0
+      },
+      "mt_eitc": {
+        "2023": 147.90533
+      },
+      "mt_exemptions": {
+        "2023": 0
+      },
+      "mt_exemptions_count": {
+        "2023": 0
+      },
+      "mt_income_tax": {
+        "2023": 0
+      },
+      "mt_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "mt_refundable_credits": {
+        "2023": 0
+      },
+      "mt_standard_deduction": {
+        "2023": 0
+      },
+      "mt_taxable_income": {
+        "2023": 0
+      },
+      "n1820": {
+        "2023": 0
+      },
+      "n21": {
+        "2023": 0
+      },
+      "n24": {
+        "2023": 0
+      },
+      "nc_ctc": {
+        "2023": 0
+      },
+      "nc_income_tax": {
+        "2023": 0
+      },
+      "nc_income_tax_before_credits": {
+        "2023": 0
+      },
+      "nc_non_refundable_credits": {
+        "2023": 0
+      },
+      "nc_taxable_income": {
+        "2023": 0
+      },
+      "nd_additions": {
+        "2023": 0
+      },
+      "nd_income_tax": {
+        "2023": 0
+      },
+      "nd_income_tax_before_credits": {
+        "2023": 0
+      },
+      "nd_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "nd_ltcg_subtraction": {
+        "2023": 0
+      },
+      "nd_mpc": {
+        "2023": 0
+      },
+      "nd_nonrefundable_credits": {
+        "2023": 0
+      },
+      "nd_qdiv_subtraction": {
+        "2023": 0
+      },
+      "nd_refundable_credits": {
+        "2023": 0
+      },
+      "nd_rtrc": {
+        "2023": 0
+      },
+      "nd_subtractions": {
+        "2023": 0
+      },
+      "nd_taxable_income": {
+        "2023": 0
+      },
+      "ne_agi": {
+        "2023": 0
+      },
+      "ne_agi_additions": {
+        "2023": 0
+      },
+      "ne_agi_subtractions": {
+        "2023": 0
+      },
+      "ne_cdcc_nonrefundable": {
+        "2023": 0
+      },
+      "ne_cdcc_refundable": {
+        "2023": 0
+      },
+      "ne_eitc": {
+        "2023": 0
+      },
+      "ne_elderly_disabled_credit": {
+        "2023": 0
+      },
+      "ne_exemptions": {
+        "2023": 0
+      },
+      "ne_income_tax": {
+        "2023": 0
+      },
+      "ne_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ne_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ne_itemized_deductions": {
+        "2023": 0
+      },
+      "ne_nonrefundable_credits": {
+        "2023": 0
+      },
+      "ne_refundable_credits": {
+        "2023": 0
+      },
+      "ne_standard_deduction": {
+        "2023": 0
+      },
+      "ne_taxable_income": {
+        "2023": 0
+      },
+      "net_capital_gain": {
+        "2023": 0
+      },
+      "net_investment_income": {
+        "2023": 0
+      },
+      "net_investment_income_tax": {
+        "2023": 0
+      },
+      "new_clean_vehicle_battery_capacity": {
+        "2023": 0
+      },
+      "new_clean_vehicle_battery_components_made_in_north_america": {
+        "2023": 0
+      },
+      "new_clean_vehicle_battery_critical_minerals_extracted_in_trading_partner_country": {
+        "2023": 0
+      },
+      "new_clean_vehicle_classification": {
+        "2023": "OTHER"
+      },
+      "new_clean_vehicle_credit": {
+        "2023": 0
+      },
+      "new_clean_vehicle_credit_eligible": {
+        "2023": false
+      },
+      "new_clean_vehicle_msrp": {
+        "2023": 0
+      },
+      "nh_base_exemption": {
+        "2023": 0
+      },
+      "nh_blind_exemption": {
+        "2023": 0
+      },
+      "nh_disabled_exemption": {
+        "2023": 0
+      },
+      "nh_education_tax_credit": {
+        "2023": 0
+      },
+      "nh_income_tax": {
+        "2023": 0
+      },
+      "nh_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "nh_old_age_exemption": {
+        "2023": 0
+      },
+      "nh_refundable_credits": {
+        "2023": 0
+      },
+      "nh_taxable_income": {
+        "2023": 0
+      },
+      "nh_total_exemptions": {
+        "2023": 0
+      },
+      "nj_agi": {
+        "2023": 0
+      },
+      "nj_blind_or_disabled_exemption": {
+        "2023": 0
+      },
+      "nj_cdcc": {
+        "2023": 0
+      },
+      "nj_childless_eitc_age_eligible": {
+        "2023": false
+      },
+      "nj_ctc": {
+        "2023": 0
+      },
+      "nj_dependents_attending_college_exemption": {
+        "2023": 0
+      },
+      "nj_dependents_exemption": {
+        "2023": 0
+      },
+      "nj_eitc": {
+        "2023": 0
+      },
+      "nj_eitc_income_eligible": {
+        "2023": false
+      },
+      "nj_income_tax": {
+        "2023": 0
+      },
+      "nj_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "nj_main_income_tax": {
+        "2023": 0
+      },
+      "nj_non_refundable_credits": {
+        "2023": 0
+      },
+      "nj_other_retirement_income_exclusion": {
+        "2023": 0
+      },
+      "nj_other_retirement_special_exclusion": {
+        "2023": 0
+      },
+      "nj_pension_retirement_exclusion": {
+        "2023": 0
+      },
+      "nj_potential_property_tax_deduction": {
+        "2023": 0
+      },
+      "nj_property_tax_credit": {
+        "2023": 0
+      },
+      "nj_property_tax_credit_eligible": {
+        "2023": false
+      },
+      "nj_property_tax_deduction": {
+        "2023": 0
+      },
+      "nj_property_tax_deduction_eligible": {
+        "2023": false
+      },
+      "nj_refundable_credits": {
+        "2023": 0
+      },
+      "nj_regular_exemption": {
+        "2023": 0
+      },
+      "nj_retirement_exclusion_fraction": {
+        "2023": 0
+      },
+      "nj_senior_exemption": {
+        "2023": 0
+      },
+      "nj_taking_property_tax_deduction": {
+        "2023": false
+      },
+      "nj_taxable_income": {
+        "2023": 0
+      },
+      "nj_taxable_income_before_property_tax_deduction": {
+        "2023": 0
+      },
+      "nj_total_deductions": {
+        "2023": 0
+      },
+      "nj_total_exemptions": {
+        "2023": 0
+      },
+      "nm_2021_income_rebate": {
+        "2023": 0
+      },
+      "nm_additional_2021_income_rebate": {
+        "2023": 0
+      },
+      "nm_additions": {
+        "2023": 0
+      },
+      "nm_aged_blind_exemption": {
+        "2023": 0
+      },
+      "nm_cdcc": {
+        "2023": 0
+      },
+      "nm_cdcc_eligible": {
+        "2023": false
+      },
+      "nm_cdcc_max_amount": {
+        "2023": 0
+      },
+      "nm_ctc": {
+        "2023": 0
+      },
+      "nm_deduction_for_certain_dependents": {
+        "2023": 0
+      },
+      "nm_deduction_for_certain_dependents_eligible": {
+        "2023": false
+      },
+      "nm_deductions": {
+        "2023": 0
+      },
+      "nm_eitc": {
+        "2023": 0
+      },
+      "nm_eitc_demographic_eligible": {
+        "2023": true
+      },
+      "nm_eitc_eligible": {
+        "2023": false
+      },
+      "nm_exemptions": {
+        "2023": 0
+      },
+      "nm_hundred_year_exemption": {
+        "2023": 0
+      },
+      "nm_income_tax": {
+        "2023": 0
+      },
+      "nm_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "nm_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "nm_itemized_deductions": {
+        "2023": 0
+      },
+      "nm_low_and_middle_income_exemption": {
+        "2023": 0
+      },
+      "nm_low_income_comprehensive_tax_rebate": {
+        "2023": 0
+      },
+      "nm_low_income_comprehensive_tax_rebate_exemptions": {
+        "2023": 0
+      },
+      "nm_medical_care_expense_deduction": {
+        "2023": 0
+      },
+      "nm_medical_expense_credit": {
+        "2023": 0
+      },
+      "nm_medical_expense_exemption": {
+        "2023": 0
+      },
+      "nm_modified_gross_income": {
+        "2023": 0
+      },
+      "nm_net_capital_gains_deduction": {
+        "2023": 0
+      },
+      "nm_non_refundable_credits": {
+        "2023": 0
+      },
+      "nm_other_deductions_and_exemptions": {
+        "2023": 0
+      },
+      "nm_property_tax_rebate": {
+        "2023": 0
+      },
+      "nm_property_tax_rebate_eligible": {
+        "2023": false
+      },
+      "nm_refundable_credits": {
+        "2023": 0
+      },
+      "nm_social_security_income_exemption": {
+        "2023": 0
+      },
+      "nm_supplemental_2021_income_rebate": {
+        "2023": 0
+      },
+      "nm_taxable_income": {
+        "2023": 0
+      },
+      "non_refundable_american_opportunity_credit": {
+        "2023": 0
+      },
+      "non_refundable_ctc": {
+        "2023": 2375
+      },
+      "nu06": {
+        "2023": 0
+      },
+      "nu13": {
+        "2023": 0
+      },
+      "nu18": {
+        "2023": 0
+      },
+      "num": {
+        "2023": 2
+      },
+      "ny_agi": {
+        "2023": 0
+      },
+      "ny_agi_additions": {
+        "2023": 0
+      },
+      "ny_agi_subtractions": {
+        "2023": 0
+      },
+      "ny_cdcc": {
+        "2023": 0
+      },
+      "ny_cdcc_max": {
+        "2023": 0
+      },
+      "ny_cdcc_rate": {
+        "2023": 0
+      },
+      "ny_college_tuition_credit": {
+        "2023": 0
+      },
+      "ny_ctc": {
+        "2023": 0
+      },
+      "ny_deductions": {
+        "2023": 0
+      },
+      "ny_eitc": {
+        "2023": 0
+      },
+      "ny_exemptions": {
+        "2023": 0
+      },
+      "ny_household_credit": {
+        "2023": 0
+      },
+      "ny_income_tax": {
+        "2023": 0
+      },
+      "ny_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ny_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ny_itemized_deductions": {
+        "2023": 0
+      },
+      "ny_itemized_deductions_max": {
+        "2023": 0
+      },
+      "ny_itemized_deductions_reduction": {
+        "2023": 0
+      },
+      "ny_itemizes": {
+        "2023": false
+      },
+      "ny_main_income_tax": {
+        "2023": 0
+      },
+      "ny_non_refundable_credits": {
+        "2023": 0
+      },
+      "ny_real_property_tax_credit": {
+        "2023": 0
+      },
+      "ny_refundable_credits": {
+        "2023": 0
+      },
+      "ny_standard_deduction": {
+        "2023": 0
+      },
+      "ny_supplemental_eitc": {
+        "2023": 0
+      },
+      "ny_supplemental_tax": {
+        "2023": 0
+      },
+      "ny_taxable_income": {
+        "2023": 0
+      },
+      "nyc_cdcc": {
+        "2023": 0
+      },
+      "nyc_cdcc_age_restricted_expenses": {
+        "2023": 0
+      },
+      "nyc_cdcc_applicable_percentage": {
+        "2023": 0
+      },
+      "nyc_cdcc_eligible": {
+        "2023": false
+      },
+      "nyc_cdcc_share_qualifying_childcare_expenses": {
+        "2023": 0
+      },
+      "nyc_eitc": {
+        "2023": 0
+      },
+      "nyc_household_credit": {
+        "2023": 0
+      },
+      "nyc_income_tax": {
+        "2023": 0
+      },
+      "nyc_income_tax_before_credits": {
+        "2023": 0
+      },
+      "nyc_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "nyc_non_refundable_credits": {
+        "2023": 0
+      },
+      "nyc_refundable_credits": {
+        "2023": 0
+      },
+      "nyc_school_credit_income": {
+        "2023": 0
+      },
+      "nyc_school_tax_credit_fixed_amount": {
+        "2023": 0
+      },
+      "nyc_school_tax_credit_rate_reduction_amount": {
+        "2023": 0
+      },
+      "nyc_taxable_income": {
+        "2023": 0
+      },
+      "nyc_unincorporated_business_credit": {
+        "2023": 0
+      },
+      "oh_agi": {
+        "2023": 0
+      },
+      "oh_bonus_depreciation_add_back": {
+        "2023": 0
+      },
+      "oh_cdcc": {
+        "2023": 0
+      },
+      "oh_eitc": {
+        "2023": 0
+      },
+      "oh_federal_conformity_deductions": {
+        "2023": 0
+      },
+      "oh_income_tax_before_credits": {
+        "2023": 0
+      },
+      "oh_income_tax_exempt": {
+        "2023": false
+      },
+      "oh_non_public_school_credits": {
+        "2023": 0
+      },
+      "oh_other_add_backs": {
+        "2023": 0
+      },
+      "oh_section_179_expense_add_back": {
+        "2023": 0
+      },
+      "oh_senior_citizen_credit": {
+        "2023": 0
+      },
+      "oh_taxable_income": {
+        "2023": 0
+      },
+      "oh_uniformed_services_retirement_income_deduction": {
+        "2023": 0
+      },
+      "ok_adjustments": {
+        "2023": 0
+      },
+      "ok_agi": {
+        "2023": 0
+      },
+      "ok_agi_additions": {
+        "2023": 0
+      },
+      "ok_agi_subtractions": {
+        "2023": 0
+      },
+      "ok_child_care_child_tax_credit": {
+        "2023": 0
+      },
+      "ok_count_exemptions": {
+        "2023": 0
+      },
+      "ok_eitc": {
+        "2023": 0
+      },
+      "ok_exemptions": {
+        "2023": 0
+      },
+      "ok_gross_income": {
+        "2023": 0
+      },
+      "ok_income_tax": {
+        "2023": 0
+      },
+      "ok_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ok_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ok_itemized_deductions": {
+        "2023": 0
+      },
+      "ok_nonrefundable_credits": {
+        "2023": 0
+      },
+      "ok_ptc": {
+        "2023": 0
+      },
+      "ok_refundable_credits": {
+        "2023": 0
+      },
+      "ok_standard_deduction": {
+        "2023": 0
+      },
+      "ok_stc": {
+        "2023": 0
+      },
+      "ok_taxable_income": {
+        "2023": 0
+      },
+      "ok_use_tax": {
+        "2023": 0
+      },
+      "or_ctc": {
+        "2023": 0
+      },
+      "or_deductions": {
+        "2023": 0
+      },
+      "or_disabled_child_dependent_exemptions": {
+        "2023": 0
+      },
+      "or_eitc": {
+        "2023": 0
+      },
+      "or_exemption_credit": {
+        "2023": 0
+      },
+      "or_federal_pension_subtraction": {
+        "2023": 0
+      },
+      "or_federal_tax_liability_subtraction": {
+        "2023": 0
+      },
+      "or_income_additions": {
+        "2023": 0
+      },
+      "or_income_after_additions": {
+        "2023": 0
+      },
+      "or_income_after_subtractions": {
+        "2023": 0
+      },
+      "or_income_subtractions": {
+        "2023": 0
+      },
+      "or_income_tax": {
+        "2023": 0
+      },
+      "or_income_tax_before_credits": {
+        "2023": 0
+      },
+      "or_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "or_itemized_deductions": {
+        "2023": 0
+      },
+      "or_kicker": {
+        "2023": 0
+      },
+      "or_non_refundable_credits": {
+        "2023": 0
+      },
+      "or_refundable_credits": {
+        "2023": 0
+      },
+      "or_regular_exemptions": {
+        "2023": 0
+      },
+      "or_retirement_credit": {
+        "2023": 0
+      },
+      "or_retirement_credit_household_income": {
+        "2023": 0
+      },
+      "or_severely_disabled_exemptions": {
+        "2023": 0
+      },
+      "or_standard_deduction": {
+        "2023": 0
+      },
+      "or_tax_before_credits_in_prior_year": {
+        "2023": 0
+      },
+      "or_taxable_income": {
+        "2023": 0
+      },
+      "other_net_gain": {
+        "2023": 0
+      },
+      "othertaxes": {
+        "2023": 0
+      },
+      "pa_adjusted_taxable_income": {
+        "2023": 0
+      },
+      "pa_eligibility_income": {
+        "2023": 0
+      },
+      "pa_income_tax": {
+        "2023": 0
+      },
+      "pa_income_tax_after_forgiveness": {
+        "2023": 0
+      },
+      "pa_income_tax_before_forgiveness": {
+        "2023": 0
+      },
+      "pa_tax_deductions": {
+        "2023": 0
+      },
+      "pa_tax_forgiveness_amount": {
+        "2023": 0
+      },
+      "pa_tax_forgiveness_rate": {
+        "2023": 0
+      },
+      "pa_total_taxable_income": {
+        "2023": 0
+      },
+      "pa_use_tax": {
+        "2023": 0
+      },
+      "pell_grant_dependents_in_college": {
+        "2023": 0
+      },
+      "pell_grant_head_assets": {
+        "2023": 0
+      },
+      "pell_grant_primary_income": {
+        "2023": 0
+      },
+      "positive_agi": {
+        "2023": 40000
+      },
+      "pre_c04600": {
+        "2023": 0
+      },
+      "premium_tax_credit": {
+        "2023": 0
+      },
+      "prior_energy_efficient_home_improvement_credits": {
+        "2023": 0
+      },
+      "prior_energy_efficient_window_credits": {
+        "2023": 0
+      },
+      "property_tax_primary_residence": {
+        "2023": 0
+      },
+      "ptc_phase_out_rate": {
+        "2023": 0.02
+      },
+      "puerto_rico_income": {
+        "2023": 0
+      },
+      "purchased_qualifying_new_clean_vehicle": {
+        "2023": false
+      },
+      "purchased_qualifying_used_clean_vehicle": {
+        "2023": false
+      },
+      "qualified_battery_storage_technology_expenditures": {
+        "2023": 0
+      },
+      "qualified_business_income_deduction": {
+        "2023": 0
+      },
+      "qualified_furnace_or_hot_water_boiler_expenditures": {
+        "2023": 0
+      },
+      "qualified_retirement_penalty": {
+        "2023": 0
+      },
+      "recapture_of_investment_credit": {
+        "2023": 0
+      },
+      "recovery_rebate_credit": {
+        "2023": 0
+      },
+      "refundable_american_opportunity_credit": {
+        "2023": 0
+      },
+      "refundable_ctc": {
+        "2023": 5625
+      },
+      "refundable_payroll_tax_credit": {
+        "2023": 0
+      },
+      "regular_tax_before_credits": {
+        "2023": 1230
+      },
+      "rents": {
+        "2023": false
+      },
+      "reported_slspc": {
+        "2023": 0
+      },
+      "residential_clean_energy_credit": {
+        "2023": 0
+      },
+      "residential_efficiency_electrification_rebate": {
+        "2023": 0
+      },
+      "residential_efficiency_electrification_retrofit_energy_savings": {
+        "2023": 0
+      },
+      "residential_efficiency_electrification_retrofit_expenditures": {
+        "2023": 0
+      },
+      "retirement_savings_credit": {
+        "2023": 0
+      },
+      "ri_cdcc": {
+        "2023": 0
+      },
+      "ri_eitc": {
+        "2023": 0
+      },
+      "ri_income_tax": {
+        "2023": 0
+      },
+      "ri_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ri_refundable_credits": {
+        "2023": 0
+      },
+      "ri_standard_deduction": {
+        "2023": 0
+      },
+      "ri_taxable_income": {
+        "2023": 0
+      },
+      "rptc": {
+        "2023": 0
+      },
+      "rrc_arpa": {
+        "2023": 0
+      },
+      "rrc_caa": {
+        "2023": 0
+      },
+      "rrc_cares": {
+        "2023": 0
+      },
+      "salt_deduction": {
+        "2023": 0
+      },
+      "salt_refund_last_year": {
+        "2023": 0
+      },
+      "sc_cdcc": {
+        "2023": 0
+      },
+      "sc_eitc": {
+        "2023": 6162.7
+      },
+      "sc_income_tax_before_credits": {
+        "2023": 0
+      },
+      "sc_military_retirement_income_deduction_head": {
+        "2023": 0
+      },
+      "sc_military_retirement_income_deduction_spouse": {
+        "2023": 0
+      },
+      "sc_retirement_income_deduction_head": {
+        "2023": 0
+      },
+      "sc_retirement_income_deduction_spouse": {
+        "2023": 0
+      },
+      "sc_senior_exemption": {
+        "2023": 0
+      },
+      "sc_state_tax_addback": {
+        "2023": 0
+      },
+      "sc_taxable_income": {
+        "2023": 0
+      },
+      "sc_two_wage_earner_credit": {
+        "2023": 0
+      },
+      "sc_young_child_exemption": {
+        "2023": 0
+      },
+      "second_lowest_silver_plan_cost": {
+        "2023": 0
+      },
+      "section_22_income": {
+        "2023": 0
+      },
+      "self_employed_health_insurance_ald": {
+        "2023": 0
+      },
+      "self_employed_pension_contribution_ald": {
+        "2023": 0
+      },
+      "self_employment_tax_ald": {
+        "2023": 0
+      },
+      "sep": {
+        "2023": 1
+      },
+      "separate_filer_itemizes": {
+        "2023": false
+      },
+      "small_wind_energy_property_expenditures": {
+        "2023": 0
+      },
+      "solar_electric_property_expenditures": {
+        "2023": 0
+      },
+      "solar_water_heating_property_expenditures": {
+        "2023": 0
+      },
+      "specified_possession_income": {
+        "2023": 0
+      },
+      "spouse_earned": {
+        "2023": 0
+      },
+      "spouse_is_disabled": {
+        "2023": false
+      },
+      "spouse_separate_adjusted_gross_income": {
+        "2023": 0
+      },
+      "spouse_separate_tax_unit_size": {
+        "2023": 0
+      },
+      "standard": {
+        "2023": 27700
+      },
+      "standard_deduction": {
+        "2023": 27700
+      },
+      "state_and_local_sales_or_income_tax": {
+        "2023": 0
+      },
+      "state_income_tax": {
+        "2023": 0
+      },
+      "state_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "state_sales_tax": {
+        "2023": 0
+      },
+      "surtax": {
+        "2023": 0
+      },
+      "tax": {
+        "2023": -7495.1777
+      },
+      "tax_exempt_social_security": {
+        "2023": 0
+      },
+      "tax_liability_if_itemizing": {
+        "2023": -10555.178
+      },
+      "tax_liability_if_not_itemizing": {
+        "2023": -10555.178
+      },
+      "tax_unit_childcare_expenses": {
+        "2023": 0
+      },
+      "tax_unit_children": {
+        "2023": 4
+      },
+      "tax_unit_count_dependents": {
+        "2023": 4
+      },
+      "tax_unit_dependent_elsewhere": {
+        "2023": false
+      },
+      "tax_unit_dependents": {
+        "2023": 4
+      },
+      "tax_unit_earned_income": {
+        "2023": 40000
+      },
+      "tax_unit_fpg": {
+        "2023": 40280
+      },
+      "tax_unit_id": {
+        "2023": 0
+      },
+      "tax_unit_income_ami_ratio": {
+        "2023": 0
+      },
+      "tax_unit_is_joint": {
+        "2023": true
+      },
+      "tax_unit_itemizes": {
+        "2023": false
+      },
+      "tax_unit_medicaid_income_level": {
+        "2023": 0.99304867
+      },
+      "tax_unit_net_capital_gains": {
+        "2023": 0
+      },
+      "tax_unit_partnership_s_corp_income": {
+        "2023": 0
+      },
+      "tax_unit_rental_income": {
+        "2023": 0
+      },
+      "tax_unit_size": {
+        "2023": 6
+      },
+      "tax_unit_social_security": {
+        "2023": 0
+      },
+      "tax_unit_spouse_dependent_elsewhere": {
+        "2023": false
+      },
+      "tax_unit_ss": {
+        "2023": 0
+      },
+      "tax_unit_ssi": {
+        "2023": 0
+      },
+      "tax_unit_state": {
+        "2023": "AL"
+      },
+      "tax_unit_stillborn_children": {
+        "2023": 0
+      },
+      "tax_unit_taxable_social_security": {
+        "2023": 0
+      },
+      "tax_unit_taxable_unemployment_compensation": {
+        "2023": 0
+      },
+      "tax_unit_unemployment_compensation": {
+        "2023": 0
+      },
+      "tax_unit_weight": {
+        "2023": 0
+      },
+      "taxable_income": {
+        "2023": 12300
+      },
+      "taxable_income_deductions": {
+        "2023": 27700
+      },
+      "taxable_income_deductions_if_itemizing": {
+        "2023": 0
+      },
+      "taxable_income_deductions_if_not_itemizing": {
+        "2023": 27700
+      },
+      "taxable_income_less_qbid": {
+        "2023": 12300
+      },
+      "taxable_ss_magi": {
+        "2023": 40000
+      },
+      "taxable_uc_agi": {
+        "2023": 40000
+      },
+      "taxbc": {
+        "2023": 1230
+      },
+      "taxcalc_c04470": {
+        "2023": 0
+      },
+      "taxcalc_c09200": {
+        "2023": 0
+      },
+      "taxcalc_c17000": {
+        "2023": 0
+      },
+      "taxcalc_c18300": {
+        "2023": 0
+      },
+      "taxcalc_c19200": {
+        "2023": 0
+      },
+      "taxcalc_c19700": {
+        "2023": 0
+      },
+      "taxcalc_c20500": {
+        "2023": 0
+      },
+      "taxcalc_cmbtp": {
+        "2023": 0
+      },
+      "taxcalc_dsi": {
+        "2023": false
+      },
+      "taxcalc_e00200": {
+        "2023": 40000
+      },
+      "taxcalc_e00300": {
+        "2023": 0
+      },
+      "taxcalc_e00400": {
+        "2023": 0
+      },
+      "taxcalc_e00600": {
+        "2023": 0
+      },
+      "taxcalc_e00650": {
+        "2023": 0
+      },
+      "taxcalc_e00700": {
+        "2023": 0
+      },
+      "taxcalc_e00800": {
+        "2023": 0
+      },
+      "taxcalc_e00900": {
+        "2023": 0
+      },
+      "taxcalc_e01100": {
+        "2023": 0
+      },
+      "taxcalc_e01200": {
+        "2023": 0
+      },
+      "taxcalc_e01500": {
+        "2023": 0
+      },
+      "taxcalc_e01700": {
+        "2023": 0
+      },
+      "taxcalc_e02000": {
+        "2023": 0
+      },
+      "taxcalc_e02100": {
+        "2023": 0
+      },
+      "taxcalc_e02300": {
+        "2023": 0
+      },
+      "taxcalc_e02400": {
+        "2023": 0
+      },
+      "taxcalc_e03150": {
+        "2023": 0
+      },
+      "taxcalc_e03210": {
+        "2023": 0
+      },
+      "taxcalc_e03220": {
+        "2023": 0
+      },
+      "taxcalc_e03230": {
+        "2023": 0
+      },
+      "taxcalc_e03240": {
+        "2023": 0
+      },
+      "taxcalc_e03270": {
+        "2023": 0
+      },
+      "taxcalc_e03290": {
+        "2023": 0
+      },
+      "taxcalc_e03300": {
+        "2023": 0
+      },
+      "taxcalc_e03400": {
+        "2023": 0
+      },
+      "taxcalc_e03500": {
+        "2023": 0
+      },
+      "taxcalc_e09700": {
+        "2023": 0
+      },
+      "taxcalc_e09800": {
+        "2023": 0
+      },
+      "taxcalc_e09900": {
+        "2023": 0
+      },
+      "taxcalc_e11200": {
+        "2023": 0
+      },
+      "taxcalc_e17500": {
+        "2023": 0
+      },
+      "taxcalc_e18500": {
+        "2023": 0
+      },
+      "taxcalc_e19200": {
+        "2023": 0
+      },
+      "taxcalc_e19800": {
+        "2023": 0
+      },
+      "taxcalc_e20100": {
+        "2023": 0
+      },
+      "taxcalc_e20400": {
+        "2023": 0
+      },
+      "taxcalc_e24515": {
+        "2023": 0
+      },
+      "taxcalc_e24518": {
+        "2023": 0
+      },
+      "taxcalc_e26270": {
+        "2023": 0
+      },
+      "taxcalc_e27200": {
+        "2023": 0
+      },
+      "taxcalc_e32800": {
+        "2023": 0
+      },
+      "taxcalc_e58990": {
+        "2023": 0
+      },
+      "taxcalc_e62900": {
+        "2023": 0
+      },
+      "taxcalc_e87530": {
+        "2023": 0
+      },
+      "taxcalc_f2441": {
+        "2023": 4
+      },
+      "taxcalc_f6251": {
+        "2023": false
+      },
+      "taxcalc_fips": {
+        "2023": 6
+      },
+      "taxcalc_g20500": {
+        "2023": 0
+      },
+      "taxcalc_hasqdivltcg": {
+        "2023": false
+      },
+      "taxcalc_midr": {
+        "2023": false
+      },
+      "taxcalc_niit": {
+        "2023": 0
+      },
+      "taxcalc_p22250": {
+        "2023": 0
+      },
+      "taxcalc_p23250": {
+        "2023": 0
+      },
+      "taxcalc_pencon": {
+        "2023": 0
+      },
+      "taxcalc_pt_binc_w2_wages": {
+        "2023": 0
+      },
+      "taxcalc_pt_sstb_income": {
+        "2023": false
+      },
+      "taxcalc_pt_ubia_property": {
+        "2023": 0
+      },
+      "taxcalc_s006": {
+        "2023": 0
+      },
+      "taxsim_age1": {
+        "2023": 10
+      },
+      "taxsim_age2": {
+        "2023": 10
+      },
+      "taxsim_age3": {
+        "2023": 10
+      },
+      "taxsim_childcare": {
+        "2023": 0
+      },
+      "taxsim_dep13": {
+        "2023": 4
+      },
+      "taxsim_dep17": {
+        "2023": 4
+      },
+      "taxsim_dep18": {
+        "2023": 4
+      },
+      "taxsim_depx": {
+        "2023": 4
+      },
+      "taxsim_dividends": {
+        "2023": 0
+      },
+      "taxsim_fiitax": {
+        "2023": -10555.178
+      },
+      "taxsim_gssi": {
+        "2023": 0
+      },
+      "taxsim_intrec": {
+        "2023": 0
+      },
+      "taxsim_ltcg": {
+        "2023": 0
+      },
+      "taxsim_mstat": {
+        "2023": 2
+      },
+      "taxsim_page": {
+        "2023": 40
+      },
+      "taxsim_pbusinc": {
+        "2023": 0
+      },
+      "taxsim_pensions": {
+        "2023": 0
+      },
+      "taxsim_pprofinc": {
+        "2023": 0
+      },
+      "taxsim_psemp": {
+        "2023": 0
+      },
+      "taxsim_pui": {
+        "2023": 0
+      },
+      "taxsim_pwages": {
+        "2023": 40000
+      },
+      "taxsim_sage": {
+        "2023": 40
+      },
+      "taxsim_sbusinc": {
+        "2023": 0
+      },
+      "taxsim_scorp": {
+        "2023": 0
+      },
+      "taxsim_siitax": {
+        "2023": 0
+      },
+      "taxsim_sprofinc": {
+        "2023": 0
+      },
+      "taxsim_ssemp": {
+        "2023": 0
+      },
+      "taxsim_state": {
+        "2023": 0
+      },
+      "taxsim_stcg": {
+        "2023": 0
+      },
+      "taxsim_swages": {
+        "2023": 0
+      },
+      "taxsim_taxsimid": {
+        "2023": 0
+      },
+      "taxsim_tfica": {
+        "2023": 3060
+      },
+      "taxsim_ui": {
+        "2023": 0
+      },
+      "taxsim_v10": {
+        "2023": 40000
+      },
+      "taxsim_v11": {
+        "2023": 0
+      },
+      "taxsim_v12": {
+        "2023": 0
+      },
+      "taxsim_v18": {
+        "2023": 12300
+      },
+      "taxsim_v25": {
+        "2023": 4930.1777
+      },
+      "taxsim_year": {
+        "2023": 2023
+      },
+      "tuition_and_fees": {
+        "2023": 0
+      },
+      "unrecaptured_section_1250_gain": {
+        "2023": 0
+      },
+      "unreported_payroll_tax": {
+        "2023": 0
+      },
+      "us_govt_interest": {
+        "2023": 0
+      },
+      "used_clean_vehicle_credit": {
+        "2023": 0
+      },
+      "used_clean_vehicle_credit_eligible": {
+        "2023": false
+      },
+      "used_clean_vehicle_sale_price": {
+        "2023": 0
+      },
+      "ut_additions_to_income": {
+        "2023": 0
+      },
+      "ut_at_home_parent_credit": {
+        "2023": 0
+      },
+      "ut_claims_retirement_credit": {
+        "2023": false
+      },
+      "ut_eitc": {
+        "2023": 0
+      },
+      "ut_federal_deductions_for_taxpayer_credit": {
+        "2023": 0
+      },
+      "ut_income_tax": {
+        "2023": 0
+      },
+      "ut_income_tax_before_credits": {
+        "2023": 0
+      },
+      "ut_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "ut_income_tax_exempt": {
+        "2023": false
+      },
+      "ut_personal_exemption": {
+        "2023": 0
+      },
+      "ut_refundable_credits": {
+        "2023": 0
+      },
+      "ut_retirement_credit": {
+        "2023": 0
+      },
+      "ut_retirement_credit_max": {
+        "2023": 0
+      },
+      "ut_ss_benefits_credit": {
+        "2023": 0
+      },
+      "ut_ss_benefits_credit_max": {
+        "2023": 0
+      },
+      "ut_state_tax_refund": {
+        "2023": 0
+      },
+      "ut_subtractions_from_income": {
+        "2023": 0
+      },
+      "ut_taxable_income": {
+        "2023": 0
+      },
+      "ut_taxpayer_credit": {
+        "2023": 0
+      },
+      "ut_taxpayer_credit_max": {
+        "2023": 0
+      },
+      "ut_taxpayer_credit_phase_out_income": {
+        "2023": 0
+      },
+      "ut_taxpayer_credit_reduction": {
+        "2023": 0
+      },
+      "ut_total_dependents": {
+        "2023": 0
+      },
+      "ut_total_income": {
+        "2023": 0
+      },
+      "va_afagi": {
+        "2023": 0
+      },
+      "va_age_deduction": {
+        "2023": 0
+      },
+      "va_aged_blind_exemption": {
+        "2023": 0
+      },
+      "va_disability_income_subtraction": {
+        "2023": 0
+      },
+      "va_federal_state_employees_subtraction": {
+        "2023": 0
+      },
+      "va_income_tax_before_credits": {
+        "2023": 0
+      },
+      "va_military_basic_pay_subtraction": {
+        "2023": 0
+      },
+      "va_military_benefit_subtraction": {
+        "2023": 0
+      },
+      "va_personal_exemption": {
+        "2023": 0
+      },
+      "va_standard_deduction": {
+        "2023": 0
+      },
+      "va_taxable_income": {
+        "2023": 0
+      },
+      "va_total_exemptions": {
+        "2023": 0
+      },
+      "vt_agi": {
+        "2023": 0
+      },
+      "vt_agi_additions": {
+        "2023": 0
+      },
+      "vt_agi_subtractions": {
+        "2023": 0
+      },
+      "vt_income_tax": {
+        "2023": 0
+      },
+      "vt_income_tax_before_non_refundable_credits": {
+        "2023": 0
+      },
+      "vt_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "vt_non_refundable_credits": {
+        "2023": 0
+      },
+      "vt_personal_exemptions": {
+        "2023": 0
+      },
+      "vt_refundable_credits": {
+        "2023": 0
+      },
+      "vt_standard_deduction": {
+        "2023": 0
+      },
+      "vt_taxable_income": {
+        "2023": 0
+      },
+      "wa_capital_gains_tax": {
+        "2023": 0
+      },
+      "wa_income_tax": {
+        "2023": 0
+      },
+      "wa_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "wa_refundable_credits": {
+        "2023": 0
+      },
+      "wa_working_families_tax_credit": {
+        "2023": 0
+      },
+      "wi_agi": {
+        "2023": 0
+      },
+      "wi_capital_gain_loss_addition": {
+        "2023": 0
+      },
+      "wi_capital_gain_loss_subtraction": {
+        "2023": 0
+      },
+      "wi_capital_loss": {
+        "2023": 0
+      },
+      "wi_childcare_expense_credit": {
+        "2023": 0
+      },
+      "wi_childcare_expense_subtraction": {
+        "2023": 0
+      },
+      "wi_earned_income_credit": {
+        "2023": 0
+      },
+      "wi_exemption": {
+        "2023": 0
+      },
+      "wi_homestead_credit": {
+        "2023": 0
+      },
+      "wi_homestead_eligible": {
+        "2023": false
+      },
+      "wi_homestead_income": {
+        "2023": 0
+      },
+      "wi_homestead_property_tax": {
+        "2023": 0
+      },
+      "wi_income_additions": {
+        "2023": 0
+      },
+      "wi_income_subtractions": {
+        "2023": 0
+      },
+      "wi_income_tax": {
+        "2023": 0
+      },
+      "wi_income_tax_before_credits": {
+        "2023": 0
+      },
+      "wi_income_tax_before_refundable_credits": {
+        "2023": 0
+      },
+      "wi_itemized_deduction_credit": {
+        "2023": 0
+      },
+      "wi_married_couple_credit": {
+        "2023": 0
+      },
+      "wi_nonrefundable_credits": {
+        "2023": 0
+      },
+      "wi_property_tax_credit": {
+        "2023": 0
+      },
+      "wi_refundable_credits": {
+        "2023": 0
+      },
+      "wi_retirement_income_subtraction": {
+        "2023": 0
+      },
+      "wi_retirement_income_subtraction_agi_eligible": {
+        "2023": false
+      },
+      "wi_standard_deduction": {
+        "2023": 0
+      },
+      "wi_taxable_income": {
+        "2023": 0
+      },
+      "wi_unemployment_compensation_subtraction": {
+        "2023": 0
+      },
+      "wv_income_tax_before_credits": {
+        "2023": 0
+      },
+      "wv_personal_exemption": {
+        "2023": 0
+      },
+      "wv_public_pension_subtraction": {
+        "2023": 0
+      },
+      "wv_taxable_income": {
+        "2023": 0
+      },
+      "xtot": {
+        "2023": 6
+      }
+    }
+  }
+}

--- a/tests/python/test_yearly_var_removal.py
+++ b/tests/python/test_yearly_var_removal.py
@@ -29,7 +29,7 @@ def create_test_household(household_id, country_id):
         (
             household_id,
             country_id,
-            json.dumps(test_household, sort_keys=True),
+            json.dumps(test_household),
             "Garbage value",
             "Garbage value",
             "0.0.0",
@@ -101,7 +101,7 @@ def test_us_household_under_policy():
   result_object = get_household_under_policy(
     "us", 
     TEST_HOUSEHOLD_ID,
-    CURRENT_LAW_US)
+    CURRENT_LAW_US)["result"]
   
   remove_test_household(
     TEST_HOUSEHOLD_ID,
@@ -114,7 +114,26 @@ def test_us_household_under_policy():
     "us"
   )
 
-  assert expected_object == result_object["result"]
+  # Remove variables that are calculated randomly:
+  del expected_object["households"]["your household"]["county"]
+  del expected_object["households"]["your household"]["county_str"]
+  del expected_object["households"]["your household"]["three_digit_zip_code"]
+  del expected_object["households"]["your household"]["zip_code"]
+  
+  del result_object["households"]["your household"]["county"]
+  del result_object["households"]["your household"]["county_str"]
+  del result_object["households"]["your household"]["three_digit_zip_code"]
+  del result_object["households"]["your household"]["zip_code"]
+
+  # Remove person_ids (note that this is a bug driven by JSON's inherent
+  # unordered nature)
+  for person in expected_object["people"]:
+    del expected_object["people"][person]["person_id"]
+  
+  for person in result_object["people"]:
+    del result_object["people"][person]["person_id"]
+
+  assert expected_object == result_object
 
 def test_uk_household_under_policy():
   """
@@ -141,7 +160,7 @@ def test_uk_household_under_policy():
   result_object = get_household_under_policy(
     "uk", 
     TEST_HOUSEHOLD_ID,
-    CURRENT_LAW_UK)
+    CURRENT_LAW_UK)["result"]
   
   remove_test_household(
     TEST_HOUSEHOLD_ID,
@@ -154,4 +173,18 @@ def test_uk_household_under_policy():
     "uk"
   )
 
-  assert expected_object == result_object["result"]
+  # Remove child_index (note that this is a bug driven by JSON's inherent
+  # unordered nature)
+  for person in expected_object["people"]:
+    del expected_object["people"][person]["child_index"]
+  
+  for person in result_object["people"]:
+    del result_object["people"][person]["child_index"]
+
+  with open("./expectedObject.json", "w") as file:
+    json.dump(expected_object, file)
+
+  with open("./resultObject.json", "w") as file:
+    json.dump(result_object, file)
+
+  assert expected_object == result_object

--- a/tests/python/test_yearly_var_removal.py
+++ b/tests/python/test_yearly_var_removal.py
@@ -20,7 +20,7 @@ def create_test_household(household_id, country_id):
     # instead of make debug-test specifically on production server
     remove_test_household(household_id, country_id)
     
-  with open("./tests/python/data/us_household.json", "r", encoding="utf-8") as f:
+  with open(f"./tests/python/data/{country_id}_household.json", "r", encoding="utf-8") as f:
     test_household = json.load(f)
 
   try:
@@ -112,6 +112,46 @@ def test_us_household_under_policy():
     TEST_HOUSEHOLD_ID,
     CURRENT_LAW_US,
     "us"
+  )
+
+  assert expected_object == result_object["result"]
+
+def test_uk_household_under_policy():
+  """
+  Test that a UK household under current law is created correctly
+  """
+  # Note: Attempted to mock the database.query statements in get_household_under_policy,
+  # but was unable to, hence the (less secure) emission of SQL creation, followed by deletion
+  CURRENT_LAW_UK = 1
+
+  expected_object = None
+  with open("./tests/python/data/uk_household_under_policy_target.json", "r", encoding="utf-8") as f:
+    expected_object = json.load(f)
+
+  create_test_household(
+    TEST_HOUSEHOLD_ID,
+    "uk"
+  )
+
+  test_row = database.query(
+    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+    (TEST_HOUSEHOLD_ID, "uk"),
+  ).fetchone()
+
+  result_object = get_household_under_policy(
+    "uk", 
+    TEST_HOUSEHOLD_ID,
+    CURRENT_LAW_UK)
+  
+  remove_test_household(
+    TEST_HOUSEHOLD_ID,
+    "uk"
+  )
+
+  remove_calculated_hup(
+    TEST_HOUSEHOLD_ID,
+    CURRENT_LAW_UK,
+    "uk"
   )
 
   assert expected_object == result_object["result"]

--- a/tests/python/test_yearly_var_removal.py
+++ b/tests/python/test_yearly_var_removal.py
@@ -127,11 +127,13 @@ def test_us_household_under_policy():
   del expected_object["households"]["your household"]["county_str"]
   del expected_object["households"]["your household"]["three_digit_zip_code"]
   del expected_object["households"]["your household"]["zip_code"]
+  del expected_object["households"]["your household"]["ccdf_county_cluster"]
   
   del result_object["households"]["your household"]["county"]
   del result_object["households"]["your household"]["county_str"]
   del result_object["households"]["your household"]["three_digit_zip_code"]
   del result_object["households"]["your household"]["zip_code"]
+  del result_object["households"]["your household"]["ccdf_county_cluster"]
 
   # Remove person_ids (note that this is a bug driven by JSON's inherent
   # unordered nature)
@@ -210,5 +212,5 @@ def test_get_calculate(client):
   for this test to function properly.
   """
 
-  res = client.post("/", data={"key": "value"})
+  res = client.post("/us/calculate", data={"key": "value"})
   print(res, sys.stderr)

--- a/tests/python/test_yearly_var_removal.py
+++ b/tests/python/test_yearly_var_removal.py
@@ -1,0 +1,91 @@
+import pytest
+import json
+from policyengine_api.endpoints.household import get_household_under_policy
+from policyengine_api.data import database
+import sys
+
+TEST_HOUSEHOLD_ID = -100
+
+def create_test_household(household_id, country_id):
+  test_household = None
+
+  row = database.query(
+    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+    (household_id, country_id),
+  ).fetchone()
+
+  if row is not None:
+    raise Exception("Record already exists at test index")
+    
+  with open("./tests/python/data/us_household.json", "r", encoding="utf-8") as f:
+    test_household = json.load(f)
+
+  try:
+    row = database.query(
+      f"INSERT INTO household (id, country_id, household_json, household_hash, label, api_version) VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            household_id,
+            country_id,
+            json.dumps(test_household),
+            "Garbage value",
+            "Garbage value",
+            "0.0.0",
+        ),
+    )
+
+  except Exception as err:
+    raise err
+
+  return household_id
+
+def remove_test_household(household_id, country_id):
+
+  row = database.query(
+    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+    (household_id, country_id),
+  ).fetchone()
+
+  if row is not None:
+    try:
+      database.query(
+        f"DELETE FROM household WHERE id = ? AND country_id = ?",
+        (household_id, country_id),
+      )
+    except Exception as err:
+      raise Exception(err)
+  
+  return True
+
+
+def test_us_household_under_policy():
+  """
+  Test that a US household under current law is created correctly
+  """
+  # Note: Attempted to mock the database.query statements in get_household_under_policy,
+  # but was unable to, hence the (less secure) emission of SQL creation, followed by deletion
+
+  expected_object = None
+  with open("./tests/python/data/us_household_under_policy_target.json", "r", encoding="utf-8") as f:
+    expected_object = json.load(f)
+
+  create_test_household(
+    TEST_HOUSEHOLD_ID,
+    "us"
+  )
+
+  test_row = database.query(
+    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+    (TEST_HOUSEHOLD_ID, "us"),
+  ).fetchone()
+
+  result_object = get_household_under_policy(
+    "us", 
+    TEST_HOUSEHOLD_ID,
+    2)
+  
+  remove_test_household(
+    TEST_HOUSEHOLD_ID,
+    "us"
+  )
+  
+  assert expected_object == result_object["result"]

--- a/tests/python/test_yearly_var_removal.py
+++ b/tests/python/test_yearly_var_removal.py
@@ -7,250 +7,253 @@ from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 from policyengine_api.data import database
 from policyengine_api.api import app
 
+
 @pytest.fixture
 def client():
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
 
+
 TEST_HOUSEHOLD_ID = -100
 
+
 def create_test_household(household_id, country_id):
-  test_household = None
+    test_household = None
 
-  row = database.query(
-    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
-    (household_id, country_id),
-  ).fetchone()
-
-  if row is not None:
-    # WARNING: This could mutate existing arrays if running make-test
-    # instead of make debug-test specifically on production server
-    remove_test_household(household_id, country_id)
-    
-  with open(f"./tests/python/data/{country_id}_household.json", "r", encoding="utf-8") as f:
-    test_household = json.load(f)
-
-  try:
     row = database.query(
-      f"INSERT INTO household (id, country_id, household_json, household_hash, label, api_version) VALUES (?, ?, ?, ?, ?, ?)",
-        (
-            household_id,
-            country_id,
-            json.dumps(test_household),
-            "Garbage value",
-            "Garbage value",
-            "0.0.0",
-        ),
-    )
+        f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+        (household_id, country_id),
+    ).fetchone()
 
-  except Exception as err:
-    raise err
+    if row is not None:
+        # WARNING: This could mutate existing arrays if running make-test
+        # instead of make debug-test specifically on production server
+        remove_test_household(household_id, country_id)
 
-  return household_id
+    with open(
+        f"./tests/python/data/{country_id}_household.json",
+        "r",
+        encoding="utf-8",
+    ) as f:
+        test_household = json.load(f)
+
+    try:
+        row = database.query(
+            f"INSERT INTO household (id, country_id, household_json, household_hash, label, api_version) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                household_id,
+                country_id,
+                json.dumps(test_household),
+                "Garbage value",
+                "Garbage value",
+                "0.0.0",
+            ),
+        )
+
+    except Exception as err:
+        raise err
+
+    return household_id
+
 
 def remove_test_household(household_id, country_id):
 
-  row = database.query(
-    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
-    (household_id, country_id),
-  ).fetchone()
-
-  if row is not None:
-    try:
-      database.query(
-        f"DELETE FROM household WHERE id = ? AND country_id = ?",
+    row = database.query(
+        f"SELECT * FROM household WHERE id = ? AND country_id = ?",
         (household_id, country_id),
-      )
-    except Exception as err:
-      raise err
-  
-  return True
+    ).fetchone()
+
+    if row is not None:
+        try:
+            database.query(
+                f"DELETE FROM household WHERE id = ? AND country_id = ?",
+                (household_id, country_id),
+            )
+        except Exception as err:
+            raise err
+
+    return True
+
 
 def remove_calculated_hup(household_id, policy_id, country_id):
-  """
-  Function to remove the calculated household under policy generated 
-  by get_household_under_policy, for testing purposes
-  """
+    """
+    Function to remove the calculated household under policy generated
+    by get_household_under_policy, for testing purposes
+    """
 
-  api_version = COUNTRY_PACKAGE_VERSIONS.get(country_id)
+    api_version = COUNTRY_PACKAGE_VERSIONS.get(country_id)
 
-  try:
-    database.query(
-      f"DELETE FROM computed_household WHERE household_id = ? AND policy_id = ? AND api_version = ?",
-      (household_id, policy_id, api_version)
-    )
-  except Exception as err:
-    raise err
+    try:
+        database.query(
+            f"DELETE FROM computed_household WHERE household_id = ? AND policy_id = ? AND api_version = ?",
+            (household_id, policy_id, api_version),
+        )
+    except Exception as err:
+        raise err
 
 
 def test_us_household_under_policy():
-  """
-  Test that a US household under current law is created correctly
-  """
-  # Note: Attempted to mock the database.query statements in get_household_under_policy,
-  # but was unable to, hence the (less secure) emission of SQL creation, followed by deletion
-  CURRENT_LAW_US = 2
+    """
+    Test that a US household under current law is created correctly
+    """
+    # Note: Attempted to mock the database.query statements in get_household_under_policy,
+    # but was unable to, hence the (less secure) emission of SQL creation, followed by deletion
+    CURRENT_LAW_US = 2
 
-  expected_object = None
-  with open("./tests/python/data/us_household_under_policy_target.json", "r", encoding="utf-8") as f:
-    expected_object = json.load(f)
+    expected_object = None
+    with open(
+        "./tests/python/data/us_household_under_policy_target.json",
+        "r",
+        encoding="utf-8",
+    ) as f:
+        expected_object = json.load(f)
 
-  create_test_household(
-    TEST_HOUSEHOLD_ID,
-    "us"
-  )
+    create_test_household(TEST_HOUSEHOLD_ID, "us")
 
-  test_row = database.query(
-    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
-    (TEST_HOUSEHOLD_ID, "us"),
-  ).fetchone()
+    test_row = database.query(
+        f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+        (TEST_HOUSEHOLD_ID, "us"),
+    ).fetchone()
 
-  result_object = get_household_under_policy(
-    "us", 
-    TEST_HOUSEHOLD_ID,
-    CURRENT_LAW_US)["result"]
-  
-  remove_test_household(
-    TEST_HOUSEHOLD_ID,
-    "us"
-  )
+    result_object = get_household_under_policy(
+        "us", TEST_HOUSEHOLD_ID, CURRENT_LAW_US
+    )["result"]
 
-  remove_calculated_hup(
-    TEST_HOUSEHOLD_ID,
-    CURRENT_LAW_US,
-    "us"
-  )
+    remove_test_household(TEST_HOUSEHOLD_ID, "us")
 
-  # Remove variables that are calculated randomly:
-  del expected_object["households"]["your household"]["county"]
-  del expected_object["households"]["your household"]["county_str"]
-  del expected_object["households"]["your household"]["three_digit_zip_code"]
-  del expected_object["households"]["your household"]["zip_code"]
-  del expected_object["households"]["your household"]["ccdf_county_cluster"]
-  
-  del result_object["households"]["your household"]["county"]
-  del result_object["households"]["your household"]["county_str"]
-  del result_object["households"]["your household"]["three_digit_zip_code"]
-  del result_object["households"]["your household"]["zip_code"]
-  del result_object["households"]["your household"]["ccdf_county_cluster"]
+    remove_calculated_hup(TEST_HOUSEHOLD_ID, CURRENT_LAW_US, "us")
 
-  # Remove person_ids (note that this is a bug driven by JSON's inherent
-  # unordered nature)
-  for person in expected_object["people"]:
-    del expected_object["people"][person]["person_id"]
-  
-  for person in result_object["people"]:
-    del result_object["people"][person]["person_id"]
+    # Remove variables that are calculated randomly:
+    del expected_object["households"]["your household"]["county"]
+    del expected_object["households"]["your household"]["county_str"]
+    del expected_object["households"]["your household"]["three_digit_zip_code"]
+    del expected_object["households"]["your household"]["zip_code"]
+    del expected_object["households"]["your household"]["ccdf_county_cluster"]
 
-  for marital_unit in expected_object["marital_units"]:
-    del expected_object["marital_units"][marital_unit]["marital_unit_id"]
+    del result_object["households"]["your household"]["county"]
+    del result_object["households"]["your household"]["county_str"]
+    del result_object["households"]["your household"]["three_digit_zip_code"]
+    del result_object["households"]["your household"]["zip_code"]
+    del result_object["households"]["your household"]["ccdf_county_cluster"]
 
-  for marital_unit in result_object["marital_units"]:
-    del result_object["marital_units"][marital_unit]["marital_unit_id"]
+    # Remove person_ids (note that this is a bug driven by JSON's inherent
+    # unordered nature)
+    for person in expected_object["people"]:
+        del expected_object["people"][person]["person_id"]
 
-  assert expected_object == result_object
+    for person in result_object["people"]:
+        del result_object["people"][person]["person_id"]
+
+    for marital_unit in expected_object["marital_units"]:
+        del expected_object["marital_units"][marital_unit]["marital_unit_id"]
+
+    for marital_unit in result_object["marital_units"]:
+        del result_object["marital_units"][marital_unit]["marital_unit_id"]
+
+    assert expected_object == result_object
+
 
 def test_uk_household_under_policy():
-  """
-  Test that a UK household under current law is created correctly
-  """
-  # Note: Attempted to mock the database.query statements in get_household_under_policy,
-  # but was unable to, hence the (less secure) emission of SQL creation, followed by deletion
-  CURRENT_LAW_UK = 1
+    """
+    Test that a UK household under current law is created correctly
+    """
+    # Note: Attempted to mock the database.query statements in get_household_under_policy,
+    # but was unable to, hence the (less secure) emission of SQL creation, followed by deletion
+    CURRENT_LAW_UK = 1
 
-  expected_object = None
-  with open("./tests/python/data/uk_household_under_policy_target.json", "r", encoding="utf-8") as f:
-    expected_object = json.load(f)
+    expected_object = None
+    with open(
+        "./tests/python/data/uk_household_under_policy_target.json",
+        "r",
+        encoding="utf-8",
+    ) as f:
+        expected_object = json.load(f)
 
-  create_test_household(
-    TEST_HOUSEHOLD_ID,
-    "uk"
-  )
+    create_test_household(TEST_HOUSEHOLD_ID, "uk")
 
-  test_row = database.query(
-    f"SELECT * FROM household WHERE id = ? AND country_id = ?",
-    (TEST_HOUSEHOLD_ID, "uk"),
-  ).fetchone()
+    test_row = database.query(
+        f"SELECT * FROM household WHERE id = ? AND country_id = ?",
+        (TEST_HOUSEHOLD_ID, "uk"),
+    ).fetchone()
 
-  result_object = get_household_under_policy(
-    "uk", 
-    TEST_HOUSEHOLD_ID,
-    CURRENT_LAW_UK)["result"]
-  
-  remove_test_household(
-    TEST_HOUSEHOLD_ID,
-    "uk"
-  )
+    result_object = get_household_under_policy(
+        "uk", TEST_HOUSEHOLD_ID, CURRENT_LAW_UK
+    )["result"]
 
-  remove_calculated_hup(
-    TEST_HOUSEHOLD_ID,
-    CURRENT_LAW_UK,
-    "uk"
-  )
+    remove_test_household(TEST_HOUSEHOLD_ID, "uk")
 
-  # Remove child_index (note that this is a bug driven by JSON's inherent
-  # unordered nature)
-  for person in expected_object["people"]:
-    del expected_object["people"][person]["child_index"]
-  
-  for person in result_object["people"]:
-    del result_object["people"][person]["child_index"]
+    remove_calculated_hup(TEST_HOUSEHOLD_ID, CURRENT_LAW_UK, "uk")
 
-  assert expected_object == result_object
+    # Remove child_index (note that this is a bug driven by JSON's inherent
+    # unordered nature)
+    for person in expected_object["people"]:
+        del expected_object["people"][person]["child_index"]
+
+    for person in result_object["people"]:
+        del result_object["people"][person]["child_index"]
+
+    assert expected_object == result_object
+
 
 def test_get_calculate(client):
-  """
-  Test the get_calculate endpoint with the same data as
-  test_us_household_under_policy. Note that redis must be running
-  for this test to function properly.
-  """
+    """
+    Test the get_calculate endpoint with the same data as
+    test_us_household_under_policy. Note that redis must be running
+    for this test to function properly.
+    """
 
-  CURRENT_LAW_US = 2
+    CURRENT_LAW_US = 2
 
-  expected_object = None
-  test_household = None
-  test_object = {}
+    expected_object = None
+    test_household = None
+    test_object = {}
 
-  with open("./tests/python/data/us_household_under_policy_target.json", "r", encoding="utf-8") as f:
-    expected_object = json.load(f) 
+    with open(
+        "./tests/python/data/us_household_under_policy_target.json",
+        "r",
+        encoding="utf-8",
+    ) as f:
+        expected_object = json.load(f)
 
-  with open(f"./tests/python/data/us_household.json", "r", encoding="utf-8") as f:
-    test_household = json.load(f)
+    with open(
+        f"./tests/python/data/us_household.json", "r", encoding="utf-8"
+    ) as f:
+        test_household = json.load(f)
 
-  test_policy = get_policy("us", CURRENT_LAW_US)["result"]["policy_json"]
+    test_policy = get_policy("us", CURRENT_LAW_US)["result"]["policy_json"]
 
-  test_object["policy"] = test_policy
-  test_object["household"] = test_household
+    test_object["policy"] = test_policy
+    test_object["household"] = test_household
 
-  res = client.post("/us/calculate", json=test_object)
-  result_object = json.loads(res.text)["result"]
+    res = client.post("/us/calculate", json=test_object)
+    result_object = json.loads(res.text)["result"]
 
-  # Remove variables that are calculated randomly:
-  del expected_object["households"]["your household"]["county"]
-  del expected_object["households"]["your household"]["county_str"]
-  del expected_object["households"]["your household"]["three_digit_zip_code"]
-  del expected_object["households"]["your household"]["zip_code"]
-  del expected_object["households"]["your household"]["ccdf_county_cluster"]
-  
-  del result_object["households"]["your household"]["county"]
-  del result_object["households"]["your household"]["county_str"]
-  del result_object["households"]["your household"]["three_digit_zip_code"]
-  del result_object["households"]["your household"]["zip_code"]
-  del result_object["households"]["your household"]["ccdf_county_cluster"]
+    # Remove variables that are calculated randomly:
+    del expected_object["households"]["your household"]["county"]
+    del expected_object["households"]["your household"]["county_str"]
+    del expected_object["households"]["your household"]["three_digit_zip_code"]
+    del expected_object["households"]["your household"]["zip_code"]
+    del expected_object["households"]["your household"]["ccdf_county_cluster"]
 
-  # Remove person_ids (note that this is a bug driven by JSON's inherent
-  # unordered nature)
-  for person in expected_object["people"]:
-    del expected_object["people"][person]["person_id"]
-  
-  for person in result_object["people"]:
-    del result_object["people"][person]["person_id"]
+    del result_object["households"]["your household"]["county"]
+    del result_object["households"]["your household"]["county_str"]
+    del result_object["households"]["your household"]["three_digit_zip_code"]
+    del result_object["households"]["your household"]["zip_code"]
+    del result_object["households"]["your household"]["ccdf_county_cluster"]
 
-  for marital_unit in expected_object["marital_units"]:
-    del expected_object["marital_units"][marital_unit]["marital_unit_id"]
+    # Remove person_ids (note that this is a bug driven by JSON's inherent
+    # unordered nature)
+    for person in expected_object["people"]:
+        del expected_object["people"][person]["person_id"]
 
-  for marital_unit in result_object["marital_units"]:
-    del result_object["marital_units"][marital_unit]["marital_unit_id"]
+    for person in result_object["people"]:
+        del result_object["people"][person]["person_id"]
 
-  assert expected_object == result_object
+    for marital_unit in expected_object["marital_units"]:
+        del expected_object["marital_units"][marital_unit]["marital_unit_id"]
+
+    for marital_unit in result_object["marital_units"]:
+        del result_object["marital_units"][marital_unit]["marital_unit_id"]
+
+    assert expected_object == result_object

--- a/tests/python/test_yearly_var_removal.py
+++ b/tests/python/test_yearly_var_removal.py
@@ -181,10 +181,4 @@ def test_uk_household_under_policy():
   for person in result_object["people"]:
     del result_object["people"][person]["child_index"]
 
-  with open("./expectedObject.json", "w") as file:
-    json.dump(expected_object, file)
-
-  with open("./resultObject.json", "w") as file:
-    json.dump(result_object, file)
-
   assert expected_object == result_object


### PR DESCRIPTION
This PR moves the addition of default variables to household input objects from the front end to the back end, preventing the breaking of households upon changes to country packages. This also provides backwards compatibility with households created prior to the PR. Resolves #230. 

This PR does so by making the following changes:
* The `get_household_under_policy` and `get_calculate` endpoints have an additional function that adds all yearly input variables to the household object before enqueuing calculation
* A new endpoint, accessible via PUT request at `<country_id>/household/<household_id>`, updates an existing household and returns the household ID (happy to change this to return the entire household if deemed necessary)
* Adds tests for the various new components

Please note that this PR should be merged before the corresponding one on the front end.