### PR TITLE
user_profile POST requests now return complete user object

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,4 @@
   changes:
     changed:
     - user_profile POST requests now return complete user object, not just user_id
+    - Change timestamp values in user_policies and user_profiles databases to BIGINT types and update endpoints accordingly

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - user_profile POST requests now return complete user object, not just user_id

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -76,8 +76,8 @@ CREATE TABLE IF NOT EXISTS user_policies (
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,
     api_version VARCHAR(32) NOT NULL,
-    added_date DATETIME NOT NULL,
-    updated_date DATETIME NOT NULL,
+    added_date BIGINT NOT NULL,
+    updated_date BIGINT NOT NULL,
     budgetary_cost VARCHAR(255),
     type VARCHAR(255)
 );
@@ -87,5 +87,5 @@ CREATE TABLE IF NOT EXISTS user_profiles (
   auth0_id VARCHAR(255) NOT NULL UNIQUE,
   username VARCHAR(255) UNIQUE,
   primary_country VARCHAR(3) NOT NULL,
-  user_since DATETIME NOT NULL
+  user_since BIGINT NOT NULL
 );

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -83,8 +83,8 @@ CREATE TABLE IF NOT EXISTS user_policies (
     geography VARCHAR(255) NOT NULL,
     number_of_provisions INTEGER NOT NULL,
     api_version VARCHAR(32) NOT NULL,
-    added_date DATETIME NOT NULL,
-    updated_date DATETIME NOT NULL,
+    added_date BIGINT NOT NULL,
+    updated_date BIGINT NOT NULL,
     budgetary_cost VARCHAR(255),
     type VARCHAR(255)
 );
@@ -94,5 +94,5 @@ CREATE TABLE IF NOT EXISTS user_profiles (
   auth0_id VARCHAR(255) NOT NULL UNIQUE,
   username VARCHAR(255) UNIQUE,
   primary_country VARCHAR(3) NOT NULL,
-  user_since DATETIME NOT NULL
+  user_since BIGINT NOT NULL
 );

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -72,7 +72,12 @@ def set_user_profile(country_id: str) -> dict:
     response_body = dict(
         status="ok",
         message="Record created successfully",
-        result=dict(user_id=row["user_id"]),
+        result=dict(
+            user_id=row["user_id"],
+            primary_country=row["primary_country"],
+            username=row["username"],
+            user_since=row["user_since"],
+        ),
     )
 
     return Response(

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -1,7 +1,6 @@
 from flask import Response, request
 from policyengine_api.country import validate_country
 from policyengine_api.data import database
-from datetime import datetime
 import json
 
 
@@ -147,11 +146,6 @@ def get_user_profile(country_id: str) -> dict:
             )
 
         readable_row = dict(row)
-        for key in readable_row:
-            if isinstance(readable_row[key], datetime):
-                readable_row[key] = datetime.strftime(
-                    readable_row[key], "%Y-%m-%d %H:%M:%S"
-                )
         # Delete auth0_id value if querying from user_id, as that value
         # is a more private attribute than all others
         if label == "user_id":

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from policyengine_api.data import database
 from sys import stderr
+import time
 
 
 class TestUserPolicies:
@@ -16,8 +17,9 @@ class TestUserPolicies:
     year = "2024"
     number_of_provisions = 3
     api_version = "0.123.45"
-    added_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
-    updated_date = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
+    # Simulate JS's Date.now()
+    added_date = int(time.time())
+    updated_date = int(time.time())
     budgetary_cost = "$13 billion"
 
     test_policy = {
@@ -40,7 +42,7 @@ class TestUserPolicies:
     updated_test_policy = {
         **test_policy,
         "api_version": updated_api_version,
-        "updated_date": datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S"),
+        "updated_date": int(time.time()),
     }
 
     """

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -8,7 +8,8 @@ class TestUserProfiles:
     # Define the profile to test against
     auth0_id = "dworkin"
     primary_country = "us"
-    user_since = datetime.strftime(datetime.now(), "%Y-%m-%d %H:%M:%S")
+    # Simulate JS's Date.now()
+    user_since = int(time.time())
 
     test_profile = {
         "auth0_id": auth0_id,


### PR DESCRIPTION
Fixes #1425. 
Fixes #1427.

First, this PR changes the timestamp values from the `user_profiles` and `user_policies` tables to BIGINT types, since they will be consumed by the front end in the context of JavaScript's `Date.now()` function, which returns the number of seconds since the epoch. This also prevents the numerous Python-JS-SQLite-MySQL conflicts that have emerged in the context of the DATETIME type (Python has various different formats, JS's formats are all based on epoch time, SQLite has no native handling and converts everything to TEXT using specialized handlers, and MySQL requires very specific formatting for successful insertion).

Additionally, instead of merely returning the created `user_id` value, this PR enables the `user_profile` POST endpoint to return the entire user object, other than the auth0_id.