### PR TITLE
Return created user_policy id

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - set_user_policy now returns the data which has been entered, as well as the new policy's ID

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -338,7 +338,8 @@ def set_user_policy(country_id: str) -> dict:
         )
 
         row = database.query(
-            f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND baseline_id = ? AND user_id = ? AND year = ? AND geography = ?", (country_id, reform_id, baseline_id, user_id, year, geography)
+            f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND baseline_id = ? AND user_id = ? AND year = ? AND geography = ?",
+            (country_id, reform_id, baseline_id, user_id, year, geography),
         ).fetchone()
 
     except Exception as e:
@@ -371,7 +372,7 @@ def set_user_policy(country_id: str) -> dict:
             updated_date=row["updated_date"],
             budgetary_impact=row["budgetary_impact"],
             type=row["type"],
-        )
+        ),
     )
 
     return Response(


### PR DESCRIPTION
Fixes #1439. After creating a `user_policy` record in the `user_policies` table via the `set_user_policy` endpoint, this PR returns the entire new record by running a subsequent SELECT call to the `user_policies` table. This will enable the front end to pass the created ID value to the app, allowing for subsequent PUT requests to update elements of the policy.