### PR TITLE
Fix DC microsims fail in web app

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Added extra safety check on deciles.

--- a/policyengine_api/endpoints/economy/single_economy.py
+++ b/policyengine_api/endpoints/economy/single_economy.py
@@ -34,7 +34,7 @@ def compute_general_economy(
     try:
         wealth = simulation.calculate("total_wealth")
         wealth.weights *= household_count_people
-        wealth_decile = wealth.decile_rank().astype(int).tolist()
+        wealth_decile = wealth.decile_rank().clip(1, 10).astype(int).tolist()
         wealth = wealth.astype(float).tolist()
     except:
         wealth = None
@@ -126,6 +126,7 @@ def compute_general_economy(
         "household_income_decile": simulation.calculate(
             "household_income_decile"
         )
+        .clip(1, 10)
         .astype(int)
         .tolist(),
         "household_market_income": simulation.calculate(


### PR DESCRIPTION
Fixes #1545

We should fix this in PolicyEngine-US, but essentially: sometimes we get -1 decile values for a few individual records. Probably because of negative income. But then when all records in one decile have zero weight, we get an error when taking the mean of something grouped by decile.