### PR TITLE
Create user policy table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/*
 **/*.rdb
 **/*.h5
 **/*.csv.gz
+.env

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: minor
+  changes:
+    added:
+    - user_policies database
+    - user_policy GET and POST routes

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -28,7 +28,8 @@ from .endpoints import (
     get_economic_impact,
     get_analysis,
     get_search,
-    set_user_policy
+    set_user_policy,
+    get_user_policy
 )
 
 print("Initialising API...")
@@ -99,6 +100,8 @@ app.route("/<country_id>/analysis", methods=["POST"])(
 app.route("/<country_id>/search", methods=["GET"])(get_search)
 
 app.route("/<country_id>/user_policy", methods=["POST"])(set_user_policy)
+
+app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(get_user_policy)
 
 @app.route("/liveness_check", methods=["GET"])
 def liveness_check():

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -29,7 +29,7 @@ from .endpoints import (
     get_analysis,
     get_search,
     set_user_policy,
-    get_user_policy
+    get_user_policy,
 )
 
 print("Initialising API...")
@@ -101,7 +101,10 @@ app.route("/<country_id>/search", methods=["GET"])(get_search)
 
 app.route("/<country_id>/user_policy", methods=["POST"])(set_user_policy)
 
-app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(get_user_policy)
+app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(
+    get_user_policy
+)
+
 
 @app.route("/liveness_check", methods=["GET"])
 def liveness_check():

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -28,6 +28,7 @@ from .endpoints import (
     get_economic_impact,
     get_analysis,
     get_search,
+    set_user_policy
 )
 
 print("Initialising API...")
@@ -97,6 +98,7 @@ app.route("/<country_id>/analysis", methods=["POST"])(
 
 app.route("/<country_id>/search", methods=["GET"])(get_search)
 
+app.route("/<country_id>/user_policy", methods=["POST"])(set_user_policy)
 
 @app.route("/liveness_check", methods=["GET"])
 def liveness_check():

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -149,6 +149,7 @@ class PolicyEngineDatabase:
             # Split the query into individual queries.
             queries = full_query.split(";")
             for query in queries:
+                print(query, sys.stdout)
                 # Execute each query.
                 self.query(query)
 

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -65,10 +65,12 @@ CREATE TABLE IF NOT EXISTS analysis (
 )
 
 CREATE TABLE IF NOT EXISTS user_policies (
-    id INTEGER PRIMARY KEY,
+    id INTEGER PRIMARY KEY AUTO_INCREMENT,
     country_id VARCHAR(3) NOT NULL,
-    label VARCHAR(255),
-    policy_id INTEGER NOT NULL,
+    reform_id INTEGER NOT NULL,
+    reform_label VARCHAR(255),
+    baseline_id INTEGER NOT NULL,
+    baseline_label VARCHAR(255),
     user_id VARCHAR(255) NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -63,3 +63,12 @@ CREATE TABLE IF NOT EXISTS analysis (
     analysis LONGTEXT,
     status VARCHAR(32) NOT NULL
 )
+
+CREATE TABLE IF NOT EXISTS user_policies (
+    id INTEGER PRIMARY KEY,
+    country_id VARCHAR(3) NOT NULL,
+    label VARCHAR(255),
+    policy_id INTEGER NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    type VARCHAR(255)
+);

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -74,8 +74,10 @@ CREATE TABLE IF NOT EXISTS analysis (
 CREATE TABLE IF NOT EXISTS user_policies (
     id INTEGER PRIMARY KEY,
     country_id VARCHAR(3) NOT NULL,
-    label VARCHAR(255),
-    policy_id INTEGER NOT NULL,
+    reform_id INTEGER NOT NULL,
+    reform_label VARCHAR(255),
+    baseline_id INTEGER NOT NULL,
+    baseline_label VARCHAR(255),
     user_id VARCHAR(255) NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS policy;
 DROP TABLE IF EXISTS economy;
 DROP TABLE IF EXISTS reform_impact;
 DROP TABLE IF EXISTS analysis;
+DROP TABLE IF EXISTS user_policies;
 
 CREATE TABLE IF NOT EXISTS household (
     id INTEGER PRIMARY KEY,
@@ -68,4 +69,13 @@ CREATE TABLE IF NOT EXISTS analysis (
     prompt LONGTEXT NOT NULL,
     analysis LONGTEXT,
     status VARCHAR(32) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user_policies (
+    id INTEGER PRIMARY KEY,
+    country_id VARCHAR(3) NOT NULL,
+    label VARCHAR(255),
+    policy_id INTEGER NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    type VARCHAR(255)
 );

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -7,7 +7,7 @@ from .household import (
     get_calculate,
     update_household,
 )
-from .policy import get_policy, set_policy, get_policy_search, set_user_policy
+from .policy import get_policy, set_policy, get_policy_search, set_user_policy, get_user_policy
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -7,7 +7,7 @@ from .household import (
     get_calculate,
     update_household,
 )
-from .policy import get_policy, set_policy, get_policy_search
+from .policy import get_policy, set_policy, get_policy_search, set_user_policy
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -7,7 +7,13 @@ from .household import (
     get_calculate,
     update_household,
 )
-from .policy import get_policy, set_policy, get_policy_search, set_user_policy, get_user_policy
+from .policy import (
+    get_policy,
+    set_policy,
+    get_policy_search,
+    set_user_policy,
+    get_user_policy,
+)
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -309,7 +309,21 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
         f"SELECT * FROM user_policies WHERE country_id = ? AND user_id = ?",
         (country_id, user_id),
     ).fetchall()
-    if rows is None:
+
+    rows_parsed = [
+        dict(
+            id=row["id"],
+            country_id=row["country_id"],
+            reform_id=row["reform_id"],
+            reform_label = row["reform_label"],
+            baseline_id=row["baseline_id"],
+            baseline_label=row["baseline_label"],
+            user_id=row["user_id"],
+            type=row["type"]
+        ) for row in rows
+    ]
+
+    if rows_parsed is None:
         response = dict(
             status="success",
             message=f"No saved policies found for user {user_id}",
@@ -322,5 +336,5 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
     return dict(
         status="ok",
         message=None,
-        result=rows,
+        result=rows_parsed,
     )

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -270,7 +270,15 @@ def set_user_policy(country_id: str) -> dict:
     try:
         database.query(
             f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, type) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, type),
+            (
+                country_id,
+                reform_label,
+                reform_id,
+                baseline_label,
+                baseline_id,
+                user_id,
+                type,
+            ),
         )
 
     except Exception as e:
@@ -315,12 +323,13 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
             id=row["id"],
             country_id=row["country_id"],
             reform_id=row["reform_id"],
-            reform_label = row["reform_label"],
+            reform_label=row["reform_label"],
             baseline_id=row["baseline_id"],
             baseline_label=row["baseline_label"],
             user_id=row["user_id"],
-            type=row["type"]
-        ) for row in rows
+            type=row["type"],
+        )
+        for row in rows
     ]
 
     if rows_parsed is None:

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -247,6 +247,7 @@ def get_current_law_policy_id(country_id: str) -> int:
         "ng": 4,
     }[country_id]
 
+
 def set_user_policy(country_id: str) -> dict:
     """
     Adds a record to the user_policy table that defines a particular
@@ -257,7 +258,7 @@ def set_user_policy(country_id: str) -> dict:
     country_not_found = validate_country(country_id)
     if country_not_found:
         return country_not_found
-    
+
     payload = request.json
     label = payload.pop("label", None)
     policy_id = payload.pop("policy_id")
@@ -267,13 +268,7 @@ def set_user_policy(country_id: str) -> dict:
     try:
         database.query(
             f"INSERT INTO user_policies (country_id, label, policy_id, user_id, type) VALUES (?, ?, ?, ?, ?)",
-            (
-                country_id,
-                label,
-                policy_id,
-                user_id,
-                type
-            ),
+            (country_id, label, policy_id, user_id, type),
         )
 
     except Exception as e:
@@ -298,6 +293,7 @@ def set_user_policy(country_id: str) -> dict:
         mimetype="application/json",
     )
 
+
 def get_user_policy(country_id: str, user_id: str) -> dict:
     """
     Fetch all saved user policies by user id
@@ -314,7 +310,7 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
     if rows is None:
         response = dict(
             status="success",
-            message=f"No saved policies found for user {user_id}"
+            message=f"No saved policies found for user {user_id}",
         )
         return Response(
             json.dumps(response),

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -297,3 +297,32 @@ def set_user_policy(country_id: str) -> dict:
         status=201,
         mimetype="application/json",
     )
+
+def get_user_policy(country_id: str, user_id: str) -> dict:
+    """
+    Fetch all saved user policies by user id
+    """
+
+    country_not_found = validate_country(country_id)
+    if country_not_found:
+        return country_not_found
+    # Get the policy record for a given policy ID.
+    rows = database.query(
+        f"SELECT * FROM user_policies WHERE country_id = ? AND user_id = ?",
+        (country_id, user_id),
+    ).fetchall()
+    if rows is None:
+        response = dict(
+            status="success",
+            message=f"No saved policies found for user {user_id}"
+        )
+        return Response(
+            json.dumps(response),
+            status=200,
+            mimetype="application/json",
+        )
+    return dict(
+        status="ok",
+        message=None,
+        result=rows,
+    )

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -260,15 +260,17 @@ def set_user_policy(country_id: str) -> dict:
         return country_not_found
 
     payload = request.json
-    label = payload.pop("label", None)
-    policy_id = payload.pop("policy_id")
+    reform_label = payload.pop("reform_label", None)
+    reform_id = payload.pop("reform_id")
+    baseline_label = payload.pop("baseline_label", None)
+    baseline_id = payload.pop("baseline_id")
     user_id = payload.pop("user_id")
     type = payload.pop("type", None)
 
     try:
         database.query(
-            f"INSERT INTO user_policies (country_id, label, policy_id, user_id, type) VALUES (?, ?, ?, ?, ?)",
-            (country_id, label, policy_id, user_id, type),
+            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, type) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, type),
         )
 
     except Exception as e:

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -246,3 +246,54 @@ def get_current_law_policy_id(country_id: str) -> int:
         "ca": 3,
         "ng": 4,
     }[country_id]
