### PR TITLE
In user_policy table, convert None values to IS NULL within SELECT statements

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Added script to convert user_policy SELECT statements with None values to SQL NULL values

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -122,3 +122,37 @@ class TestUserPolicies:
                 self.year,
             ),
         )
+
+    def test_nulls(self, rest_client):
+
+        database.query(
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
+            (
+                self.reform_id,
+                self.baseline_id,
+                self.user_id,
+                self.reform_label,
+                self.geography,
+                self.year,
+            ),
+        )
+
+        nulled_test_policy = {
+            **self.test_policy,
+            "baseline_label": None,
+            "reform_label": None,
+        }
+
+        res = rest_client.post("/us/user_policy", json=nulled_test_policy)
+        return_object = json.loads(res.text)
+        print(return_object)
+
+        assert return_object["status"] == "ok"
+        assert res.status_code == 201
+
+        res = rest_client.post("/us/user_policy", json=nulled_test_policy)
+        return_object = json.loads(res.text)
+        print(return_object)
+
+        assert return_object["status"] == "ok"
+        assert res.status_code == 200


### PR DESCRIPTION
Fixes #1441. This PR ensures that for the SELECT statement utilized by the `set_user_policy` endpoint, items with a value of `None` are converted to a SQL `NULL`.