### PR TITLE
Filter households with negative incomes out of `decile_impact` and `wealth_decile_impact` prior to applying formulas

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Filter negative household incomes out of decile_impact and wealth_decile_impact prior to calculating

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     changed:
-    - Filter negative household incomes out of decile_impact and wealth_decile_impact prior to calculating
+    - Filter negative income deciles out of decile_impact and wealth_decile_impact prior to calculating

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -141,11 +141,11 @@ def decile_impact(baseline: dict, reform: dict) -> dict:
         reform["household_net_income"], weights=baseline_income.weights
     )
 
-    # Filter out negative net incomes
-    baseline_income_filtered = baseline_income[baseline_income >= 0]
-    reform_income_filtered = reform_income[baseline_income >= 0]
-
+    # Filter out negative decile values
     decile = MicroSeries(baseline["household_income_decile"])
+    baseline_income_filtered = baseline_income[decile >= 0]
+    reform_income_filtered = reform_income[decile >= 0]
+
     income_change = reform_income_filtered - baseline_income_filtered
     rel_income_change_by_decile = (
         income_change.groupby(decile).sum()
@@ -183,11 +183,11 @@ def wealth_decile_impact(baseline: dict, reform: dict) -> dict:
         reform["household_net_income"], weights=baseline_income.weights
     )
 
-    # Filter out negative net incomes
-    baseline_income_filtered = baseline_income[baseline_income >= 0]
-    reform_income_filtered = reform_income[baseline_income >= 0]
-
+    # Filter out negative decile values
     decile = MicroSeries(baseline["household_wealth_decile"])
+    baseline_income_filtered = baseline_income[decile >= 0]
+    reform_income_filtered = reform_income[decile >= 0]
+
     income_change = reform_income_filtered - baseline_income_filtered
     rel_income_change_by_decile = (
         income_change.groupby(decile).sum()

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -1,5 +1,6 @@
 from microdf import MicroDataFrame, MicroSeries
 import numpy as np
+import sys
 
 
 def budgetary_impact(baseline: dict, reform: dict) -> dict:
@@ -139,21 +140,27 @@ def decile_impact(baseline: dict, reform: dict) -> dict:
     reform_income = MicroSeries(
         reform["household_net_income"], weights=baseline_income.weights
     )
+
+    # Filter out negative net incomes
+    baseline_income_filtered = baseline_income[baseline_income >= 0]
+    reform_income_filtered = reform_income[baseline_income >= 0]
+
     decile = MicroSeries(baseline["household_income_decile"])
-    income_change = reform_income - baseline_income
+    income_change = reform_income_filtered - baseline_income_filtered
     rel_income_change_by_decile = (
         income_change.groupby(decile).sum()
-        / baseline_income.groupby(decile).sum()
+        / baseline_income_filtered.groupby(decile).sum()
     )
+
     avg_income_change_by_decile = (
         income_change.groupby(decile).sum()
-        / baseline_income.groupby(decile).count()
+        / baseline_income_filtered.groupby(decile).count()
     )
     rel_decile_dict = rel_income_change_by_decile.to_dict()
     avg_decile_dict = avg_income_change_by_decile.to_dict()
     result = dict(
-        relative={int(k): v for k, v in rel_decile_dict.items() if k > 0},
-        average={int(k): v for k, v in avg_decile_dict.items() if k > 0},
+        relative={int(k): v for k, v in rel_decile_dict.items()},
+        average={int(k): v for k, v in avg_decile_dict.items()},
     )
     return result
 
@@ -175,21 +182,26 @@ def wealth_decile_impact(baseline: dict, reform: dict) -> dict:
     reform_income = MicroSeries(
         reform["household_net_income"], weights=baseline_income.weights
     )
+
+    # Filter out negative net incomes
+    baseline_income_filtered = baseline_income[baseline_income >= 0]
+    reform_income_filtered = reform_income[baseline_income >= 0]
+
     decile = MicroSeries(baseline["household_wealth_decile"])
-    income_change = reform_income - baseline_income
+    income_change = reform_income_filtered - baseline_income_filtered
     rel_income_change_by_decile = (
         income_change.groupby(decile).sum()
-        / baseline_income.groupby(decile).sum()
+        / baseline_income_filtered.groupby(decile).sum()
     )
     avg_income_change_by_decile = (
         income_change.groupby(decile).sum()
-        / baseline_income.groupby(decile).count()
+        / baseline_income_filtered.groupby(decile).count()
     )
     rel_decile_dict = rel_income_change_by_decile.to_dict()
     avg_decile_dict = avg_income_change_by_decile.to_dict()
     result = dict(
-        relative={int(k): v for k, v in rel_decile_dict.items() if k > 0},
-        average={int(k): v for k, v in avg_decile_dict.items() if k > 0},
+        relative={int(k): v for k, v in rel_decile_dict.items()},
+        average={int(k): v for k, v in avg_decile_dict.items()},
     )
     return result
 

--- a/policyengine_api/endpoints/economy/single_economy.py
+++ b/policyengine_api/endpoints/economy/single_economy.py
@@ -138,7 +138,6 @@ def compute_general_economy(
         "household_income_decile": simulation.calculate(
             "household_income_decile"
         )
-        .clip(1, 10)
         .astype(int)
         .tolist(),
         "household_market_income": simulation.calculate(


### PR DESCRIPTION
Fixes #1603. This PR changes where the `decile_impact` and `wealth_decile_impact` functions filter out households with negative household net incomes. These households appear to only exist as a result of the `enhanced_cps` dataset, and the households with the lowest negative incomes have such incredibly negative incomes that they skew the relative decile impact to be negative. 

Instead of doing so after grouping households by decile, this PR removes these households beforehand.

Before pushing, a visual demonstration of the new outputs in the front-end app will be added.

Prior to approval, I'd like to confirm that this approach is technically feasible, as I'm unsure if this method will result in an uneven decile distribution after filtering out households with negative net incomes.