### PR TITLE
Fetch all user policies, not just those corresponding with current country

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Fetch all user policies, not just those corresponding with current country

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -367,8 +367,8 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
         return country_not_found
     # Get the policy record for a given policy ID.
     rows = database.query(
-        f"SELECT * FROM user_policies WHERE country_id = ? AND user_id = ?",
-        (country_id, user_id),
+        f"SELECT * FROM user_policies WHERE user_id = ?",
+        (user_id,),
     ).fetchall()
 
     rows_parsed = [


### PR DESCRIPTION
Fixes #1436. Previously, the `get_user_policy` endpoint only fetched policies corresponding to the current country ID, but due to a change in thinking surrounding how user profiles should work, this now fetches all policies created by the user.