### PR TITLE
Return more accurate status codes in `get_analysis`

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Return correct code 404, not found, for invalid analysis ID in get_analysis


### PR DESCRIPTION
## Fixes #562 
- Return 404 when prompt ID is invalid/no record exists