+
+def set_user_policy(country_id: str) -> dict:
+    """
+    Adds a record to the user_policy table that defines a particular
+    policy as saved by a user to "their policies"; this table also contains
+    an optional "type" column that is currently unused
+    """
+
+    country_not_found = validate_country(country_id)
+    if country_not_found:
+        return country_not_found
+    
+    payload = request.json
+    label = payload.pop("label", None)
+    policy_id = payload.pop("policy_id")
+    user_id = payload.pop("user_id")
+    type = payload.pop("type", None)
+
+    try:
+        database.query(
+            f"INSERT INTO user_policies (country_id, label, policy_id, user_id, type) VALUES (?, ?, ?, ?, ?)",
+            (
+                country_id,
+                label,
+                policy_id,
+                user_id,
+                type
+            ),
+        )
+
+    except Exception as e:
+        return Response(
+            json.dumps(
+                {
+                    "message": f"Internal database error: {e}; please try again later."
+                }
+            ),
+            status=500,
+            mimetype="application/json",
+        )
+
+    response_body = dict(
+        status="ok",
+        message="Record created successfully",
+    )
+
+    return Response(
+        json.dumps(response_body),
+        status=201,
+        mimetype="application/json",
+    )

--- a/tests/python/test_policy.py
+++ b/tests/python/test_policy.py
@@ -46,7 +46,6 @@ class TestPolicyCreation:
 
 
 class TestPolicySearch:
