### PR TITLE
Add job to auto-publish to PyPI in workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -86,3 +86,27 @@ jobs:
         run: docker build -t ghcr.io/policyengine/policyengine docker
       - name: Push container
         run: docker push ghcr.io/policyengine/policyengine
+  Publish:
+    runs-on: ubuntu-latest
+    if: |
+      (github.repository == 'PolicyEngine/policyengine-api')
+      && (github.event.head_commit.message == 'Update PolicyEngine API')
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Publish a git tag
+        run: ".github/publish-git-tag.sh || true"
+      - name: Install package
+        run: make install
+      - name: Build package
+        run: make
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI }}
+          skip-existing: true

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Job to auto-publish to PyPI


### PR DESCRIPTION
Fixes #284 .

## What's changed

This PR introduces a new job to the GitHub workflow for automated publishing to PyPI.

## Changes Made

- Added the **Publish** job to the `.github/workflows/push.yml` file.
- When a commit with the message "Update PolicyEngine API" is made, the **Publish** job is triggered, resulting in the publication of a Python distribution to PyPI.