### PR TITLE
Fix typo in README.md: Remove repeated word

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To test your changes against our series of automated tests, run
 make debug-test
 ```
 
-If testing anything anything that utilizes Redis (unlikely) or the API's service workers (very unlikely), you'll also need to run one of the following:
+If testing anything that utilizes Redis (unlikely) or the API's service workers (very unlikely), you'll also need to run one of the following:
 ```
 redis-server
 ```

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Deleted duplicate word in README


### PR DESCRIPTION
Removed the repeated word "anything" in the README.