### PR TITLE
Increase max GCP instances to 2

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Increased max GCP instances to 2

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -6,7 +6,7 @@ resources:
   disk_size_gb: 64
 automatic_scaling:
   min_num_instances: 1
-  max_num_instances: 1
+  max_num_instances: 2
   cool_down_period_sec: 180
   cpu_utilization:
     target_utilization: 0.8


### PR DESCRIPTION
ISSUE TO BE ADDED. This is a draft PR that would increase the max number of GCP instances to 2.