### PR TITLE
Remove annual hardcoding from API

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Removed hard-coded year from add_yearly_variables function

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -47,12 +47,12 @@ def add_yearly_variables(household, country_id):
                     ):
                         if variables[variable]["isInputVariable"]:
                             household[entity_plural][entity][
-                                variables[variable]["name"][household_year]
-                            ] = variables[variable]["defaultValue"]
+                                variables[variable]["name"]
+                            ] = {household_year: variables[variable]["defaultValue"]}
                         else:
                             household[entity_plural][entity][
-                                variables[variable]["name"][household_year]
-                            ] = None
+                                variables[variable]["name"]
+                            ] = {household_year: None}
     return household
 
 def get_household_year(household):
@@ -61,7 +61,8 @@ def get_household_year(household):
     Args:
         household (dict): The household itself
     """
-    household_year = household["people"]["you"]["age"].keys()[0]
+    household_year = list(household["people"]["you"]["age"].keys())[0]
+    print(household_year)
     return household_year
 
 

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -66,7 +66,7 @@ def get_household_year(household):
     Args:
         household (dict): The household itself
     """
-    household_year = list(household["people"]["you"]["age"].keys())[0]
+    return list(household["people"]["you"]["age"].keys())[0]
     print(household_year)
     return household_year
 

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -48,16 +48,21 @@ def add_yearly_variables(household, country_id):
                         if variables[variable]["isInputVariable"]:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
-                            ] = {household_year: variables[variable]["defaultValue"]}
+                            ] = {
+                                household_year: variables[variable][
+                                    "defaultValue"
+                                ]
+                            }
                         else:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
                             ] = {household_year: None}
     return household
 
+
 def get_household_year(household):
     """Given a household dict, get the household's year
-    
+
     Args:
         household (dict): The household itself
     """

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -29,6 +29,7 @@ def add_yearly_variables(household, country_id):
 
     variables = metadata["variables"]
     entities = metadata["entities"]
+    household_year = get_household_year(household)
 
     for variable in variables:
         if variables[variable]["definitionPeriod"] in (
@@ -46,13 +47,22 @@ def add_yearly_variables(household, country_id):
                     ):
                         if variables[variable]["isInputVariable"]:
                             household[entity_plural][entity][
-                                variables[variable]["name"]
-                            ] = {2023: variables[variable]["defaultValue"]}
+                                variables[variable]["name"][household_year]
+                            ] = variables[variable]["defaultValue"]
                         else:
                             household[entity_plural][entity][
-                                variables[variable]["name"]
-                            ] = {2023: None}
+                                variables[variable]["name"][household_year]
+                            ] = None
     return household
+
+def get_household_year(household):
+    """Given a household dict, get the household's year
+    
+    Args:
+        household (dict): The household itself
+    """
+    household_year = household["people"]["you"]["age"].keys()[0]
+    return household_year
 
 
 def get_household(country_id: str, household_id: str) -> dict:

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -19,6 +19,7 @@ import dpath
 import math
 import logging
 import sys
+from datetime import date
 
 
 def add_yearly_variables(household, country_id):
@@ -66,7 +67,17 @@ def get_household_year(household):
     Args:
         household (dict): The household itself
     """
-    return list(household["people"]["you"]["age"].keys())[0]
+
+    # Set household_year based on current year
+    household_year = date.today().year
+
+    # Determine if "age" variable present within household
+    household_age_dict = household["people"]["you"]["age"]
+    # If it is, overwrite household_year with the value present
+    if household_age_dict:
+        household_year = list(household["people"]["you"]["age"].keys())[0]
+
+    return household_year
 
 
 def get_household(country_id: str, household_id: str) -> dict:

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -67,8 +67,6 @@ def get_household_year(household):
         household (dict): The household itself
     """
     return list(household["people"]["you"]["age"].keys())[0]
-    print(household_year)
-    return household_year
 
 
 def get_household(country_id: str, household_id: str) -> dict:


### PR DESCRIPTION
Fixes #1030. This PR removes hard-coding of annual values in the `add_yearly_variables` function by first determining what year is utilized in the emitted household object, then populating all default variables utilizing that year. A video demonstrating the changes working properly is available [here](https://www.loom.com/share/bfacee18167d4520a52c1137ec262cab?sid=fe6772e4-edb3-48ad-989b-d9af6dc5a07f), where household #100013 is a pre-created default US household with 0 income that's emitted to the local test database before making this video.

This code must be added successfully before proceeding with https://github.com/PolicyEngine/policyengine-app/issues/1017