-
     country_id = "us"
     policy_json = {"sample_input": {"2023-01-01.2024-12-31": True}}
     label = "maxwell"
@@ -83,7 +82,6 @@ class TestPolicySearch:
         assert len(filtered_return) == len(self.db_output)
 
     def test_search_unique_policies(self, rest_client):
-
         res = rest_client.get("/us/policies?unique_only=true")
         return_object = json.loads(res.text)
 

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -12,11 +12,11 @@ class TestUserPolicies:
     user_id = "maxwell"
     test_policy = {
         "country_id": country_id,
-        "baseline_id": baseline_id, 
-        "baseline_label": baseline_label, 
-        "reform_id": reform_id, 
-        "reform_label" :reform_label, 
-        "user_id": user_id, 
+        "baseline_id": baseline_id,
+        "baseline_label": baseline_label,
+        "reform_id": reform_id,
+        "reform_label": reform_label,
+        "user_id": user_id,
     }
 
     """
@@ -26,7 +26,12 @@ class TestUserPolicies:
     def test_set_and_get_record(self, rest_client):
         database.query(
             f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",
-            (self.reform_id, self.baseline_id, self.user_id, self.reform_label),
+            (
+                self.reform_id,
+                self.baseline_id,
+                self.user_id,
+                self.reform_label,
+            ),
         )
 
         res = rest_client.post("/us/user_policy", json=self.test_policy)
@@ -46,5 +51,10 @@ class TestUserPolicies:
 
         database.query(
             f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",
-            (self.reform_id, self.baseline_id, self.user_id, self.reform_label),
+            (
+                self.reform_id,
+                self.baseline_id,
+                self.user_id,
+                self.reform_label,
+            ),
         )

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -23,6 +23,8 @@ class TestUserPolicies:
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
 
+        print(return_object)
+
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -1,0 +1,39 @@
+import json
+from policyengine_api.data import database
+
+
+class TestUserPolicies:
+
+    # Define the policy to test against
+    country_id = "us"
+    policy_id = 2
+    user_id = "maxwell"
+    label = "dworkin"
+    test_policy = {"policy_id": policy_id, "user_id": user_id, "label": label}
+
+    """
+  Test adding a record to user_policies
+  """
+
+    def test_set_and_get_record(self, rest_client):
+        database.query(
+            f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
+            (self.policy_id, self.user_id, self.label),
+        )
+
+        res = rest_client.post("/us/user_policy", json=self.test_policy)
+        return_object = json.loads(res.text)
+
+        assert return_object["status"] == "ok"
+        assert res.status_code == 201
+
+        res = rest_client.get(f"/us/user_policy/{self.user_id}")
+        return_object = json.loads(res.text)
+
+        assert return_object["status"] == "ok"
+        assert return_object["result"][0]["policy_id"] == self.policy_id
+
+        database.query(
+            f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
+            (self.policy_id, self.user_id, self.label),
+        )

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -5,10 +5,19 @@ from policyengine_api.data import database
 class TestUserPolicies:
     # Define the policy to test against
     country_id = "us"
-    policy_id = 2
+    baseline_id = 2
+    baseline_label = "Current law"
+    reform_id = 0
+    reform_label = "dworkin"
     user_id = "maxwell"
-    label = "dworkin"
-    test_policy = {"policy_id": policy_id, "user_id": user_id, "label": label}
+    test_policy = {
+        "country_id": country_id,
+        "baseline_id": baseline_id, 
+        "baseline_label": baseline_label, 
+        "reform_id": reform_id, 
+        "reform_label" :reform_label, 
+        "user_id": user_id, 
+    }
 
     """
   Test adding a record to user_policies
