### PR TITLE
Change get_user_policy controller to filter by country_id

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - get_user_policy controller now filters by country_id

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -418,8 +418,8 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
         return country_not_found
     # Get the policy record for a given policy ID.
     rows = database.query(
-        f"SELECT * FROM user_policies WHERE user_id = ?",
-        (user_id,),
+        f"SELECT * FROM user_policies WHERE country_id = ? AND user_id = ?",
+        (country_id, user_id),
     ).fetchall()
 
     rows_parsed = [


### PR DESCRIPTION
Fixes #1462. This functionally reverts #1438 in order to restrict the user policies returned by the `user_policy` GET endpoint to those of the country_id passed via the URL, preventing a challenging front-end bug whereby displaying all of a user's policies across countries fails because the front-end app has no access to the relevant metadata for other countries.