### PR TITLE
Change how queue positioning is reported

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    changed:
+    - Display "Your position in the queue is 0" instead of "Your position in the queue is None" for active jobs
+    added:
+    - queue_position to response for active jobs

--- a/policyengine_api/endpoints/economy/economy.py
+++ b/policyengine_api/endpoints/economy/economy.py
@@ -212,7 +212,11 @@ def get_economic_impact(
             )
             del RECENT_JOBS[oldest_job_id]
         job = Job.fetch(job_id, connection=queue.connection)
-        queue_pos = job.get_position() if type(job.get_position()) == (int or float) else 0
+        queue_pos = (
+            job.get_position()
+            if type(job.get_position()) == (int or float)
+            else 0
+        )
         return dict(
             status=result["status"],
             message=f"Your position in the queue is {queue_pos}.",

--- a/policyengine_api/endpoints/economy/economy.py
+++ b/policyengine_api/endpoints/economy/economy.py
@@ -212,9 +212,11 @@ def get_economic_impact(
             )
             del RECENT_JOBS[oldest_job_id]
         job = Job.fetch(job_id, connection=queue.connection)
+        queue_pos = job.get_position() if type(job.get_position()) == (int or float) else 0
         return dict(
             status=result["status"],
-            message=f"Your position in the queue is {job.get_position()}.",
+            message=f"Your position in the queue is {queue_pos}.",
+            queue_position=queue_pos,
             average_time=get_average_time(),
             result=result["reform_impact_json"],
         )


### PR DESCRIPTION
Fixes #1578. This PR adds a separate `queue_position` element to the output in cases where the API is in the process of calculating and ensures that both display the queue position as "0" instead of "None" when an item is being actively calculated.

This is necessary to fix https://github.com/PolicyEngine/policyengine-app/issues/1883.