### PR TITLE
Handle JS Infinity

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Changed infinite value representation from ".inf" to "Infinity"

--- a/policyengine_api/utils/json.py
+++ b/policyengine_api/utils/json.py
@@ -23,11 +23,13 @@ def hash_object(o):
 
 
 def get_safe_json(value):
+    # This function is used when constructing metadata,
+    # which will be consumed by JS, hence Infinity, not .inf
     if isinstance(value, (int, float)):
         if value == np.inf:
-            return ".inf"
+            return "Infinity"
         elif value == -np.inf:
-            return "-.inf"
+            return "-Infinity"
         return value
     if isinstance(value, str):
         return value


### PR DESCRIPTION
Fixes #1866.
Fixes #1886.

This changes the string value that infinite values are set to, allowing for more logical processing on the front end. This change is very minimal, hence I feel no tests are needed in this case.

This must be merged before the accompanying front-end changes in https://github.com/PolicyEngine/policyengine-app/pull/2103.