### PR TITLE
Re-enable Python 3.11, remove explicity version call in start.sh

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Build changelog
         run: pip install yaml-changelog && make changelog
       - name: Preview changelog update
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: GCP authentication
         uses: "google-github-actions/auth@v2"
         with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    changed:
+    - Re-enable Python 3.11
+    removed:
+    - Explicit Python version call in start.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,2 +1,2 @@
-FROM python:3.10
+FROM python:3.11
 RUN pip install policyengine-core policyengine-uk policyengine-us ipython

--- a/gcp/Dockerfile
+++ b/gcp/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.10
+FROM python:3.11
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 RUN apt-get update && apt-get install -y build-essential checkinstall
-RUN python3.10 -m pip install --upgrade pip --trusted-host pypi.python.org --trusted-host pypi.org --trusted-host files.pythonhosted.orgpip
+RUN python3.11 -m pip install --upgrade pip --trusted-host pypi.python.org --trusted-host pypi.org --trusted-host files.pythonhosted.orgpip
 RUN apt-get update && apt-get install -y redis-server
 RUN pip install git+https://github.com/policyengine/policyengine-api

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -3,4 +3,4 @@ gunicorn -b :$PORT policyengine_api.api --timeout 300 --workers 5 &
 # Start the redis server
 redis-server &
 # Start the worker
-ANTHROPIC_API_TOKEN=$ANTHROPIC_API_TOKEN python3.10 policyengine_api/worker.py
+python3 policyengine_api/worker.py


### PR DESCRIPTION
Fixes #1924

@tawandamoyo This re-enables Python 3.11 by removing the explicit call to run from Python 3.11, as the Docker dependencies that this runs off were previously installed using Python 3.10.