### PR TITLE
Add items to user_policy table

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,4 @@
   changes:
     added:
     - Year, geography, budgetary_cost, updated_date, added_date, number_of_provisions, and api_version as rows in user_policy table
+    - PUT endpoint for handling updates to existing records

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -3,3 +3,7 @@
     added:
     - Year, geography, budgetary_cost, updated_date, added_date, number_of_provisions, and api_version as rows in user_policy table
     - PUT endpoint for handling updates to existing records
+    - user_profiles table that holds non-identifying user information
+    - POST endpoint to create records within user_profiles table
+    - GET endpoint for fetching records from user_profiles table
+    - PUT endpoint for updated user_profiles records

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Year, geography, budgetary_cost, updated_date, added_date, number_of_provisions, and api_version as rows in user_policy table

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -30,7 +30,7 @@ from .endpoints import (
     get_search,
     set_user_policy,
     get_user_policy,
-    update_user_policy
+    update_user_policy,
 )
 
 print("Initialising API...")

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -33,7 +33,7 @@ from .endpoints import (
     update_user_policy,
     set_user_profile,
     get_user_profile,
-    update_user_profile
+    update_user_profile,
 )
 
 print("Initialising API...")

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -31,6 +31,7 @@ from .endpoints import (
     set_user_policy,
     get_user_policy,
     update_user_policy,
+    set_user_profile
 )
 
 print("Initialising API...")
@@ -107,6 +108,8 @@ app.route("/<country_id>/user_policy", methods=["PUT"])(update_user_policy)
 app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(
     get_user_policy
 )
+
+app.route("/<country_id>/user_profile", methods=["POST"])(set_user_profile)
 
 
 @app.route("/liveness_check", methods=["GET"])

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -32,7 +32,8 @@ from .endpoints import (
     get_user_policy,
     update_user_policy,
     set_user_profile,
-    get_user_profile
+    get_user_profile,
+    update_user_profile
 )
 
 print("Initialising API...")
