### PR TITLE
Add overall relative LSR impacts

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Calculation of overall relative LSR impacts

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -71,14 +71,8 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
     )
 
     relative_lsr = dict(
-        income=(
-            income_lsr_hh.sum()
-            / original_earnings.sum()
-        ),
-        substitution=(
-            substitution_lsr_hh.sum()
-            / original_earnings.sum()
-        ),
+        income=(income_lsr_hh.sum() / original_earnings.sum()),
+        substitution=(substitution_lsr_hh.sum() / original_earnings.sum()),
     )
 
     decile_rel["income"] = {

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -70,6 +70,17 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
         ).to_dict(),
     )
 
+    relative_lsr = dict(
+        income=(
+            income_lsr_hh.sum()
+            / original_earnings.sum()
+        ),
+        substitution=(
+            substitution_lsr_hh.sum()
+            / original_earnings.sum()
+        ),
+    )
+
     decile_rel["income"] = {
         int(k): v for k, v in decile_rel["income"].items() if k > 0
     }
@@ -90,6 +101,7 @@ def labour_supply_response(baseline: dict, reform: dict) -> dict:
     return dict(
         substitution_lsr=substitution_lsr,
         income_lsr=income_lsr,
+        relative_lsr=relative_lsr,
         total_change=total_change,
         revenue_change=revenue_change,
         decile=dict(


### PR DESCRIPTION
Fixes #1539. This PR adds calculation of overall relative labor supply response impacts to the relevant controller in a similar fashion to #1547. This is a requirement for https://github.com/PolicyEngine/policyengine-app/issues/1787. This PR does not add any relevant tests, but if desired, that can be done.