### PR TITLE
Fix get_search request to return specified number of results, with a max value of 50.

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    fixed:
+    - Fixed get_search request to return specified number of results, with a maximum value of 50.


### PR DESCRIPTION
Fixes #422

- Fixed the `get_search` request to return specified number of results instead of just returning 10
- The default is 10, and the maximum value is 50