@@ -113,6 +114,8 @@ app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(
 app.route("/<country_id>/user_profile", methods=["POST"])(set_user_profile)
 
 app.route("/<country_id>/user_profile", methods=["GET"])(get_user_profile)
+
+app.route("/<country_id>/user_profile", methods=["PUT"])(update_user_profile)
 
 
 @app.route("/liveness_check", methods=["GET"])

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -31,7 +31,8 @@ from .endpoints import (
     set_user_policy,
     get_user_policy,
     update_user_policy,
-    set_user_profile
+    set_user_profile,
+    get_user_profile
 )
 
 print("Initialising API...")
@@ -110,6 +111,8 @@ app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(
 )
 
 app.route("/<country_id>/user_profile", methods=["POST"])(set_user_profile)
+
+app.route("/<country_id>/user_profile", methods=["GET"])(get_user_profile)
 
 
 @app.route("/liveness_check", methods=["GET"])

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -30,6 +30,7 @@ from .endpoints import (
     get_search,
     set_user_policy,
     get_user_policy,
+    update_user_policy
 )
 
 print("Initialising API...")
@@ -100,6 +101,8 @@ app.route("/<country_id>/analysis", methods=["POST"])(
 app.route("/<country_id>/search", methods=["GET"])(get_search)
 
 app.route("/<country_id>/user_policy", methods=["POST"])(set_user_policy)
+
+app.route("/<country_id>/user_policy", methods=["PUT"])(update_user_policy)
 
 app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(
     get_user_policy

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -78,5 +78,6 @@ CREATE TABLE IF NOT EXISTS user_policies (
     api_version VARCHAR(32) NOT NULL,
     added_date DATETIME NOT NULL,
     updated_date DATETIME NOT NULL,
+    budgetary_cost VARCHAR(255),
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -72,5 +72,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     baseline_id INTEGER NOT NULL,
     baseline_label VARCHAR(255),
     user_id VARCHAR(255) NOT NULL,
+    year VARCHAR(32) NOT NULL,
+    geography VARCHAR(255) NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -76,5 +76,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,
     api_version VARCHAR(32) NOT NULL,
+    added_date DATETIME NOT NULL,
+    updated_date DATETIME NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     reform_label VARCHAR(255),
     baseline_id INTEGER NOT NULL,
     baseline_label VARCHAR(255),
-    user_id VARCHAR(255) NOT NULL,
+    auth0_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
 );
 
 CREATE TABLE IF NOT EXISTS user_profiles (
-  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  user_id INTEGER PRIMARY KEY AUTO_INCREMENT,
   auth0_id VARCHAR(255) NOT NULL UNIQUE,
   username VARCHAR(255) UNIQUE,
   primary_country VARCHAR(3) NOT NULL,

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -81,3 +81,11 @@ CREATE TABLE IF NOT EXISTS user_policies (
     budgetary_cost VARCHAR(255),
     type VARCHAR(255)
 );
+
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id INTEGER PRIMARY KEY AUTO_INCREMENT,
+  auth0_id VARCHAR(255) NOT NULL UNIQUE,
+  username VARCHAR(255) UNIQUE,
+  primary_country VARCHAR(3) NOT NULL,
+  user_since DATETIME NOT NULL
+);

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     reform_label VARCHAR(255),
     baseline_id INTEGER NOT NULL,
     baseline_label VARCHAR(255),
-    auth0_id VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -74,5 +74,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     user_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
     geography VARCHAR(255) NOT NULL,
+    number_of_provisions INTEGER NOT NULL,
+    api_version VARCHAR(32) NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -80,8 +80,10 @@ CREATE TABLE IF NOT EXISTS user_policies (
     baseline_label VARCHAR(255),
     user_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
+    geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,
     api_version VARCHAR(32) NOT NULL,
-    geography VARCHAR(255) NOT NULL,
+    added_date DATETIME NOT NULL,
+    updated_date DATETIME NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -79,5 +79,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     baseline_id INTEGER NOT NULL,
     baseline_label VARCHAR(255),
     user_id VARCHAR(255) NOT NULL,
+    year VARCHAR(32) NOT NULL,
+    geography VARCHAR(255) NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -80,6 +80,8 @@ CREATE TABLE IF NOT EXISTS user_policies (
     baseline_label VARCHAR(255),
     user_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
+    number_of_provisions INTEGER NOT NULL,
+    api_version VARCHAR(32) NOT NULL,
     geography VARCHAR(255) NOT NULL,
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     reform_label VARCHAR(255),
     baseline_id INTEGER NOT NULL,
     baseline_label VARCHAR(255),
-    auth0_id VARCHAR(255) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -85,5 +85,6 @@ CREATE TABLE IF NOT EXISTS user_policies (
     api_version VARCHAR(32) NOT NULL,
     added_date DATETIME NOT NULL,
     updated_date DATETIME NOT NULL,
+    budgetary_cost VARCHAR(255),
     type VARCHAR(255)
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     reform_label VARCHAR(255),
     baseline_id INTEGER NOT NULL,
     baseline_label VARCHAR(255),
-    user_id VARCHAR(255) NOT NULL,
+    auth0_id VARCHAR(255) NOT NULL,
     year VARCHAR(32) NOT NULL,
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
 );
 
 CREATE TABLE IF NOT EXISTS user_profiles (
-  id INTEGER PRIMARY KEY,
+  user_id INTEGER PRIMARY KEY,
   auth0_id VARCHAR(255) NOT NULL UNIQUE,
   username VARCHAR(255) UNIQUE,
   primary_country VARCHAR(3) NOT NULL,

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -88,3 +88,11 @@ CREATE TABLE IF NOT EXISTS user_policies (
     budgetary_cost VARCHAR(255),
     type VARCHAR(255)
 );
+
+CREATE TABLE IF NOT EXISTS user_profiles (
+  id INTEGER PRIMARY KEY,
+  auth0_id VARCHAR(255) NOT NULL UNIQUE,
+  username VARCHAR(255) UNIQUE,
+  primary_country VARCHAR(3) NOT NULL,
+  user_since DATETIME NOT NULL
+);

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -18,3 +18,4 @@ from .policy import (
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search
+from .user_profile import set_user_profile

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -13,7 +13,7 @@ from .policy import (
     get_policy_search,
     set_user_policy,
     get_user_policy,
-    update_user_policy
+    update_user_policy,
 )
 from .economy import get_economic_impact
 from .analysis import get_analysis

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -18,4 +18,4 @@ from .policy import (
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search
-from .user_profile import (set_user_profile, get_user_profile)
+from .user_profile import (set_user_profile, get_user_profile, update_user_profile)

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -13,6 +13,7 @@ from .policy import (
     get_policy_search,
     set_user_policy,
     get_user_policy,
+    update_user_policy
 )
 from .economy import get_economic_impact
 from .analysis import get_analysis

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -18,4 +18,8 @@ from .policy import (
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search
-from .user_profile import (set_user_profile, get_user_profile, update_user_profile)
+from .user_profile import (
+    set_user_profile,
+    get_user_profile,
+    update_user_profile,
+)

--- a/policyengine_api/endpoints/__init__.py
+++ b/policyengine_api/endpoints/__init__.py
@@ -18,4 +18,4 @@ from .policy import (
 from .economy import get_economic_impact
 from .analysis import get_analysis
 from .search import get_search
-from .user_profile import set_user_profile
+from .user_profile import (set_user_profile, get_user_profile)

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -275,9 +275,6 @@ def set_user_policy(country_id: str) -> dict:
     budgetary_cost = payload.pop("budgetary_cost", None)
     type = payload.pop("type", None)
 
-    # If the record already exists, update updated_at and api_version, then return 200
-    # Do this within the record-creation POST instead of UPDATE as, at
-    # this point, the app does not know if the record exists or not
     try:
         row = database.query(
             f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND reform_label = ? AND baseline_id = ? AND baseline_label = ? AND user_id = ? AND year = ? AND geography = ?",
@@ -293,23 +290,12 @@ def set_user_policy(country_id: str) -> dict:
             ),
         ).fetchone()
         if row is not None:
-            database.query(
-                f"UPDATE user_policies SET api_version = ? AND updated_date = ? WHERE country_id = ? AND reform_id = ? AND baseline_id = ? AND user_id = ? AND year = ? AND geography = ?",
-                (
-                    api_version,
-                    updated_date,
-                    country_id,
-                    reform_id,
-                    baseline_id,
-                    user_id,
-                    year,
-                    geography
-                )
-            )
+            readable_row = dict(row)
 
             response = dict(
                 status="ok",
-                message=f"The reform #{reform_id} / baseline #{baseline_id} pair already exists for user {user_id}; updated_at and api_version values updated",
+                message=f"The reform #{reform_id} / baseline #{baseline_id} pair already exists for user {user_id}",
+                result=dict(id=readable_row["id"])
             )
             return Response(
                 json.dumps(response),

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -270,6 +270,8 @@ def set_user_policy(country_id: str) -> dict:
     geography = payload.pop("geography")
     number_of_provisions = payload.pop("number_of_provisions")
     api_version = payload.pop("api_version")
+    added_date = payload.pop("added_date")
+    updated_date = payload.pop("updated_date")
     type = payload.pop("type", None)
 
     # Fail silently if the record already exists, returning 200
@@ -310,7 +312,7 @@ def set_user_policy(country_id: str) -> dict:
 
     try:
         database.query(
-            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, added_date, updated_date, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 country_id,
                 reform_label,
@@ -322,6 +324,8 @@ def set_user_policy(country_id: str) -> dict:
                 geography,
                 number_of_provisions,
                 api_version,
+                added_date,
+                updated_date,
                 type,
             ),
         )
@@ -376,6 +380,8 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
             geography=row["geography"],
             number_of_provisions=row["number_of_provisions"],
             api_version=row["api_version"],
+            added_date=row["added_date"],
+            updated_date=row["updated_date"],
             type=row["type"],
         )
         for row in rows

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -287,7 +287,7 @@ def set_user_policy(country_id: str) -> dict:
                 baseline_label,
                 user_id,
                 year,
-                geography
+                geography,
             ),
         ).fetchone()
         if row is not None:

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -275,7 +275,7 @@ def set_user_policy(country_id: str) -> dict:
     # Fail silently if the record already exists, returning 200
     try:
         row = database.query(
-            f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND reform_label = ? AND baseline_id = ? AND baseline_label = ? AND user_id = ?",
+            f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND reform_label = ? AND baseline_id = ? AND baseline_label = ? AND user_id = ? AND year = ? AND geography = ?",
             (
                 country_id,
                 reform_id,
@@ -283,6 +283,8 @@ def set_user_policy(country_id: str) -> dict:
                 baseline_id,
                 baseline_label,
                 user_id,
+                year,
+                geography
             ),
         ).fetchone()
         if row is not None:

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -275,7 +275,9 @@ def set_user_policy(country_id: str) -> dict:
     budgetary_cost = payload.pop("budgetary_cost", None)
     type = payload.pop("type", None)
 
-    # Fail silently if the record already exists, returning 200
+    # If the record already exists, update updated_at and api_version, then return 200
+    # Do this within the record-creation POST instead of UPDATE as, at
+    # this point, the app does not know if the record exists or not
     try:
         row = database.query(
             f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND reform_label = ? AND baseline_id = ? AND baseline_label = ? AND user_id = ? AND year = ? AND geography = ?",
@@ -291,9 +293,23 @@ def set_user_policy(country_id: str) -> dict:
             ),
         ).fetchone()
         if row is not None:
+            database.query(
+                f"UPDATE user_policies SET api_version = ? AND updated_date = ? WHERE country_id = ? AND reform_id = ? AND baseline_id = ? AND user_id = ? AND year = ? AND geography = ?",
+                (
+                    api_version,
+                    updated_date,
+                    country_id,
+                    reform_id,
+                    baseline_id,
+                    user_id,
+                    year,
+                    geography
+                )
+            )
+
             response = dict(
-                status="Record not created",
-                message=f"The reform #{reform_id} / baseline #{baseline_id} pair already exists for user {user_id}",
+                status="ok",
+                message=f"The reform #{reform_id} / baseline #{baseline_id} pair already exists for user {user_id}; updated_at and api_version values updated",
             )
             return Response(
                 json.dumps(response),

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -272,6 +272,7 @@ def set_user_policy(country_id: str) -> dict:
     api_version = payload.pop("api_version")
     added_date = payload.pop("added_date")
     updated_date = payload.pop("updated_date")
+    budgetary_cost = payload.pop("budgetary_cost", None)
     type = payload.pop("type", None)
 
     # Fail silently if the record already exists, returning 200
@@ -312,7 +313,7 @@ def set_user_policy(country_id: str) -> dict:
 
     try:
         database.query(
-            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, added_date, updated_date, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, added_date, updated_date, budgetary_cost, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 country_id,
                 reform_label,
@@ -326,6 +327,7 @@ def set_user_policy(country_id: str) -> dict:
                 api_version,
                 added_date,
                 updated_date,
+                budgetary_cost,
                 type,
             ),
         )
@@ -382,6 +384,7 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
             api_version=row["api_version"],
             added_date=row["added_date"],
             updated_date=row["updated_date"],
+            budgetary_cost=row["budgetary_cost"],
             type=row["type"],
         )
         for row in rows

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -266,6 +266,8 @@ def set_user_policy(country_id: str) -> dict:
     baseline_label = payload.pop("baseline_label", None)
     baseline_id = payload.pop("baseline_id")
     user_id = payload.pop("user_id")
+    year = payload.pop("year")
+    geography = payload.pop("geography")
     type = payload.pop("type", None)
 
     # Fail silently if the record already exists, returning 200
@@ -304,7 +306,7 @@ def set_user_policy(country_id: str) -> dict:
 
     try:
         database.query(
-            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, type) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 country_id,
                 reform_label,
@@ -312,6 +314,8 @@ def set_user_policy(country_id: str) -> dict:
                 baseline_label,
                 baseline_id,
                 user_id,
+                year,
+                geography,
                 type,
             ),
         )
@@ -362,6 +366,8 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
             baseline_id=row["baseline_id"],
             baseline_label=row["baseline_label"],
             user_id=row["user_id"],
+            year=row["year"],
+            geography=row["geography"],
             type=row["type"],
         )
         for row in rows

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -295,7 +295,7 @@ def set_user_policy(country_id: str) -> dict:
             response = dict(
                 status="ok",
                 message=f"The reform #{reform_id} / baseline #{baseline_id} pair already exists for user {user_id}",
-                result=dict(id=readable_row["id"])
+                result=dict(id=readable_row["id"]),
             )
             return Response(
                 json.dumps(response),
@@ -408,6 +408,7 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
         result=rows_parsed,
     )
 
+
 def update_user_policy(country_id: str) -> dict:
     """
     Update any parts of a user_policy, given a user_policy ID
@@ -416,7 +417,7 @@ def update_user_policy(country_id: str) -> dict:
     country_not_found = validate_country(country_id)
     if country_not_found:
         return country_not_found
-    
+
     # Construct the relevant UPDATE request
     setter_array = []
     args = []
@@ -425,18 +426,13 @@ def update_user_policy(country_id: str) -> dict:
         setter_array.append(f"{key} = ?")
         args.append(payload[key])
     setter_phrase = ", ".join(setter_array)
-    
+
     user_policy_id = payload.pop("id")
     args.append(user_policy_id)
     sql_request = f"UPDATE user_policies SET {setter_phrase} WHERE id = ?"
 
     try:
-      database.query(
-          sql_request,
-          (
-            tuple(args)
-          )
-      )
+        database.query(sql_request, (tuple(args)))
     except Exception as e:
         return Response(
             json.dumps(
@@ -447,13 +443,11 @@ def update_user_policy(country_id: str) -> dict:
             status=500,
             mimetype="application/json",
         )
-    
+
     response_body = dict(
         status="ok",
         message="Record updated successfully",
-        result=dict(
-            id=user_policy_id
-        )
+        result=dict(id=user_policy_id),
     )
 
     return Response(

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -422,12 +422,13 @@ def update_user_policy(country_id: str) -> dict:
     setter_array = []
     args = []
     payload = request.json
+    user_policy_id = payload.pop("id")
+
     for key in payload:
         setter_array.append(f"{key} = ?")
         args.append(payload[key])
     setter_phrase = ", ".join(setter_array)
 
-    user_policy_id = payload.pop("id")
     args.append(user_policy_id)
     sql_request = f"UPDATE user_policies SET {setter_phrase} WHERE id = ?"
 

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -268,6 +268,8 @@ def set_user_policy(country_id: str) -> dict:
     user_id = payload.pop("user_id")
     year = payload.pop("year")
     geography = payload.pop("geography")
+    number_of_provisions = payload.pop("number_of_provisions")
+    api_version = payload.pop("api_version")
     type = payload.pop("type", None)
 
     # Fail silently if the record already exists, returning 200
@@ -306,7 +308,7 @@ def set_user_policy(country_id: str) -> dict:
 
     try:
         database.query(
-            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 country_id,
                 reform_label,
@@ -316,6 +318,8 @@ def set_user_policy(country_id: str) -> dict:
                 user_id,
                 year,
                 geography,
+                number_of_provisions,
+                api_version,
                 type,
             ),
         )
@@ -368,6 +372,8 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
             user_id=row["user_id"],
             year=row["year"],
             geography=row["geography"],
+            number_of_provisions=row["number_of_provisions"],
+            api_version=row["api_version"],
             type=row["type"],
         )
         for row in rows

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -1,0 +1,92 @@
+from flask import Response, request
+from policyengine_api.country import validate_country
+from policyengine_api.data import database
+import json
+
+def set_user_profile(country_id: str) -> dict:
+    """
+    Creates a new user_profile
+    """
+    country_not_found = validate_country(country_id)
+    if country_not_found:
+        return country_not_found
+    
+    payload = request.json
+    primary_country = country_id
+    auth0_id = payload.pop("auth0_id")
+    username = payload.pop("username", None)
+    user_since = payload.pop("user_since")
+
+    try:
+        row = database.query(
+            f"SELECT * FROM user_profiles WHERE auth0_id = ?",
+            (
+                auth0_id,
+            ),
+        ).fetchone()
+        if row is not None:
+            response = dict(
+                status="error",
+                message=f"User with auth0_id {auth0_id} already exists",
+            )
+            return Response(
+                json.dumps(response),
+                status=403,
+                mimetype="application/json",
+            )
+    except Exception as e:
+        return Response(
+            json.dumps(
+                {
+                    "message": f"Internal database error: {e}; please try again later."
+                }
+            ),
+            status=500,
+            mimetype="application/json",
+        )
+
+    try:
+        # Unfortunately, it's not possible to use RETURNING
+        # with SQLite3 without rewriting the PolicyEngineDatabase
+        # object or implementing a true ORM, thus the double query
+        database.query(
+            f"INSERT INTO user_profiles (primary_country, auth0_id, username, user_since) VALUES (?, ?, ?, ?)",
+            (
+                primary_country,
+                auth0_id,
+                username,
+                user_since
+            ),
+        )
+
+        row = database.query(
+            f"SELECT * FROM user_profiles WHERE auth0_id = ?",
+            (
+                auth0_id,
+            )
+        ).fetchone()
+
+    except Exception as e:
+        return Response(
+            json.dumps(
+                {
+                    "message": f"Internal database error: {e}; please try again later."
+                }
+            ),
+            status=500,
+            mimetype="application/json",
+        )
+
+    response_body = dict(
+        status="ok",
+        message="Record created successfully",
+        result=dict(
+            user_id=row["user_id"]
+        )
+    )
+
+    return Response(
+        json.dumps(response_body),
+        status=201,
+        mimetype="application/json",
+    )

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -89,9 +89,7 @@ def get_user_profile(country_id: str) -> dict:
     all data except auth0_id
     """
 
-    DATETIME_TYPE_KEYS = [
-        "user_since"
-    ]
+    DATETIME_TYPE_KEYS = ["user_since"]
 
     country_not_found = validate_country(country_id)
     if country_not_found:
@@ -134,7 +132,9 @@ def get_user_profile(country_id: str) -> dict:
 
         readable_row = dict(row)
         for key in DATETIME_TYPE_KEYS:
-            readable_row[key] = datetime.strftime(readable_row[key], "%Y-%m-%d %H:%M:%S")
+            readable_row[key] = datetime.strftime(
+                readable_row[key], "%Y-%m-%d %H:%M:%S"
+            )
         if label == "user_id":
             del readable_row["auth0_id"]
 

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -1,6 +1,7 @@
 from flask import Response, request
 from policyengine_api.country import validate_country
 from policyengine_api.data import database
+from datetime import datetime
 import json
 
 
@@ -88,6 +89,10 @@ def get_user_profile(country_id: str) -> dict:
     all data except auth0_id
     """
 
+    DATETIME_TYPE_KEYS = [
+        "user_since"
+    ]
+
     country_not_found = validate_country(country_id)
     if country_not_found:
         return country_not_found
@@ -128,6 +133,8 @@ def get_user_profile(country_id: str) -> dict:
         ).fetchone()
 
         readable_row = dict(row)
+        for key in DATETIME_TYPE_KEYS:
+            readable_row[key] = datetime.strftime(readable_row[key], "%Y-%m-%d %H:%M:%S")
         if label == "user_id":
             del readable_row["auth0_id"]
 

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -3,6 +3,7 @@ from policyengine_api.country import validate_country
 from policyengine_api.data import database
 import json
 
+
 def set_user_profile(country_id: str) -> dict:
     """
     Creates a new user_profile
@@ -10,7 +11,7 @@ def set_user_profile(country_id: str) -> dict:
     country_not_found = validate_country(country_id)
     if country_not_found:
         return country_not_found
-    
+
     payload = request.json
     primary_country = country_id
     auth0_id = payload.pop("auth0_id")
@@ -20,9 +21,7 @@ def set_user_profile(country_id: str) -> dict:
     try:
         row = database.query(
             f"SELECT * FROM user_profiles WHERE auth0_id = ?",
-            (
-                auth0_id,
-            ),
+            (auth0_id,),
         ).fetchone()
         if row is not None:
             response = dict(
@@ -51,19 +50,11 @@ def set_user_profile(country_id: str) -> dict:
         # object or implementing a true ORM, thus the double query
         database.query(
             f"INSERT INTO user_profiles (primary_country, auth0_id, username, user_since) VALUES (?, ?, ?, ?)",
-            (
-                primary_country,
-                auth0_id,
-                username,
-                user_since
-            ),
+            (primary_country, auth0_id, username, user_since),
         )
 
         row = database.query(
-            f"SELECT * FROM user_profiles WHERE auth0_id = ?",
-            (
-                auth0_id,
-            )
+            f"SELECT * FROM user_profiles WHERE auth0_id = ?", (auth0_id,)
         ).fetchone()
 
     except Exception as e:
@@ -80,9 +71,7 @@ def set_user_profile(country_id: str) -> dict:
     response_body = dict(
         status="ok",
         message="Record created successfully",
-        result=dict(
-            user_id=row["user_id"]
-        )
+        result=dict(user_id=row["user_id"]),
     )
 
     return Response(
@@ -90,6 +79,7 @@ def set_user_profile(country_id: str) -> dict:
         status=201,
         mimetype="application/json",
     )
+
 
 def get_user_profile(country_id: str) -> dict:
     """
@@ -112,7 +102,7 @@ def get_user_profile(country_id: str) -> dict:
             status=500,
             mimetype="application/json",
         )
-    
+
     label = ""
     value = None
     if request.args.get("auth0_id"):
@@ -134,10 +124,7 @@ def get_user_profile(country_id: str) -> dict:
 
     try:
         row = database.query(
-            f"SELECT * FROM user_profiles WHERE {label} = ?",
-            (
-                value,
-            )
+            f"SELECT * FROM user_profiles WHERE {label} = ?", (value,)
         ).fetchone()
 
         readable_row = dict(row)
@@ -158,7 +145,7 @@ def get_user_profile(country_id: str) -> dict:
     response_body = dict(
         status="ok",
         message=f"User #{readable_row['user_id']} found successfully",
-        result=readable_row
+        result=readable_row,
     )
 
     return Response(
@@ -166,9 +153,9 @@ def get_user_profile(country_id: str) -> dict:
         status=200,
         mimetype="application/json",
     )
-    
+
+
 def update_user_profile(country_id: str) -> dict:
-    
     """
     Update any part of a user_profile, given a user_id,
     except the auth0_id value; any attempt to edit this
@@ -190,15 +177,15 @@ def update_user_profile(country_id: str) -> dict:
 
     for key in payload:
         if key == "auth0_id":
-          return Response(
-              json.dumps(
-                  {
-                      "message": "Unauthorized attempt to modify auth0_id parameter; request denied"
-                  }
-              ),
-              status=403,
-              mimetype="application/json",
-          )
+            return Response(
+                json.dumps(
+                    {
+                        "message": "Unauthorized attempt to modify auth0_id parameter; request denied"
+                    }
+                ),
+                status=403,
+                mimetype="application/json",
+            )
         setter_array.append(f"{key} = ?")
         args.append(payload[key])
     setter_phrase = ", ".join(setter_array)

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -87,7 +87,6 @@ class TestUserPolicies:
 
         res = rest_client.put("/us/user_policy", json=updated_test_policy)
         return_object = json.loads(res.text)
-        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 200

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -39,7 +39,7 @@ class TestUserPolicies:
     updated_test_policy = {
         **test_policy,
         "api_version": updated_api_version,
-        "updated_date": datetime.datetime.now()
+        "updated_date": datetime.datetime.now(),
     }
 
     """
@@ -81,7 +81,7 @@ class TestUserPolicies:
         user_policy_id = return_object["result"]["id"]
         updated_test_policy = {
             **self.updated_test_policy,
-            "id": user_policy_id
+            "id": user_policy_id,
         }
 
         res = rest_client.put("/us/user_policy", json=updated_test_policy)

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -15,8 +15,8 @@ class TestUserPolicies:
     year = "2024"
     number_of_provisions = 3
     api_version = "0.123.45"
-    added_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
-    updated_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
+    added_date = (datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),)
+    updated_date = (datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),)
     budgetary_cost = "$13 billion"
 
     test_policy = {
@@ -39,7 +39,9 @@ class TestUserPolicies:
     updated_test_policy = {
         **test_policy,
         "api_version": updated_api_version,
-        "updated_date": datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
+        "updated_date": datetime.strftime(
+            datetime.now(), "%Y-%m-%d %H:%M:%S.%f"
+        ),
     }
 
     """

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -10,7 +10,7 @@ class TestUserPolicies:
     baseline_label = "Current law"
     reform_id = 0
     reform_label = "dworkin"
-    auth0_id = "maxwell"
+    user_id = 15
     geography = "us"
     year = "2024"
     number_of_provisions = 3
@@ -25,7 +25,7 @@ class TestUserPolicies:
         "baseline_label": baseline_label,
         "reform_id": reform_id,
         "reform_label": reform_label,
-        "auth0_id": auth0_id,
+        "user_id": user_id,
         "geography": geography,
         "year": year,
         "number_of_provisions": number_of_provisions,
@@ -48,11 +48,11 @@ class TestUserPolicies:
 
     def test_set_and_get_record(self, rest_client):
         database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND auth0_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
-                self.auth0_id,
+                self.user_id,
                 self.reform_label,
                 self.geography,
                 self.year,
@@ -65,7 +65,7 @@ class TestUserPolicies:
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.get(f"/us/user_policy/{self.auth0_id}")
+        res = rest_client.get(f"/us/user_policy/{self.user_id}")
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
@@ -91,11 +91,11 @@ class TestUserPolicies:
         assert res.status_code == 200
 
         row = database.query(
-            f"SELECT * FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND auth0_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            f"SELECT * FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
-                self.auth0_id,
+                self.user_id,
                 self.reform_label,
                 self.geography,
                 self.year,
@@ -105,11 +105,11 @@ class TestUserPolicies:
         assert readable_row["api_version"] == self.updated_api_version
 
         database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND auth0_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
-                self.auth0_id,
+                self.user_id,
                 self.reform_label,
                 self.geography,
                 self.year,

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -61,6 +61,7 @@ class TestUserPolicies:
 
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -1,5 +1,5 @@
 import json
-import datetime
+from datetime import datetime
 from policyengine_api.data import database
 
 
@@ -15,8 +15,8 @@ class TestUserPolicies:
     year = "2024"
     number_of_provisions = 3
     api_version = "0.123.45"
-    added_date = datetime.datetime.now()
-    updated_date = datetime.datetime.now()
+    added_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
+    updated_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
     budgetary_cost = "$13 billion"
 
     test_policy = {
@@ -39,7 +39,7 @@ class TestUserPolicies:
     updated_test_policy = {
         **test_policy,
         "api_version": updated_api_version,
-        "updated_date": datetime.datetime.now(),
+        "updated_date": datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
     }
 
     """

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -28,8 +28,8 @@ class TestUserPolicies:
         "user_id": user_id,
         "geography": geography,
         "year": year,
-        # "number_of_provisions": number_of_provisions,
-        # "api_version": api_version,
+        "number_of_provisions": number_of_provisions,
+        "api_version": api_version,
         # "added_date": added_date,
         # "updated_date": updated_date,
         # "budgetary_cost": budgetary_cost

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -10,7 +10,7 @@ class TestUserPolicies:
     baseline_label = "Current law"
     reform_id = 0
     reform_label = "dworkin"
-    user_id = "maxwell"
+    auth0_id = "maxwell"
     geography = "us"
     year = "2024"
     number_of_provisions = 3
@@ -25,7 +25,7 @@ class TestUserPolicies:
         "baseline_label": baseline_label,
         "reform_id": reform_id,
         "reform_label": reform_label,
-        "user_id": user_id,
+        "auth0_id": auth0_id,
         "geography": geography,
         "year": year,
         "number_of_provisions": number_of_provisions,
@@ -48,11 +48,11 @@ class TestUserPolicies:
 
     def test_set_and_get_record(self, rest_client):
         database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND auth0_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
-                self.user_id,
+                self.auth0_id,
                 self.reform_label,
                 self.geography,
                 self.year,
@@ -65,7 +65,7 @@ class TestUserPolicies:
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.get(f"/us/user_policy/{self.user_id}")
+        res = rest_client.get(f"/us/user_policy/{self.auth0_id}")
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
@@ -91,11 +91,11 @@ class TestUserPolicies:
         assert res.status_code == 200
 
         row = database.query(
-            f"SELECT * FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            f"SELECT * FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND auth0_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
-                self.user_id,
+                self.auth0_id,
                 self.reform_label,
                 self.geography,
                 self.year,
@@ -105,11 +105,11 @@ class TestUserPolicies:
         assert readable_row["api_version"] == self.updated_api_version
 
         database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND auth0_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
-                self.user_id,
+                self.auth0_id,
                 self.reform_label,
                 self.geography,
                 self.year,

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 from policyengine_api.data import database
 
 
@@ -10,6 +11,14 @@ class TestUserPolicies:
     reform_id = 0
     reform_label = "dworkin"
     user_id = "maxwell"
+    geography = "us"
+    year = "2024"
+    number_of_provisions = 3
+    api_version = "0.123.45"
+    added_date = datetime.datetime.now()
+    updated_date = datetime.datetime.now()
+    budgetary_cost = "$13 billion"
+
     test_policy = {
         "country_id": country_id,
         "baseline_id": baseline_id,
@@ -17,6 +26,13 @@ class TestUserPolicies:
         "reform_id": reform_id,
         "reform_label": reform_label,
         "user_id": user_id,
+        "geography": geography,
+        "year": year,
+        # "number_of_provisions": number_of_provisions,
+        # "api_version": api_version,
+        # "added_date": added_date,
+        # "updated_date": updated_date,
+        # "budgetary_cost": budgetary_cost
     }
 
     """
@@ -25,17 +41,20 @@ class TestUserPolicies:
 
     def test_set_and_get_record(self, rest_client):
         database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
                 self.user_id,
                 self.reform_label,
+                self.geography,
+                self.year
             ),
         )
 
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
@@ -54,11 +73,13 @@ class TestUserPolicies:
         assert res.status_code == 200
 
         database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ?",
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
             (
                 self.reform_id,
                 self.baseline_id,
                 self.user_id,
                 self.reform_label,
+                self.geography,
+                self.year
             ),
         )

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -63,7 +63,6 @@ class TestUserPolicies:
 
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
-        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
@@ -89,6 +88,7 @@ class TestUserPolicies:
 
         res = rest_client.put("/us/user_policy", json=updated_test_policy)
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 200

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -32,7 +32,7 @@ class TestUserPolicies:
         "api_version": api_version,
         "added_date": added_date,
         "updated_date": updated_date,
-        "budgetary_cost": budgetary_cost
+        "budgetary_cost": budgetary_cost,
     }
 
     """
@@ -48,7 +48,7 @@ class TestUserPolicies:
                 self.user_id,
                 self.reform_label,
                 self.geography,
-                self.year
+                self.year,
             ),
         )
 
@@ -79,6 +79,6 @@ class TestUserPolicies:
                 self.user_id,
                 self.reform_label,
                 self.geography,
-                self.year
+                self.year,
             ),
         )

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -32,7 +32,7 @@ class TestUserPolicies:
         "api_version": api_version,
         "added_date": added_date,
         "updated_date": updated_date,
-        # "budgetary_cost": budgetary_cost
+        "budgetary_cost": budgetary_cost
     }
 
     """
