### PR TITLE
Propagate units to descendants for ParameterScale objects

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+      - add units to parameters that were lacking units due to specification of units at a higher level (using rate_unit, for instance)

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -216,6 +216,7 @@ class PolicyEngineCountry:
                 continue
             end_name = parameter.name.split(".")[-1]
             if isinstance(parameter, ParameterScale):
+                parameter.propagate_units()
                 parameter_data[parameter.name] = {
                     "type": "parameterNode",
                     "parameter": parameter.name,

--- a/tests/python/test_units.py
+++ b/tests/python/test_units.py
@@ -1,0 +1,23 @@
+from policyengine_api.endpoints.metadata import get_metadata
+
+
+def test_units():
+    m = get_metadata("us")
+    assert (
+        m["result"]["parameters"][
+            "gov.states.md.tax.income.rates.head[0].rate"
+        ]["unit"]
+        == "/1"
+    )
+    assert (
+        m["result"]["parameters"][
+            "gov.states.md.tax.income.rates.head[0].threshold"
+        ]["unit"]
+        == "currency-USD"
+    )
+    assert (
+        m["result"]["parameters"][
+            "gov.irs.credits.eitc.phase_out.start[0].amount"
+        ]["unit"]
+        == "currency-USD"
+    )


### PR DESCRIPTION
- We fix #1195 by calling the method `propagate_units` in `build_parameters`, which propagates units correctly to descendants of `ParameterScale` objects. `propagate_units` was added to `ParameterScale` objects in https://github.com/PolicyEngine/policyengine-core/pull/162.
- We add a test to check that the units are propagated correctly.