### PR TITLE
Remove `budgetary_impact` from the `set_user_policy` endpoint's unique record testing

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+    - Removed unique testing for budgetary_impact within set_user_policy

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -302,6 +302,15 @@ def set_user_policy(country_id: str) -> dict:
 
     nullable_key_string = " AND ".join(nullable_keys)
 
+    # When setting a user policy, "unique" records contain
+    # a unique set of the following pieces of data:
+    # country_id, reform_id, baseline_id, user_id, year,
+    # geography, reform_label, baseline_label;
+    # added_date, budgetary_impact, updated_date,
+    # number_of_provisions, and api_version are 
+    # all are changeable, and thus do not need
+    # to be tested; type is not yet implemented
+
     try:
         row = database.query(
             f"SELECT * FROM user_policies WHERE country_id = ? AND reform_id = ? AND baseline_id = ? AND user_id = ? AND year = ? AND geography = ? AND {nullable_key_string}",

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -289,8 +289,6 @@ def set_user_policy(country_id: str) -> dict:
     possible_nulls = {
         "reform_label": reform_label,
         "baseline_label": baseline_label,
-        "budgetary_impact": budgetary_impact,
-        "type": type,
     }
 
     for key, value in possible_nulls.items():

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -305,7 +305,7 @@ def set_user_policy(country_id: str) -> dict:
     # country_id, reform_id, baseline_id, user_id, year,
     # geography, reform_label, baseline_label;
     # added_date, budgetary_impact, updated_date,
-    # number_of_provisions, and api_version are 
+    # number_of_provisions, and api_version are
     # all are changeable, and thus do not need
     # to be tested; type is not yet implemented
 


### PR DESCRIPTION
Fixes #1459. This ensures that `budgetary_impact` isn't treated as a unique key within a record, preventing duplicate record creation when a user accesses their profile.