@@ -16,8 +25,8 @@ class TestUserPolicies:
 
     def test_set_and_get_record(self, rest_client):
         database.query(
-            f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
-            (self.policy_id, self.user_id, self.label),
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",
+            (self.reform_id, self.baseline_id, self.user_id, self.reform_label),
         )
 
         res = rest_client.post("/us/user_policy", json=self.test_policy)
@@ -32,9 +41,10 @@ class TestUserPolicies:
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
-        assert return_object["result"][0]["policy_id"] == self.policy_id
+        assert return_object["result"][0]["reform_id"] == self.reform_id
+        assert return_object["result"][0]["baseline_id"] == self.baseline_id
 
         database.query(
-            f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
-            (self.policy_id, self.user_id, self.label),
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",
+            (self.reform_id, self.baseline_id, self.user_id, self.reform_label),
         )

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -1,9 +1,8 @@
 import json
-from policyengine_api.data import database
+from policyengine_api.data import local_database
 
 
 class TestUserPolicies:
-
     # Define the policy to test against
     country_id = "us"
     policy_id = 2
@@ -16,7 +15,7 @@ class TestUserPolicies:
   """
 
     def test_set_and_get_record(self, rest_client):
-        database.query(
+        local_database.query(
             f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
             (self.policy_id, self.user_id, self.label),
         )
@@ -33,7 +32,7 @@ class TestUserPolicies:
         assert return_object["status"] == "ok"
         assert return_object["result"][0]["policy_id"] == self.policy_id
 
-        database.query(
+        local_database.query(
             f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
             (self.policy_id, self.user_id, self.label),
         )

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -1,5 +1,5 @@
 import json
-from policyengine_api.data import local_database
+from policyengine_api.data import database
 
 
 class TestUserPolicies:
@@ -15,7 +15,7 @@ class TestUserPolicies:
   """
 
     def test_set_and_get_record(self, rest_client):
-        local_database.query(
+        database.query(
             f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
             (self.policy_id, self.user_id, self.label),
         )
@@ -32,7 +32,7 @@ class TestUserPolicies:
         assert return_object["status"] == "ok"
         assert return_object["result"][0]["policy_id"] == self.policy_id
 
-        local_database.query(
+        database.query(
             f"DELETE FROM user_policies WHERE policy_id = ? AND user_id = ? AND label = ?",
             (self.policy_id, self.user_id, self.label),
         )


### PR DESCRIPTION
Fixes #1381 
Fixes #1382 
Fixes #1383 

This PR creates a new table, `user_policies`, that stores instances of policies created by authenticated users, storing their user ID. This then creates a GET route that returns an array of all policies a user with a particular ID has created, as well as a POST route for creating individual user-policy associations. This is a prerequisite for solving various front-end issues aimed at creating an authenticated user experience.