### PR TITLE
Rename user_policies table's budgetary_cost to budgetary_impact

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Renamed user_policies table's "budgetary_cost" column to "budgetary_impact"

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     api_version VARCHAR(32) NOT NULL,
     added_date BIGINT NOT NULL,
     updated_date BIGINT NOT NULL,
-    budgetary_cost VARCHAR(255),
+    budgetary_impact VARCHAR(255),
     type VARCHAR(255)
 );
 

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -85,7 +85,7 @@ CREATE TABLE IF NOT EXISTS user_policies (
     api_version VARCHAR(32) NOT NULL,
     added_date BIGINT NOT NULL,
     updated_date BIGINT NOT NULL,
-    budgetary_cost VARCHAR(255),
+    budgetary_impact VARCHAR(255),
     type VARCHAR(255)
 );
 

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -272,7 +272,7 @@ def set_user_policy(country_id: str) -> dict:
     api_version = payload.pop("api_version")
     added_date = payload.pop("added_date")
     updated_date = payload.pop("updated_date")
-    budgetary_cost = payload.pop("budgetary_cost", None)
+    budgetary_impact = payload.pop("budgetary_impact", None)
     type = payload.pop("type", None)
 
     try:
@@ -315,7 +315,7 @@ def set_user_policy(country_id: str) -> dict:
 
     try:
         database.query(
-            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, added_date, updated_date, budgetary_cost, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            f"INSERT INTO user_policies (country_id, reform_label, reform_id, baseline_label, baseline_id, user_id, year, geography, number_of_provisions, api_version, added_date, updated_date, budgetary_impact, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 country_id,
                 reform_label,
@@ -329,7 +329,7 @@ def set_user_policy(country_id: str) -> dict:
                 api_version,
                 added_date,
                 updated_date,
-                budgetary_cost,
+                budgetary_impact,
                 type,
             ),
         )
@@ -386,7 +386,7 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
             api_version=row["api_version"],
             added_date=row["added_date"],
             updated_date=row["updated_date"],
-            budgetary_cost=row["budgetary_cost"],
+            budgetary_impact=row["budgetary_impact"],
             type=row["type"],
         )
         for row in rows
@@ -394,7 +394,7 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
 
     if rows_parsed is None:
         response = dict(
-            status="success",
+            status="ok",
             message=f"No saved policies found for user {user_id}",
         )
         return Response(

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -20,7 +20,7 @@ class TestUserPolicies:
     # Simulate JS's Date.now()
     added_date = int(time.time())
     updated_date = int(time.time())
-    budgetary_cost = "$13 billion"
+    budgetary_impact = "$13 billion"
 
     test_policy = {
         "country_id": country_id,
@@ -35,7 +35,7 @@ class TestUserPolicies:
         "api_version": api_version,
         "added_date": added_date,
         "updated_date": updated_date,
-        "budgetary_cost": budgetary_cost,
+        "budgetary_impact": budgetary_impact,
     }
 
     updated_api_version = "0.456.78"


### PR DESCRIPTION
Fixes #1431. In order to better align with the rest of the back end, this renames the `user_policies` table's `budgetary_cost` column to `budgetary_impact`