### PR TITLE
Hash household_id

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -2812,3 +2812,8 @@
     fixed:
     - Negative income deciles removed from outputs.
   date: 2024-02-18 18:37:01
+- bump: patch
+  changes:
+    changed:
+    - Hash user id.
+  date: 2024-02-18 18:47:01

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -51,11 +51,7 @@ def add_yearly_variables(household, country_id):
                         if variables[variable]["isInputVariable"]:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
-                            ] = {
-                                household_year: variables[variable][
-                                    "defaultValue"
-                                ]
-                            }
+                            ] = {household_year: variables[variable]["defaultValue"]}
                         else:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
@@ -233,9 +229,7 @@ def update_household(country_id: str, household_id: str) -> Response:
         )
 
 
-def get_household_under_policy(
-    country_id: str, household_id: str, policy_id: str
-):
+def get_household_under_policy(country_id: str, household_id: str, policy_id: str):
     """Get a household's output data under a given policy.
 
     Args:
@@ -323,9 +317,7 @@ def get_household_under_policy(
     country = COUNTRIES.get(country_id)
 
     try:
-        result = country.calculate(
-            household["household_json"], policy["policy_json"]
-        )
+        result = country.calculate(household["household_json"], policy["policy_json"])
     except Exception as e:
         logging.exception(e)
         response_body = dict(


### PR DESCRIPTION
Fixes #805 

I'm not sure if my approach is correct since I found we have already used `household_hash = hash_object(household_json)` to create a unique identifier for each household based on its content. 

My suggestion to modify the code was an attempt to provide a more comprehensive answer to the issue title about hashing user IDs for privacy, under the assumption that we were looking to hash household_id directly. (I assume this is the right approach since the label is a good first issue)

I also would like to ask about the db credentials since I want to do the local test. I'm not sure if I understand the question correctly or if I do the right thing. Please take a look and let me know if I should modify anything. Thank you!

