### PR TITLE
Repair `get_analysis` endpoint

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Converted get_analysis SQL GET statement argument to tuple-type

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -3,4 +3,4 @@ gunicorn -b :$PORT policyengine_api.api --timeout 300 --workers 5 &
 # Start the redis server
 redis-server &
 # Start the worker
-python3.9 policyengine_api/worker.py
+ANTRHOPIC_API_TOKEN=$ANTHROPIC_API_TOKEN python3.9 policyengine_api/worker.py

--- a/policyengine_api/endpoints/analysis.py
+++ b/policyengine_api/endpoints/analysis.py
@@ -119,7 +119,7 @@ def get_analysis(country_id: str, prompt_id=None):
     else:
         analysis_row = local_database.query(
             "SELECT analysis, status FROM analysis WHERE prompt_id = ?",
-            prompt_id,
+            (prompt_id,),
         ).fetchone()
         analysis = analysis_row["analysis"]
         status = analysis_row["status"]


### PR DESCRIPTION
Fixes #1510.

Currently, the API's `get_analysis` endpoint passes a single argument into the `PolicyEngineDatabase.query()` statement that runs on the deployed database. However, this argument is a string, while the deployed database calls for a list and the local database that runs alongside it (and which we use to debug) calls for a tuple.

I'm not entirely sure why this wasn't a problem with our prior ChatGPT implementation, but I have a few theories that I won't expound on here. Either way, it seems to be a bigger issue with the deployed MySQL database than the local SQLite one, so the below video demonstrates the code working with the deployed database:

https://github.com/PolicyEngine/policyengine-api/assets/14987227/02fa0de3-460b-4243-b927-1e112559e699