### PR TITLE
Fix Docker settings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -44,6 +44,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.POLICYENGINE_DOCKER }}
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Build container
         run: docker build -t ghcr.io/policyengine/policyengine docker
   test:
@@ -54,6 +56,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    container:
+        image: nikhilwoodruff/policyengine-api
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,27 +2,32 @@ name: Pull request
 
 on: pull_request
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
-      - uses: psf/black@stable
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5
+      - name: Format with Black
+        uses: psf/black@stable
         with:
           options: ". -l 79 --check"
   check-version:
     name: Check version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -37,15 +42,14 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.POLICYENGINE_DOCKER }}
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Build container
         run: docker build -t ghcr.io/policyengine/policyengine docker
   test:
@@ -56,8 +60,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,8 +21,8 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          env:
-            ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,8 @@ jobs:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
+          env:
+            ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,8 +47,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    container:
-      image: nikhilwoodruff/policyengine-api
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: GCP authentication
         uses: "google-github-actions/auth@v2"
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,12 +13,12 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine API')
     steps:
       - uses: actions/checkout@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Check formatting
         uses: "lgeiger/black-action@master"
         with:
           args: ". -l 79 --check"
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   versioning:
     name: Update versioning
     if: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.POLICYENGINE_GITHUB }}
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -56,6 +58,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -85,6 +89,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.POLICYENGINE_DOCKER }}
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Build container
         run: docker build -t ghcr.io/policyengine/policyengine docker
       - name: Push container

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   Lint:
     runs-on: ubuntu-latest
@@ -14,8 +17,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Check formatting
         uses: "lgeiger/black-action@master"
         with:
@@ -33,8 +34,6 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.POLICYENGINE_GITHUB }}
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -59,8 +58,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -83,15 +80,14 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.POLICYENGINE_DOCKER }}
-        env:
-          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Build container
         run: docker build -t ghcr.io/policyengine/policyengine docker
       - name: Push container

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,8 @@ jobs:
       (github.repository == 'PolicyEngine/policyengine-uk')
       && (github.event.head_commit.message == 'Update PolicyEngine API')
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
         env:
           ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       - name: Check formatting

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,8 @@ jobs:
         uses: "lgeiger/black-action@master"
         with:
           args: ". -l 79 --check"
+        env:
+          ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   versioning:
     name: Update versioning
     if: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: GCP authentication
         uses: "google-github-actions/auth@v2"
         with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update PolicyEngine US to 1.16.0

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,5 @@
 - bump: patch
   changes:
     changed:
-    - Update PolicyEngine US to 1.16.0
+    - Return to using Python 3.10
+    - Use standard-build Python image for Docker container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,2 +1,2 @@
-FROM python:3.9
+FROM python:3.10
 RUN pip install policyengine-core policyengine-uk policyengine-us ipython

--- a/gcp/Dockerfile
+++ b/gcp/Dockerfile
@@ -1,13 +1,7 @@
-FROM gcr.io/google-appengine/python
+FROM python:3.10
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
-# Install Python 3.9.4 from source
 RUN apt-get update && apt-get install -y build-essential checkinstall
-RUN apt-get install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
-RUN wget https://www.python.org/ftp/python/3.9.4/Python-3.9.4.tgz
-RUN tar xzf Python-3.9.4.tgz
-RUN cd Python-3.9.4 && ./configure --enable-optimizations
-RUN cd Python-3.9.4 && make altinstall
-RUN python3.9 -m pip install --upgrade pip
+RUN python3.10 -m pip install --upgrade pip --trusted-host pypi.python.org --trusted-host pypi.org --trusted-host files.pythonhosted.orgpip
 RUN apt-get update && apt-get install -y redis-server
 RUN pip install git+https://github.com/policyengine/policyengine-api

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -8,5 +8,5 @@ To update the starter image:
 * `cd gcp`
 * `docker build .`
 * `docker images` to get the image id (the most recent one should be the one you just built)
-* `docker tag <image id> nikhilwoodruff/policyengine-api`
-* `docker push nikhilwoodruff/policyengine-api`
+* `docker tag <image id> policyengine/policyengine-api`
+* `docker push policyengine/policyengine-api`

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -15,3 +15,7 @@ liveness_check:
   timeout_sec: 30
   failure_threshold: 5
   success_threshold: 2
+runtime_config:
+  operating_system: "ubuntu22"
+  runtime_version: "22"
+

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -3,4 +3,4 @@ gunicorn -b :$PORT policyengine_api.api --timeout 300 --workers 5 &
 # Start the redis server
 redis-server &
 # Start the worker
-ANTHROPIC_API_TOKEN=$ANTHROPIC_API_TOKEN python3.9 policyengine_api/worker.py
+ANTHROPIC_API_TOKEN=$ANTHROPIC_API_TOKEN python3.10 policyengine_api/worker.py

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "policyengine-ng==0.5.1",
         "policyengine-il==0.1.0",
         "policyengine_uk==0.85.0",
-        "policyengine_us==1.12.0",
+        "policyengine_us==1.16.0",
         "pymysql",
         "redis",
         "rq",


### PR DESCRIPTION
Fixes #1634 
Fixes #1635 

PR changes how we deploy from a Docker container, using the Docker version of Python 3.10 instead of a custom-built one to avoid issues with the `_ssl` module, as even when manually installing relevant versions of OpenSSL, the module simply wouldn't build.