### PR TITLE
Add `ETERNITY` and `MONTH`-level variables to households

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    added:
+    - Eternal and monthly variables to API-computed set.

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -31,7 +31,11 @@ def add_yearly_variables(household, country_id):
     entities = metadata["entities"]
 
     for variable in variables:
-        if variables[variable]["definitionPeriod"] == "year":
+        if variables[variable]["definitionPeriod"] in (
+            "year",
+            "month",
+            "eternity",
+        ):
             entity_plural = entities[variables[variable]["entity"]]["plural"]
             if entity_plural in household:
                 possible_entities = household[entity_plural].keys()


### PR DESCRIPTION
cc @MaxGhenis 