### PR TITLE
Fix test_nulls test to properly delete existing record

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Altered how test_user_policy's test_nulls test removes test records

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -125,23 +125,22 @@ class TestUserPolicies:
 
     def test_nulls(self, rest_client):
 
-        database.query(
-            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND reform_label = ? AND geography = ? AND year = ?",
-            (
-                self.reform_id,
-                self.baseline_id,
-                self.user_id,
-                self.reform_label,
-                self.geography,
-                self.year,
-            ),
-        )
-
         nulled_test_policy = {
             **self.test_policy,
             "baseline_label": None,
             "reform_label": None,
         }
+
+        database.query(
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND  geography = ? AND year = ?",
+            (
+                self.reform_id,
+                self.baseline_id,
+                self.user_id,
+                self.geography,
+                self.year,
+            ),
+        )
 
         res = rest_client.post("/us/user_policy", json=nulled_test_policy)
         return_object = json.loads(res.text)
@@ -156,3 +155,14 @@ class TestUserPolicies:
 
         assert return_object["status"] == "ok"
         assert res.status_code == 200
+
+        database.query(
+            f"DELETE FROM user_policies WHERE reform_id = ? AND baseline_id = ? AND user_id = ? AND geography = ? AND year = ?",
+            (
+                self.reform_id,
+                self.baseline_id,
+                self.user_id,
+                self.geography,
+                self.year,
+            ),
+        )


### PR DESCRIPTION
Fixes #1455. In the previous iteration of this test, the test failed to properly delete the existing test record, then failed to clean itself up by deleting the test record it creates, and this PR fixes both of those shortcomings.