### PR TITLE
Update PolicyEngine US to 1.96.0

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Update PolicyEngine US to 1.96.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "policyengine-ng==0.5.1",
         "policyengine-il==0.1.0",
         "policyengine_uk==2.1.1",
-        "policyengine_us==1.93.0",
+        "policyengine_us==1.96.0",
         "pymysql",
         "redis",
         "rq",


### PR DESCRIPTION
Update PolicyEngine US to 1.96.0