### PR TITLE
Ensure get_household_year doesn't break on empty age variable

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Ensure that get_household_year doesn't break on empty age variable

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -71,11 +71,13 @@ def get_household_year(household):
     # Set household_year based on current year
     household_year = date.today().year
 
-    # Determine if "age" variable present within household
-    household_age_dict = household["people"]["you"]["age"]
+    # Determine if "age" variable present within household and return list of values at it
+    household_age_list = list(
+        household.get("people", {}).get("you", {}).get("age", {}).keys()
+    )
     # If it is, overwrite household_year with the value present
-    if household_age_dict and len(household_age_dict) > 0:
-        household_year = list(household["people"]["you"]["age"].keys())[0]
+    if len(household_age_list) > 0:
+        household_year = household_age_list[0]
 
     return household_year
 

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -74,7 +74,7 @@ def get_household_year(household):
     # Determine if "age" variable present within household
     household_age_dict = household["people"]["you"]["age"]
     # If it is, overwrite household_year with the value present
-    if household_age_dict:
+    if household_age_dict and len(household_age_dict) > 0:
         household_year = list(household["people"]["you"]["age"].keys())[0]
 
     return household_year


### PR DESCRIPTION
Fixes #1067. This PR ensures that `get_household_year` doesn't break if the head of household possesses an `age` variable, but this variable is empty. Though it is a bug, this situation emerged at times recently due to a front-end design oversight (age was added by default to all household members except head of household) and a bug (pre-seeding of variables within the `VariableEditor` component only added variables if they didn't exist in any household member, meaning that when `age` was the variable within the component, it was impossible to add it for head of household). 

Though the fixes to these bugs have either been fixed or are in review in `policyengine-app`, it would be best to account for this potential circumstance in the back end to at least allow for more graceful failure.