### PR TITLE
Rename endpoints to use hyphens not underscores

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: major
+  changes:
+    changed:
+    - Renamed endpoints containing underscores (user_policy, user_profile, liveness_check & readiness_check) to use hyphens; updated tests

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -11,6 +11,7 @@ automatic_scaling:
   cpu_utilization:
     target_utilization: 0.8
 liveness_check:
+  path: "/liveness-check"
   check_interval_sec: 30
   timeout_sec: 30
   failure_threshold: 5

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -100,19 +100,19 @@ app.route("/<country_id>/simulation-analysis", methods=["POST"])(
     execute_simulation_analysis
 )
 
-app.route("/<country_id>/user_policy", methods=["POST"])(set_user_policy)
+app.route("/<country_id>/user-policy", methods=["POST"])(set_user_policy)
 
-app.route("/<country_id>/user_policy", methods=["PUT"])(update_user_policy)
+app.route("/<country_id>/user-policy", methods=["PUT"])(update_user_policy)
 
-app.route("/<country_id>/user_policy/<user_id>", methods=["GET"])(
+app.route("/<country_id>/user-policy/<user_id>", methods=["GET"])(
     get_user_policy
 )
 
-app.route("/<country_id>/user_profile", methods=["POST"])(set_user_profile)
+app.route("/<country_id>/user-profile", methods=["POST"])(set_user_profile)
 
-app.route("/<country_id>/user_profile", methods=["GET"])(get_user_profile)
+app.route("/<country_id>/user-profile", methods=["GET"])(get_user_profile)
 
-app.route("/<country_id>/user_profile", methods=["PUT"])(update_user_profile)
+app.route("/<country_id>/user-profile", methods=["PUT"])(update_user_profile)
 
 app.route("/simulations", methods=["GET"])(get_simulations)
 
@@ -123,14 +123,14 @@ app.route("/<country_id>/tracer-analysis", methods=["POST"])(
 )
 
 
-@app.route("/liveness_check", methods=["GET"])
+@app.route("/liveness-check", methods=["GET"])
 def liveness_check():
     return flask.Response(
         "OK", status=200, headers={"Content-Type": "text/plain"}
     )
 
 
-@app.route("/readiness_check", methods=["GET"])
+@app.route("/readiness-check", methods=["GET"])
 def readiness_check():
     return flask.Response(
         "OK", status=200, headers={"Content-Type": "text/plain"}

--- a/policyengine_api/openapi_spec.yaml
+++ b/policyengine_api/openapi_spec.yaml
@@ -741,7 +741,7 @@ paths:
               schema:
                 type: string
 
-  /liveness_check:
+  /liveness-check:
     get:
       summary: Test for server liveness.
       operationId: liveness_check
@@ -753,7 +753,7 @@ paths:
             text/plain:
               schema:
                 type: string
-  /readiness_check:
+  /readiness-check:
     get:
       summary: Test for server readiness.
       operationId: readiness_check

--- a/tests/api/test_liveness.yaml
+++ b/tests/api/test_liveness.yaml
@@ -1,4 +1,4 @@
 name: Liveness
-endpoint: /liveness_check
+endpoint: /liveness-check
 response:
   status: 200

--- a/tests/api/test_readiness.yaml
+++ b/tests/api/test_readiness.yaml
@@ -1,4 +1,4 @@
 name: Readiness
-endpoint: /readiness_check
+endpoint: /readiness-check
 response:
   status: 200

--- a/tests/python/test_user_policy.py
+++ b/tests/python/test_user_policy.py
@@ -62,14 +62,14 @@ class TestUserPolicies:
             ),
         )
 
-        res = rest_client.post("/us/user_policy", json=self.test_policy)
+        res = rest_client.post("/us/user-policy", json=self.test_policy)
         return_object = json.loads(res.text)
         print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.get(f"/us/user_policy/{self.user_id}")
+        res = rest_client.get(f"/us/user-policy/{self.user_id}")
         return_object = json.loads(res.text)
         print(return_object)
 
@@ -77,7 +77,7 @@ class TestUserPolicies:
         assert return_object["result"][0]["reform_id"] == self.reform_id
         assert return_object["result"][0]["baseline_id"] == self.baseline_id
 
-        res = rest_client.post("/us/user_policy", json=self.test_policy)
+        res = rest_client.post("/us/user-policy", json=self.test_policy)
         return_object = json.loads(res.text)
         print(return_object)
 
@@ -90,7 +90,7 @@ class TestUserPolicies:
             "id": user_policy_id,
         }
 
-        res = rest_client.put("/us/user_policy", json=updated_test_policy)
+        res = rest_client.put("/us/user-policy", json=updated_test_policy)
         return_object = json.loads(res.text)
         print(return_object)
 
@@ -142,14 +142,14 @@ class TestUserPolicies:
             ),
         )
 
-        res = rest_client.post("/us/user_policy", json=nulled_test_policy)
+        res = rest_client.post("/us/user-policy", json=nulled_test_policy)
         return_object = json.loads(res.text)
         print(return_object)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.post("/us/user_policy", json=nulled_test_policy)
+        res = rest_client.post("/us/user-policy", json=nulled_test_policy)
         return_object = json.loads(res.text)
         print(return_object)
 

--- a/tests/python/test_user_profile.py
+++ b/tests/python/test_user_profile.py
@@ -30,13 +30,13 @@ class TestUserProfiles:
             ),
         )
 
-        res = rest_client.post("/us/user_profile", json=self.test_profile)
+        res = rest_client.post("/us/user-profile", json=self.test_profile)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.get(f"/us/user_profile?auth0_id={self.auth0_id}")
+        res = rest_client.get(f"/us/user-profile?auth0_id={self.auth0_id}")
         return_object = json.loads(res.text)
         print(return_object)
 
@@ -50,7 +50,7 @@ class TestUserProfiles:
 
         user_id = return_object["result"]["user_id"]
 
-        res = rest_client.get(f"/us/user_profile?user_id={user_id}")
+        res = rest_client.get(f"/us/user-profile?user_id={user_id}")
         return_object = json.loads(res.text)
 
         assert res.status_code == 200
@@ -64,7 +64,7 @@ class TestUserProfiles:
         test_username = "maxwell"
         updated_profile = {"user_id": user_id, "username": test_username}
 
-        res = rest_client.put("/us/user_profile", json=updated_profile)
+        res = rest_client.put("/us/user-profile", json=updated_profile)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
@@ -82,7 +82,7 @@ class TestUserProfiles:
         }
 
         res = rest_client.put(
-            "/us/user_profile", json=malicious_updated_profile
+            "/us/user-profile", json=malicious_updated_profile
         )
         return_object = json.loads(res.text)
 
@@ -97,7 +97,7 @@ class TestUserProfiles:
         non_existent_auth0_id = 15303
 
         res = rest_client.get(
-            f"/us/user_profile?auth0_id={non_existent_auth0_id}"
+            f"/us/user-profile?auth0_id={non_existent_auth0_id}"
         )
         return_object = json.loads(res.text)
         print(return_object)


### PR DESCRIPTION
Fixes #1863 

## requires

- [x] frontend update of edited endpoints - pr opened at [#2123](https://github.com/PolicyEngine/policyengine-app/pull/2123)