### PR TITLE
Pin core

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Pinned policyengine-core to v. 2.19.0 or lower

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "gunicorn",
         "markupsafe==2.0.1",
         "openai",
-        "PolicyEngine-Core>2.11",
+        "PolicyEngine-Core>2.11,<2.19.1",
         "policyengine_canada==0.95.0",
         "policyengine-ng==0.5.1",
         "policyengine-il==0.1.0",


### PR DESCRIPTION
Fixes #1471. This pins policyengine-core to prior to its current version, 2.19.1, to avoid an issue with enums on the US site breaking buttons (more detail on the app at issue [#1660](https://www.github.com/PolicyEngine/policyengine-app/issues/1660).