### PR TITLE
Remove explicit start.sh copy command

### DIFF
--- a/gcp/policyengine_api/Dockerfile
+++ b/gcp/policyengine_api/Dockerfile
@@ -11,9 +11,6 @@ WORKDIR /app
 # Copy application
 ADD . /app
 
-# Copy start.sh explicitly
-COPY policyengine_api/gcp/policyengine_api/start.sh /app/start.sh
-
 # Make start.sh executable
 RUN chmod +x /app/start.sh
 


### PR DESCRIPTION
Fixes #1644 

PR removes the AI-suggested line to copy the `start.sh` file explicitly due to an incorrect filepath.