### PR TITLE
Remove capturing so as to get fuller datastream during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ debug:
 	FLASK_APP=policyengine_api.api FLASK_DEBUG=1 flask run --without-threads
 
 test:
-	pytest -vv --durations=0 --timeout=250 -rP tests
+	pytest -vv --durations=0 --timeout=250 -rP -s tests
 
 debug-test:
-	FLASK_DEBUG=1 pytest -vv --durations=0 --timeout=250 -rP tests
+	FLASK_DEBUG=1 pytest -vv --durations=0 --timeout=250 -rP -s tests
 
 format:
 	black . -l 79

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Added flag to disable Pytest capturing temporarily


### PR DESCRIPTION
Fixes #1349. Should be removed once deployment issues are diagnosed and fixed.