### PR TITLE
Enable 2025 household calculations for US

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Enabled 2025 household calculations for US

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -136,6 +136,7 @@ class PolicyEngineCountry:
                 dict(name="wy", label="Wyoming"),
             ]
             time_period = [
+                dict(name=2025, label="2025"),
                 dict(name=2024, label="2024"),
                 dict(name=2023, label="2023"),
                 dict(name=2022, label="2022"),


### PR DESCRIPTION
Fixes #1097. Is a prerequisite for app [#1208](https://github.com/PolicyEngine/policyengine-app/issues/1208). This commit adds 2025 as a year for the API's US country setup.

In a Loom video [here](https://www.loom.com/share/7501bc0a6e894f21bb22ee25629c67c1?sid=440131f8-a5b6-4605-8b4f-bf87eb641eba), I test this running locally by creating two identical household objects for 2024 and 2025, then POSTing to the household creation endpoint for each. I then take each household ID and GET them over current law, demonstrating that the returned household net income of each is the same. Finally, I show the locally running API logs, showing no issue. Note that the error logs regarding California tax variables visible in the video are from when I ran tests over 2023, when those variables did not exist.