### PR TITLE
Add relative LSR changes to single_economy controller

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Overall relative LSR change to single_economy controller

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -1,5 +1,6 @@
 from microdf import MicroDataFrame, MicroSeries
 import numpy as np
+import json
 
 
 def budgetary_impact(baseline: dict, reform: dict) -> dict:
@@ -22,6 +23,7 @@ def budgetary_impact(baseline: dict, reform: dict) -> dict:
 
 
 def labour_supply_response(baseline: dict, reform: dict) -> dict:
+
     substitution_lsr = (
         reform["substitution_lsr"] - baseline["substitution_lsr"]
     )
@@ -62,6 +64,12 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
         ).to_dict(),
     )
 
+    substitution_lsr_rel = (
+        substitution_lsr_hh.sum() / household_market_income.sum()
+    )
+    income_lsr_rel = income_lsr_hh.sum() / household_market_income.sum()
+    total_lsr_rel = substitution_lsr_rel + income_lsr_rel
+
     decile_rel["income"] = {
         int(k): v for k, v in decile_rel["income"].items() if k > 0
     }
@@ -83,6 +91,9 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
         substitution_lsr=substitution_lsr,
         income_lsr=income_lsr,
         total_change=total_change,
+        substitution_lsr_rel=substitution_lsr_rel,
+        income_lsr_rel=income_lsr_rel,
+        total_lsr_rel=total_lsr_rel,
         revenue_change=revenue_change,
         decile=dict(
             average=decile_avg,

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -87,10 +87,17 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
         - baseline["weekly_hours_substitution_effect"],
     )
 
+    lsr_rel = dict(
+        substitution=substitution_lsr_rel,
+        income=income_lsr_rel,
+        total=total_lsr_rel
+    )
+
     return dict(
         substitution_lsr=substitution_lsr,
         income_lsr=income_lsr,
         total_change=total_change,
+        relative_change=lsr_rel,
         substitution_lsr_rel=substitution_lsr_rel,
         income_lsr_rel=income_lsr_rel,
         total_lsr_rel=total_lsr_rel,

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -41,9 +41,6 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
     )
     decile = np.array(baseline["household_income_decile"])
     household_weight = baseline["household_weight"]
-    household_market_income = MicroSeries(
-        baseline["household_market_income"], weights=household_weight
-    )
     substitution_lsr_hh = MicroSeries(
         substitution_lsr_hh, weights=household_weight
     )
@@ -55,19 +52,18 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
     )
     decile_rel = dict(
         income=(
-            income_lsr_hh.groupby(decile).sum()
-            / household_market_income.groupby(decile).sum()
+            income_lsr_hh.groupby(decile).sum() / baseline["total_net_income"]
         ).to_dict(),
         substitution=(
             substitution_lsr_hh.groupby(decile).sum()
-            / household_market_income.groupby(decile).sum()
+            / baseline["total_net_income"]
         ).to_dict(),
     )
 
     substitution_lsr_rel = (
-        substitution_lsr_hh.sum() / household_market_income.sum()
+        substitution_lsr_hh.sum() / baseline["total_net_income"]
     )
-    income_lsr_rel = income_lsr_hh.sum() / household_market_income.sum()
+    income_lsr_rel = income_lsr_hh.sum() / baseline["total_net_income"]
     total_lsr_rel = substitution_lsr_rel + income_lsr_rel
 
     decile_rel["income"] = {
@@ -90,7 +86,7 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
     lsr_rel = dict(
         substitution=substitution_lsr_rel,
         income=income_lsr_rel,
-        total=total_lsr_rel
+        total=total_lsr_rel,
     )
 
     return dict(


### PR DESCRIPTION
Fixes #1539. Fixes #1542. This PR alters the `single_economy` controller (or more specifically, the `labour_supply_response` function within `endpoints/economy/compare.py`) in order to respond with relative society-wide income, substitution, and total labor supply effects. This also calculates the relative overall and decile LSR impacts against `total_net_income` instead of `household_market_income`. In this, I'm hoping for confirmation that this does, in fact, represent `earnings`; it is my understanding that it does, but hoping for a double-check.

These change are required to enable https://github.com/PolicyEngine/policyengine-app/issues/1787