### PR TITLE
Update PolicyEngine US to 1.26.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update PolicyEngine US to 1.26.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "policyengine-ng==0.5.1",
         "policyengine-il==0.1.0",
         "policyengine_uk==1.0.0",
-        "policyengine_us==1.25.2",
+        "policyengine_us==1.26.0",
         "pymysql",
         "redis",
         "rq",


### PR DESCRIPTION
Update PolicyEngine US to 1.26.0