@@ -54,7 +54,6 @@ class TestUserPolicies:
 
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
-        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from policyengine_api.data import database
+from sys import stderr
 
 
 class TestUserPolicies:
@@ -15,8 +16,8 @@ class TestUserPolicies:
     year = "2024"
     number_of_provisions = 3
     api_version = "0.123.45"
-    added_date = (datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),)
-    updated_date = (datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),)
+    added_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
+    updated_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
     budgetary_cost = "$13 billion"
 
     test_policy = {
@@ -39,9 +40,7 @@ class TestUserPolicies:
     updated_test_policy = {
         **test_policy,
         "api_version": updated_api_version,
-        "updated_date": datetime.strftime(
-            datetime.now(), "%Y-%m-%d %H:%M:%S.%f"
-        ),
+        "updated_date": datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S"),
     }
 
     """

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -30,8 +30,8 @@ class TestUserPolicies:
         "year": year,
         "number_of_provisions": number_of_provisions,
         "api_version": api_version,
-        # "added_date": added_date,
-        # "updated_date": updated_date,
+        "added_date": added_date,
+        "updated_date": updated_date,
         # "budgetary_cost": budgetary_cost
     }
 

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -68,7 +68,7 @@ class TestUserPolicies:
         res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
 
-        assert return_object["status"] == "Record not created"
+        assert return_object["status"] == "ok"
         assert res.status_code == 200
 
         database.query(

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -72,11 +72,37 @@ class TestUserPolicies:
         assert return_object["result"][0]["reform_id"] == self.reform_id
         assert return_object["result"][0]["baseline_id"] == self.baseline_id
 
-        res = rest_client.post("/us/user_policy", json=self.updated_test_policy)
+        res = rest_client.post("/us/user_policy", json=self.test_policy)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 200
+
+        user_policy_id = return_object["result"]["id"]
+        updated_test_policy = {
+            **self.updated_test_policy,
+            "id": user_policy_id
+        }
+
+        res = rest_client.put("/us/user_policy", json=updated_test_policy)
+        return_object = json.loads(res.text)
+
+        assert return_object["status"] == "ok"
+        assert res.status_code == 200
+
+        row = database.query(
+            f"SELECT * FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            (
+                self.reform_id,
+                self.baseline_id,
+                self.user_id,
+                self.reform_label,
+                self.geography,
+                self.year,
+            ),
+        ).fetchone()
+        readable_row = dict(row)
+        assert readable_row["api_version"] == self.updated_api_version
 
         database.query(
             f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -35,6 +35,13 @@ class TestUserPolicies:
         "budgetary_cost": budgetary_cost,
     }
 
+    updated_api_version = "0.456.78"
+    updated_test_policy = {
+        **test_policy,
+        "api_version": updated_api_version,
+        "updated_date": datetime.datetime.now()
+    }
+
     """
   Test adding a record to user_policies
   """
@@ -65,7 +72,7 @@ class TestUserPolicies:
         assert return_object["result"][0]["reform_id"] == self.reform_id
         assert return_object["result"][0]["baseline_id"] == self.baseline_id
 
-        res = rest_client.post("/us/user_policy", json=self.test_policy)
+        res = rest_client.post("/us/user_policy", json=self.updated_test_policy)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -8,11 +8,11 @@ class TestUserProfiles:
     auth0_id = "dworkin"
     primary_country = "us"
     user_since = datetime.datetime.now()
-    
+
     test_profile = {
         "auth0_id": auth0_id,
         "primary_country": primary_country,
-        "user_since": user_since
+        "user_since": user_since,
     }
 
     """
@@ -40,7 +40,9 @@ class TestUserProfiles:
         assert res.status_code == 200
         assert return_object["status"] == "ok"
         assert return_object["result"]["auth0_id"] == self.auth0_id
-        assert return_object["result"]["primary_country"] == self.primary_country
+        assert (
+            return_object["result"]["primary_country"] == self.primary_country
+        )
         assert return_object["result"]["username"] == None
 
         user_id = return_object["result"]["user_id"]
@@ -50,15 +52,14 @@ class TestUserProfiles:
 
         assert res.status_code == 200
         assert return_object["status"] == "ok"
-        assert return_object["result"]["primary_country"] == self.primary_country
+        assert (
+            return_object["result"]["primary_country"] == self.primary_country
+        )
         assert return_object["result"].get("auth0_id") is None
         assert return_object["result"]["username"] == None
 
         test_username = "maxwell"
-        updated_profile = {
-            "user_id": user_id,
-            "username": test_username
-        }
+        updated_profile = {"user_id": user_id, "username": test_username}
 
         res = rest_client.put("/us/user_profile", json=updated_profile)
         return_object = json.loads(res.text)
@@ -68,28 +69,23 @@ class TestUserProfiles:
 
         row = database.query(
             f"SELECT * FROM user_profiles WHERE user_id = ? AND username = ?",
-            (
-                user_id,
-                test_username
-            ),
+            (user_id, test_username),
         ).fetchone()
         assert row is not None
 
         malicious_updated_profile = {
             **updated_profile,
-            "auth0_id": self.auth0_id
+            "auth0_id": self.auth0_id,
         }
 
-        res = rest_client.put("/us/user_profile", json=malicious_updated_profile)
+        res = rest_client.put(
+            "/us/user_profile", json=malicious_updated_profile
+        )
         return_object = json.loads(res.text)
 
         assert res.status_code == 403
 
         database.query(
             f"DELETE FROM user_profiles WHERE user_id = ? AND auth0_id = ? AND primary_country = ?",
-            (
-                user_id,
-                self.auth0_id,
-                self.primary_country
-            ),
+            (user_id, self.auth0_id, self.primary_country),
         )

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -8,7 +8,7 @@ class TestUserProfiles:
     # Define the profile to test against
     auth0_id = "dworkin"
     primary_country = "us"
-    user_since = (datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),)
+    user_since = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
 
     test_profile = {
         "auth0_id": auth0_id,

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -1,13 +1,14 @@
 import json
-import datetime
+from datetime import datetime
 from policyengine_api.data import database
+import time    
 
 
 class TestUserProfiles:
     # Define the profile to test against
     auth0_id = "dworkin"
     primary_country = "us"
-    user_since = datetime.datetime.now()
+    user_since = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
 
     test_profile = {
         "auth0_id": auth0_id,

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -34,9 +34,8 @@ class TestUserProfiles:
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.get(f"/us/user_profile/auth0_id={self.auth0_id}")
+        res = rest_client.get(f"/us/user_profile?auth0_id={self.auth0_id}")
         return_object = json.loads(res.text)
-        print(return_object)
 
         assert res.status_code == 200
         assert return_object["status"] == "ok"
@@ -46,14 +45,13 @@ class TestUserProfiles:
 
         user_id = return_object["result"]["user_id"]
 
-        res = rest_client.get(f"/us/user_profile/user_id={user_id}")
+        res = rest_client.get(f"/us/user_profile?user_id={user_id}")
         return_object = json.loads(res.text)
-        print(return_object)
 
         assert res.status_code == 200
         assert return_object["status"] == "ok"
         assert return_object["result"]["primary_country"] == self.primary_country
-        assert not return_object["result"]["auth0_id"]
+        assert return_object["result"].get("auth0_id") is None
         assert return_object["result"]["username"] == None
 
         test_username = "maxwell"

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -31,6 +31,7 @@ class TestUserProfiles:
         res = rest_client.post("/us/user_profile", json=self.test_profile)
         return_object = json.loads(res.text)
 
+        print(return_object)
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -62,7 +62,6 @@ class TestUserProfiles:
 
         res = rest_client.put("/us/user_profile", json=updated_profile)
         return_object = json.loads(res.text)
-        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 200
@@ -75,6 +74,16 @@ class TestUserProfiles:
             ),
         ).fetchone()
         assert row is not None
