### PR TITLE
Remove 2021 option in US metadata

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+      - 2021 option in US country metadata in country.py file

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -140,7 +140,6 @@ class PolicyEngineCountry:
                 dict(name=2024, label="2024"),
                 dict(name=2023, label="2023"),
                 dict(name=2022, label="2022"),
-                dict(name=2021, label="2021"),
             ]
             options["region"] = region
             options["time_period"] = time_period


### PR DESCRIPTION
Fixes #1364 

This removes the 2021 option in the US country metadata, which is contained in the file "country.py".