### PR TITLE
Fix `get_policy_search` endpoint to return `404` when no policy is found

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: minor
+  changes:
+    added:
+    - added fix to return correct status codes for no policies found in get_policy_search endpoint
+  


### PR DESCRIPTION
## Fixes #416 

## Changes
- Added checks for when no policy is found in `get_policy_search`