+
+        malicious_updated_profile = {
+            **updated_profile,
+            "auth0_id": self.auth0_id
+        }
+
+        res = rest_client.put("/us/user_profile", json=malicious_updated_profile)
+        return_object = json.loads(res.text)
+
+        assert res.status_code == 403
 
         database.query(
             f"DELETE FROM user_profiles WHERE user_id = ? AND auth0_id = ? AND primary_country = ?",

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -32,7 +32,6 @@ class TestUserProfiles:
         res = rest_client.post("/us/user_profile", json=self.test_profile)
         return_object = json.loads(res.text)
 
-        print(return_object)
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -1,14 +1,14 @@
 import json
 from datetime import datetime
 from policyengine_api.data import database
-import time    
+import time
 
 
 class TestUserProfiles:
     # Define the profile to test against
     auth0_id = "dworkin"
     primary_country = "us"
-    user_since = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),
+    user_since = (datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S.%f"),)
 
     test_profile = {
         "auth0_id": auth0_id,

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -1,0 +1,86 @@
+import json
+import datetime
+from policyengine_api.data import database
+
+
+class TestUserProfiles:
+    # Define the profile to test against
+    auth0_id = "dworkin"
+    primary_country = "us",
+    user_since = datetime.datetime.now()
+    
+    test_profile = {
+        "auth0_id": auth0_id,
+        "primary_country": primary_country,
+        "user_since": user_since
+    }
+
+    """
+    Test adding a record to user_profiles
+    """
+
+    def test_set_and_get_record(self, rest_client):
+        database.query(
+            f"DELETE FROM user_profiles WHERE auth0_id = ? AND primary_country = ? AND user_since = ?",
+            (
+                self.auth0_id,
+                self.primary_country,
+                self.user_since
+            ),
+        )
+
+        res = rest_client.post("/us/user_profile", json=self.test_profile)
+        return_object = json.loads(res.text)
+
+        assert return_object["status"] == "ok"
+        assert res.status_code == 201
+
+        res = rest_client.get(f"/us/user_profile/auth0_id={self.auth0_id}")
+        return_object = json.loads(res.text)
+
+        assert res.status_code == 200
+        assert return_object["status"] == "ok"
+        assert return_object["result"]["auth0_id"] == self.auth0_id
+        assert return_object["result"]["primary_country"] == self.primary_country
+        assert return_object["result"]["username"] == None
+
+        user_id = return_object["result"]["user_id"]
+
+        res = rest_client.get(f"/us/user_profile/user_id={user_id}")
+        return_object = json.loads(res.text)
+
+        assert res.status_code == 200
+        assert return_object["status"] == "ok"
+        assert return_object["result"]["primary_country"] == self.primary_country
+        assert not return_object["result"]["auth0_id"]
+        assert return_object["result"]["username"] == None
+
+        test_username = "maxwell"
+        updated_profile = {
+            "user_id": user_id,
+            "username": test_username
+        }
+
+        res = rest_client.put("/us/user_profile", json=updated_profile)
+        return_object = json.loads(res.text)
+
+        assert return_object["status"] == "ok"
+        assert res.status_code == 200
+
+        row = database.query(
+            f"SELECT * FROM user_profiles WHERE user_id = ? AND username = ?",
+            (
+                user_id,
+                test_username
+            ),
+        ).fetchone()
+        assert row is not None
+
+        database.query(
+            f"DELETE FROM user_profiles WHERE user_id = ? AND auth0_id = ? AND primary_country = ?",
+            (
+                user_id,
+                self.auth0_id,
+                self.primary_country
+            ),
+        )

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -6,7 +6,7 @@ from policyengine_api.data import database
 class TestUserProfiles:
     # Define the profile to test against
     auth0_id = "dworkin"
-    primary_country = "us",
+    primary_country = "us"
     user_since = datetime.datetime.now()
     
     test_profile = {
@@ -21,11 +21,10 @@ class TestUserProfiles:
 
     def test_set_and_get_record(self, rest_client):
         database.query(
-            f"DELETE FROM user_profiles WHERE auth0_id = ? AND primary_country = ? AND user_since = ?",
+            f"DELETE FROM user_profiles WHERE auth0_id = ? AND primary_country = ?",
             (
                 self.auth0_id,
                 self.primary_country,
-                self.user_since
             ),
         )
 
@@ -37,6 +36,7 @@ class TestUserProfiles:
 
         res = rest_client.get(f"/us/user_profile/auth0_id={self.auth0_id}")
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert res.status_code == 200
         assert return_object["status"] == "ok"
@@ -48,6 +48,7 @@ class TestUserProfiles:
 
         res = rest_client.get(f"/us/user_profile/user_id={user_id}")
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert res.status_code == 200
         assert return_object["status"] == "ok"
@@ -63,6 +64,7 @@ class TestUserProfiles:
 
         res = rest_client.put("/us/user_profile", json=updated_profile)
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 200

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -37,6 +37,7 @@ class TestUserProfiles:
 
         res = rest_client.get(f"/us/user_profile?auth0_id={self.auth0_id}")
         return_object = json.loads(res.text)
+        print(return_object)
 
         assert res.status_code == 200
         assert return_object["status"] == "ok"
@@ -90,3 +91,14 @@ class TestUserProfiles:
             f"DELETE FROM user_profiles WHERE user_id = ? AND auth0_id = ? AND primary_country = ?",
             (user_id, self.auth0_id, self.primary_country),
         )
+
+    def test_non_existent_record(self, rest_client):
+        non_existent_auth0_id = 15303
+
+        res = rest_client.get(
+            f"/us/user_profile?auth0_id={non_existent_auth0_id}"
+        )
+        return_object = json.loads(res.text)
+        print(return_object)
+
+        assert res.status_code == 404


### PR DESCRIPTION
Fixes #1407. 
Fixes #1410.
Fixes #1411.
Fixes #1412.
Fixes #1417.
Fixes #1418.
Fixes #1420.

This PR adds created_date, updated_date, year, geography, number_of_provisions, budgetary_cost, and api_version as required columns (except budgetary_cost, which is optional) to the user_policy table, and updates `set_user_policy`, `get_user_policy`, and the user_policy table's Pytest test to handle these additions. It also changes the response status of a POST request where a user record already exists to "ok". It creates a PUT endpoint to enable modifications of existing records using the record ID that is returned by the POST controller if the record already exists, enabling both the updating of the `updated_date` and `api_version` fields of an existing record, as well as the addition of a `budgetary_cost` provision following successful policy calculation on the front end.

The below video illustrates the additional new fields that comprise a record; the use of the PUT endpoint to change the API version; and the new method by which the POST endpoint handles previously created records.

https://github.com/PolicyEngine/policyengine-api/assets/14987227/d174fb3c-cef5-4bf9-93fd-fcb83e54c380
