### PR TITLE
Alter CPU deployment

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Altered deployment CPU number

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -1,7 +1,7 @@
 runtime: custom
 env: flex
 resources:
-  cpu: 16
+  cpu: 10
   memory_gb: 64
   disk_size_gb: 64
 automatic_scaling:


### PR DESCRIPTION
Fixes #1034. This commit reduces the number of CPUs available to the app to the minimum possible while still maintaining the amount of RAM the deployment is permitted, per the formula available at https://cloud.google.com/appengine/docs/flexible/reference/app-yaml?tab=python#resource-settings, in an effort to reduce unnecessary resource consumption.