### PR TITLE
Update API, GCP to Python 3.10

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: GCP authentication
         uses: "google-github-actions/auth@v2"
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: GCP authentication
         uses: "google-github-actions/auth@v2"
         with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Upgraded to Python 3.10

--- a/gcp/Dockerfile
+++ b/gcp/Dockerfile
@@ -1,13 +1,13 @@
 FROM gcr.io/google-appengine/python
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
-# Install Python 3.9.13 from source
+# Install Python 3.10.9 from source
 RUN apt-get update && apt-get install -y build-essential checkinstall
 RUN apt-get install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
-RUN wget https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz
-RUN tar xzf Python-3.9.7.tgz
-RUN cd Python-3.9.7 && ./configure --enable-optimizations
-RUN cd Python-3.9.7 && make altinstall
-RUN python3.9 -m pip install --upgrade pip
+RUN wget https://www.python.org/ftp/python/3.10.9/Python-3.10.9.tgz
+RUN tar xzf Python-3.10.9.tgz
+RUN cd Python-3.10.9 && ./configure --enable-optimizations
+RUN cd Python-3.10.9 && make altinstall
+RUN python3.10 -m pip install --upgrade pip
 RUN apt-get update && apt-get install -y redis-server
 RUN pip install git+https://github.com/policyengine/policyengine-api

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -3,4 +3,4 @@ gunicorn -b :$PORT policyengine_api.api --timeout 300 --workers 5 &
 # Start the redis server
 redis-server &
 # Start the worker
-ANTRHOPIC_API_TOKEN=$ANTHROPIC_API_TOKEN python3.9 policyengine_api/worker.py
+ANTRHOPIC_API_TOKEN=$ANTHROPIC_API_TOKEN python3.10 policyengine_api/worker.py

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         "anthropic",
         "click>=8",
         "cloud-sql-python-connector",
-        "faiss-cpu",
+        "faiss-cpu<1.8.0",
         "flask>=1",
         "flask-cors>=3",
         "google-cloud-logging",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "flask>=1",
         "flask-cors>=3",
         "google-cloud-logging",
+        "grpcio==1.46.3",
         "gunicorn",
         "markupsafe==2.0.1",
         "openai",


### PR DESCRIPTION
Fixes #1437.
Fixes #438.

Updates GCP install to Python 3.10 and pins various packages that hinder local development/execution.