### PR TITLE
Ensure unique user policies

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Function to ensure that only unique user policies are saved

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -250,9 +250,10 @@ def get_current_law_policy_id(country_id: str) -> int:
 
 def set_user_policy(country_id: str) -> dict:
     """
-    Adds a record to the user_policy table that defines a particular
-    policy as saved by a user to "their policies"; this table also contains
-    an optional "type" column that is currently unused
+    Adds a record (if unique, barring type) to the user_policy table
+    that defines a particular policy as saved by a user to "their
+    policies"; this table also contains an optional "type" column that
+    is currently unused
     """
 
     country_not_found = validate_country(country_id)
@@ -266,6 +267,40 @@ def set_user_policy(country_id: str) -> dict:
     baseline_id = payload.pop("baseline_id")
     user_id = payload.pop("user_id")
     type = payload.pop("type", None)
+
+    # Fail silently if the record already exists, returning 200
+    try:
+        row = database.query(
+            f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND reform_label = ? AND baseline_id = ? AND baseline_label = ? AND user_id = ?",
+            (
+                country_id,
+                reform_id,
+                reform_label,
+                baseline_id,
+                baseline_label,
+                user_id,
+            ),
+        ).fetchone()
+        if row is not None:
+            response = dict(
+                status="Record not created",
+                message=f"The reform #{reform_id} / baseline #{baseline_id} pair already exists for user {user_id}",
+            )
+            return Response(
+                json.dumps(response),
+                status=200,
+                mimetype="application/json",
+            )
+    except Exception as e:
+        return Response(
+            json.dumps(
+                {
+                    "message": f"Internal database error: {e}; please try again later."
+                }
+            ),
+            status=500,
+            mimetype="application/json",
+        )
 
     try:
         database.query(

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -37,8 +37,6 @@ class TestUserPolicies:
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
 
-        print(return_object)
-
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
@@ -48,6 +46,12 @@ class TestUserPolicies:
         assert return_object["status"] == "ok"
         assert return_object["result"][0]["reform_id"] == self.reform_id
         assert return_object["result"][0]["baseline_id"] == self.baseline_id
+
+        res = rest_client.post("/us/user_policy", json=self.test_policy)
+        return_object = json.loads(res.text)
+
+        assert return_object["status"] == "Record not created"
+        assert res.status_code == 200
 
         database.query(
             f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",


### PR DESCRIPTION
Fixes #1404. This PR ensures that any time a user policy is emitted to the database, a new record is only created if unique (barring the "type" field, which it does not check at the moment). Below is a video demonstrating the behavior when records are emitted to the testing database with Postman. This also adds a test to ensure proper behavior.

https://github.com/PolicyEngine/policyengine-api/assets/14987227/7aaf74cc-0207-4826-94c1-ce7161cafb24