### PR TITLE
Add logging to worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/*
 **/*.h5
 **/*.csv.gz
 .env
+logs/*
 *.log
 
 # Ignore generated credentials from google-github-actions/auth

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/*
 **/*.h5
 **/*.csv.gz
 .env
+*.log
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: minor
+  changes:
+    added:
+    - Logging module called WorkerLogger to log microsim runs that use worker
+    - Basic informational logging for microsim runs
+    - Warning-level logging for NaN values present in calculated microsim variables

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -26,6 +26,7 @@ from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 from policyengine_api.utils.worker_logs import WorkerLogger
 from policyengine_api.utils.diagnostics import check_for_nans
 
+
 class PolicyEngineCountry:
     def __init__(self, country_package_name: str, country_id: str):
         self.country_package_name = country_package_name
@@ -320,7 +321,9 @@ class PolicyEngineCountry:
     ):
         logger = WorkerLogger()
 
-        logger.log(f"PolicyEngineCountry.calculate() called in {self.country_id} for household {household_id} with policy {policy_id}")
+        logger.log(
+            f"PolicyEngineCountry.calculate() called in {self.country_id} for household {household_id} with policy {policy_id}"
+        )
 
         if reform is not None and len(reform.keys()) > 0:
             system = self.tax_benefit_system.clone()
@@ -345,18 +348,24 @@ class PolicyEngineCountry:
         else:
             system = self.tax_benefit_system
 
-        logger.log(f"Tax-benefit system created and parameters updated in {self.country_id} for household {household_id} with policy {policy_id}")
+        logger.log(
+            f"Tax-benefit system created and parameters updated in {self.country_id} for household {household_id} with policy {policy_id}"
+        )
 
         simulation = self.country_package.Simulation(
             tax_benefit_system=system,
             situation=household,
         )
 
-        logger.log(f"Simulation created in {self.country_id} for household {household_id} with policy {policy_id}")
+        logger.log(
+            f"Simulation created in {self.country_id} for household {household_id} with policy {policy_id}"
+        )
 
         household = json.loads(json.dumps(household))
 
-        logger.log(f"Household created in {self.country_id} for household {household_id} with policy {policy_id}")
+        logger.log(
+            f"Household created in {self.country_id} for household {household_id} with policy {policy_id}"
+        )
 
         simulation.trace = True
         requested_computations = get_requested_computations(household)

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -318,6 +318,10 @@ class PolicyEngineCountry:
         household_id: Optional[int] = None,
         policy_id: Optional[int] = None,
     ):
+        logger = WorkerLogger()
+
+        logger.log(f"PolicyEngineCountry.calculate() called in {self.country_id} for household {household_id} with policy {policy_id}")
+
         if reform is not None and len(reform.keys()) > 0:
             system = self.tax_benefit_system.clone()
             for parameter_name in reform:
@@ -341,17 +345,21 @@ class PolicyEngineCountry:
         else:
             system = self.tax_benefit_system
 
+        logger.log(f"Tax-benefit system created and parameters updated in {self.country_id} for household {household_id} with policy {policy_id}")
+
         simulation = self.country_package.Simulation(
             tax_benefit_system=system,
             situation=household,
         )
 
+        logger.log(f"Simulation created in {self.country_id} for household {household_id} with policy {policy_id}")
+
         household = json.loads(json.dumps(household))
+
+        logger.log(f"Household created in {self.country_id} for household {household_id} with policy {policy_id}")
 
         simulation.trace = True
         requested_computations = get_requested_computations(household)
-
-        logger = WorkerLogger()
 
         for (
             entity_plural,

--- a/policyengine_api/endpoints/economy/economy.py
+++ b/policyengine_api/endpoints/economy/economy.py
@@ -94,7 +94,7 @@ def get_economic_impact(
         )
         for r in result
     ]
-    job_id = f"reform_impact_{country_id}_{policy_id}_{baseline_policy_id}_{region}_{time_period}_{options_hash}_{api_version}"
+    job_id = f"impact_{country_id}_{policy_id}_{baseline_policy_id}_{region}_{time_period}"
 
     if len(result) == 0:
         RECENT_JOBS[job_id] = dict(

--- a/policyengine_api/endpoints/economy/reform_impact.py
+++ b/policyengine_api/endpoints/economy/reform_impact.py
@@ -58,7 +58,7 @@ def set_reform_impact_data(
     reform_policy: dict,
 ):
     current_job = get_current_job()
-    logger = WorkerLogger(current_job)
+    logger = WorkerLogger(job_id=current_job.id)
     logger.log("Setting reform impact data")
 
     options_hash = json.dumps(options, sort_keys=True)
@@ -122,7 +122,7 @@ def set_reform_impact_data_routine(
         options (dict): Any additional options.
     """
     current_job = get_current_job()
-    logger = WorkerLogger(current_job)
+    logger = WorkerLogger(job_id=current_job.id)
     logger.log("Running set_reform_impact_data_routine")
     options_hash = json.dumps(options, sort_keys=True)
     baseline_policy_id = int(baseline_policy_id)

--- a/policyengine_api/endpoints/economy/reform_impact.py
+++ b/policyengine_api/endpoints/economy/reform_impact.py
@@ -13,6 +13,7 @@ from .single_economy import compute_economy
 from policyengine_api.utils import hash_object
 from datetime import datetime
 import traceback
+from policyengine_api.utils.worker_logs import WorkerLogger
 
 
 def ensure_economy_computed(

--- a/policyengine_api/endpoints/economy/reform_impact.py
+++ b/policyengine_api/endpoints/economy/reform_impact.py
@@ -79,9 +79,13 @@ def set_reform_impact_data(
         )
     except Exception as e:
         # Save the status as error and the message as the error message
-        logger.log(f"Exception raised in set_reform_impact_data: {e}", level="error")
+        logger.log(
+            f"Exception raised in set_reform_impact_data: {e}", level="error"
+        )
         logger.log(f"Traceback: {traceback.format_exc()}", level="error")
-        logger.log(f"Setting reform #{policy_id} impact data to error", level="error")
+        logger.log(
+            f"Setting reform #{policy_id} impact data to error", level="error"
+        )
         local_database.query(
             "UPDATE reform_impact SET status = ?, message = ?, end_time = ? WHERE country_id = ? AND reform_policy_id = ? AND baseline_policy_id = ? AND region = ? AND time_period = ? AND options_hash = ?",
             (

--- a/policyengine_api/endpoints/economy/reform_impact.py
+++ b/policyengine_api/endpoints/economy/reform_impact.py
@@ -233,6 +233,7 @@ def set_reform_impact_data_routine(
         baseline_economy = baseline_economy["result"]
         reform_economy = reform_economy["result"]
         comment("Comparing baseline and reform")
+        logger.log("Comparing baseline and reform")
         impact = compare_economic_outputs(
             baseline_economy, reform_economy, country_id=country_id
         )

--- a/policyengine_api/endpoints/economy/single_economy.py
+++ b/policyengine_api/endpoints/economy/single_economy.py
@@ -9,11 +9,13 @@ import time
 import os
 from rq import get_current_job
 from policyengine_api.utils.worker_logs import WorkerLogger
+import numpy as np
 
 
 def compute_general_economy(
     simulation: Microsimulation, country_id: str = None
 ) -> dict:
+    # Initialize logging
     current_job = get_current_job()
     worker_id = current_job.worker_name
     logger = WorkerLogger(job_id=current_job.id)
@@ -21,65 +23,118 @@ def compute_general_economy(
     logger.memory_monitor.start()
     logger.log("Computing general economy")
 
-    total_tax = simulation.calculate("household_tax").sum()
-    total_spending = simulation.calculate("household_benefits").sum()
+    # Calculate tax and spending based on country
+    total_tax = check_scalar_output(
+        logger, simulation.calculate("household_tax").sum(), "total_tax"
+    )
+    total_spending = check_scalar_output(
+        logger,
+        simulation.calculate("household_benefits").sum(),
+        "total_spending",
+    )
 
     if country_id == "uk":
-        total_tax = simulation.calculate("gov_tax").sum()
-        total_spending = simulation.calculate("gov_spending").sum()
+        total_tax = check_scalar_output(
+            logger, simulation.calculate("gov_tax").sum(), "uk_total_tax"
+        )
+        total_spending = check_scalar_output(
+            logger,
+            simulation.calculate("gov_spending").sum(),
+            "uk_total_spending",
+        )
+
+    # Calculate income and household metrics
     personal_hh_equiv_income = simulation.calculate(
         "equiv_household_net_income"
     )
     personal_hh_equiv_income[personal_hh_equiv_income < 0] = 0
     household_count_people = simulation.calculate("household_count_people")
     personal_hh_equiv_income.weights *= household_count_people
+
+    # Calculate inequality metrics
     try:
-        gini = personal_hh_equiv_income.gini()
+        gini = check_scalar_output(
+            logger, personal_hh_equiv_income.gini(), "gini"
+        )
     except:
-        print(
-            "WARNING: Gini index calculations resulted in an error: returning no change, but this is inaccurate."
+        logger.log(
+            "WARNING: Gini index calculations resulted in an error: returning default value",
+            level="warning",
         )
         gini = 0.4
+
+    # Calculate percentile metrics
     in_top_10_pct = personal_hh_equiv_income.decile_rank() == 10
     in_top_1_pct = personal_hh_equiv_income.percentile_rank() == 100
     personal_hh_equiv_income.weights /= household_count_people
-    top_10_percent_share = (
+
+    # Calculate income shares
+    top_10_percent_share = check_scalar_output(
+        logger,
         personal_hh_equiv_income[in_top_10_pct].sum()
-        / personal_hh_equiv_income.sum()
+        / personal_hh_equiv_income.sum(),
+        "top_10_percent_share",
     )
-    top_1_percent_share = (
+    top_1_percent_share = check_scalar_output(
+        logger,
         personal_hh_equiv_income[in_top_1_pct].sum()
-        / personal_hh_equiv_income.sum()
+        / personal_hh_equiv_income.sum(),
+        "top_1_percent_share",
     )
+
+    # Calculate optional metrics with safe fallbacks
+    def safe_calculate(calc_name, default=None, transform=None):
+        try:
+            value = simulation.calculate(calc_name)
+            if transform:
+                value = transform(value)
+            return value
+        except:
+            logger.log(
+                f"WARNING: {calc_name} calculation failed, using default value",
+                level="warning",
+            )
+            return default
+
+    # Wealth calculations
     try:
         wealth = simulation.calculate("total_wealth")
         wealth.weights *= household_count_people
         wealth_decile = wealth.decile_rank().clip(1, 10).astype(int).tolist()
         wealth = wealth.astype(float).tolist()
     except:
+        logger.log("WARNING: Wealth calculations failed", level="warning")
         wealth = None
         wealth_decile = None
-    try:
-        is_male = simulation.calculate("is_male").astype(bool).tolist()
-    except:
-        is_male = None
-    try:
-        race = simulation.calculate("race").astype(str).tolist()
-    except:
-        race = None
-    try:
-        total_state_tax = simulation.calculate(
-            "household_state_income_tax"
-        ).sum()
-    except Exception as e:
-        total_state_tax = 0
 
-    # Labour supply responses
-    substitution_lsr = 0
-    income_lsr = 0
-    budgetary_impact_lsr = 0
-    income_lsr_hh = (household_count_people * 0).astype(float).tolist()
-    substitution_lsr_hh = (household_count_people * 0).astype(float).tolist()
+    # Demographic calculations
+    is_male = safe_calculate(
+        "is_male", transform=lambda x: x.astype(bool).tolist()
+    )
+    race = safe_calculate("race", transform=lambda x: x.astype(str).tolist())
+
+    # Tax calculations
+    total_state_tax = check_scalar_output(
+        logger,
+        safe_calculate(
+            "household_state_income_tax",
+            default=0,
+            transform=lambda x: x.sum(),
+        ),
+        "total_state_tax",
+    )
+
+    # Labor supply response calculations
+    lsr_values = {
+        "substitution_lsr": 0,
+        "income_lsr": 0,
+        "budgetary_impact_lsr": 0,
+        "income_lsr_hh": (household_count_people * 0).astype(float).tolist(),
+        "substitution_lsr_hh": (household_count_people * 0)
+        .astype(float)
+        .tolist(),
+    }
+
     if (
         "employment_income_behavioral_response"
         in simulation.tax_benefit_system.variables
@@ -87,149 +142,333 @@ def compute_general_economy(
         if any(
             simulation.calculate("employment_income_behavioral_response") != 0
         ):
-            substitution_lsr = simulation.calculate(
-                "substitution_elasticity_lsr"
-            ).sum()
-            income_lsr = simulation.calculate("income_elasticity_lsr").sum()
-            lsr_branch = simulation.get_branch("lsr_measurement")
-            lsr_revenue = (
-                lsr_branch.calculate("household_net_income").sum()
-                - lsr_branch.calculate("household_market_income").sum()
-            )
-            baseline_revenue = (
-                simulation.calculate("household_net_income").sum()
-                - simulation.calculate("household_market_income").sum()
-            )
-            budgetary_impact_lsr = lsr_revenue - baseline_revenue
+            lsr_values.update(calculate_lsr_metrics(simulation, logger))
 
-            income_lsr_hh = (
-                simulation.calculate(
-                    "income_elasticity_lsr", map_to="household"
-                )
-                .astype(float)
-                .tolist()
-            )
-            substitution_lsr_hh = (
-                simulation.calculate(
-                    "substitution_elasticity_lsr", map_to="household"
-                )
-                .astype(float)
-                .tolist()
-            )
+    # Country-specific calculations
+    hours_metrics = calculate_hours_metrics(simulation, country_id, logger)
 
-    if country_id == "us":
-        weekly_hours = simulation.calculate("weekly_hours_worked").sum()
-        weekly_hours_income_effect = simulation.calculate(
-            "weekly_hours_worked_behavioural_response_income_elasticity"
-        ).sum()
-        weekly_hours_substitution_effect = simulation.calculate(
-            "weekly_hours_worked_behavioural_response_substitution_elasticity"
-        ).sum()
-    else:
-        weekly_hours = 0
-        weekly_hours_income_effect = 0
-        weekly_hours_substitution_effect = 0
+    # Construct result dictionary
+    result = construct_result_dict(
+        simulation,
+        total_tax,
+        total_state_tax,
+        total_spending,
+        gini,
+        top_10_percent_share,
+        top_1_percent_share,
+        wealth,
+        wealth_decile,
+        is_male,
+        race,
+        lsr_values,
+        hours_metrics,
+    )
 
-    result = {
-        "total_net_income": simulation.calculate("household_net_income").sum(),
-        "employment_income_hh": simulation.calculate(
+    # Add UK-specific program calculations
+    if country_id == "uk":
+        result["programs"] = calculate_uk_programs(simulation, logger)
+
+    logger.memory_monitor.stop()
+    logger.log("Finished computing general economy")
+    return result
+
+
+def calculate_lsr_metrics(simulation, logger):
+    """Calculate labor supply response metrics"""
+    substitution_lsr = check_scalar_output(
+        logger,
+        simulation.calculate("substitution_elasticity_lsr").sum(),
+        "substitution_lsr",
+    )
+    income_lsr = check_scalar_output(
+        logger,
+        simulation.calculate("income_elasticity_lsr").sum(),
+        "income_lsr",
+    )
+
+    lsr_branch = simulation.get_branch("lsr_measurement")
+    lsr_revenue = (
+        lsr_branch.calculate("household_net_income").sum()
+        - lsr_branch.calculate("household_market_income").sum()
+    )
+    baseline_revenue = (
+        simulation.calculate("household_net_income").sum()
+        - simulation.calculate("household_market_income").sum()
+    )
+    budgetary_impact_lsr = check_scalar_output(
+        logger, lsr_revenue - baseline_revenue, "budgetary_impact_lsr"
+    )
+
+    return {
+        "substitution_lsr": float(substitution_lsr),
+        "income_lsr": float(income_lsr),
+        "budgetary_impact_lsr": float(budgetary_impact_lsr),
+        "income_lsr_hh": simulation.calculate(
+            "income_elasticity_lsr", map_to="household"
+        )
+        .astype(float)
+        .tolist(),
+        "substitution_lsr_hh": simulation.calculate(
+            "substitution_elasticity_lsr", map_to="household"
+        )
+        .astype(float)
+        .tolist(),
+    }
+
+
+def calculate_hours_metrics(simulation, country_id, logger):
+    """Calculate hours-related metrics based on country"""
+    if country_id != "us":
+        return {
+            "weekly_hours": 0,
+            "weekly_hours_income_effect": 0,
+            "weekly_hours_substitution_effect": 0,
+        }
+
+    return {
+        "weekly_hours": check_scalar_output(
+            logger,
+            simulation.calculate("weekly_hours_worked").sum(),
+            "weekly_hours",
+        ),
+        "weekly_hours_income_effect": check_scalar_output(
+            logger,
+            simulation.calculate(
+                "weekly_hours_worked_behavioural_response_income_elasticity"
+            ).sum(),
+            "weekly_hours_income_effect",
+        ),
+        "weekly_hours_substitution_effect": check_scalar_output(
+            logger,
+            simulation.calculate(
+                "weekly_hours_worked_behavioural_response_substitution_elasticity"
+            ).sum(),
+            "weekly_hours_substitution_effect",
+        ),
+    }
+
+
+def calculate_uk_programs(simulation, logger):
+    """Calculate UK-specific program values"""
+    PROGRAMS = [
+        "income_tax",
+        "national_insurance",
+        "vat",
+        "council_tax",
+        "fuel_duty",
+        "tax_credits",
+        "universal_credit",
+        "child_benefit",
+        "state_pension",
+        "pension_credit",
+        "ni_employer",
+    ]
+    IS_POSITIVE = [True] * 5 + [False] * 5 + [True]
+
+    programs = {}
+    for program in PROGRAMS:
+        value = check_scalar_output(
+            logger,
+            simulation.calculate(program, map_to="household").sum()
+            * (1 if IS_POSITIVE[PROGRAMS.index(program)] else -1),
+            f"uk_program_{program}",
+        )
+        programs[program] = value
+
+    return programs
+
+
+def check_scalar_output(logger, value, calc_name: str):
+    """
+    Check if a scalar output contains NaN or None values and log a warning if found.
+
+    Args:
+        logger: WorkerLogger instance
+        value: The value to check
+        calc_name: Name of the calculation being checked
+    """
+    if value is None:
+        logger.log(
+            f"WARNING: {calc_name} calculation resulted in None value",
+            level="warning",
+        )
+    elif np.isnan(value).any():
+        logger.log(
+            f"WARNING: {calc_name} calculation contains NaN values",
+            level="warning",
+        )
+    return value
+
+
+def safe_calculate_with_check(
+    simulation, logger, variable_name: str, map_to: str = None, transform=None
+):
+    """
+    Safely calculate a variable with NaN checking before and after transformation.
+
+    Args:
+        simulation: Microsimulation instance
+        logger: WorkerLogger instance
+        variable_name: Name of the variable to calculate
+        map_to: Optional mapping target (e.g., 'household', 'person')
+        transform: Optional transformation function to apply after calculation
+    """
+    # Calculate raw value
+    calc_args = {"variable_name": variable_name}
+    if map_to:
+        calc_args["map_to"] = map_to
+
+    raw_value = simulation.calculate(**calc_args)
+
+    # Check raw value
+    check_scalar_output(logger, raw_value, f"{variable_name}_raw")
+
+    # Apply transformation if provided
+    if transform:
+        try:
+            transformed_value = transform(raw_value)
+            # Check transformed value
+            return check_scalar_output(
+                logger, transformed_value, f"{variable_name}_transformed"
+            )
+        except Exception as e:
+            logger.log(
+                f"WARNING: Transform failed for {variable_name}: {str(e)}",
+                level="warning",
+            )
+            return raw_value
+
+    return raw_value
+
+
+def construct_result_dict(
+    simulation,
+    total_tax,
+    total_state_tax,
+    total_spending,
+    gini,
+    top_10_percent_share,
+    top_1_percent_share,
+    wealth,
+    wealth_decile,
+    is_male,
+    race,
+    lsr_values,
+    hours_metrics,
+):
+    """Construct the final result dictionary"""
+    logger = WorkerLogger(job_id=get_current_job().id)
+
+    return {
+        "total_net_income": safe_calculate_with_check(
+            simulation,
+            logger,
+            "household_net_income",
+            transform=lambda x: x.sum(),
+        ),
+        "employment_income_hh": safe_calculate_with_check(
+            simulation,
+            logger,
             "employment_income",
             map_to="household",
-        )
-        .astype(float)
-        .tolist(),
-        "self_employment_income_hh": simulation.calculate(
+            transform=lambda x: x.astype(float).tolist(),
+        ),
+        "self_employment_income_hh": safe_calculate_with_check(
+            simulation,
+            logger,
             "self_employment_income",
             map_to="household",
-        )
-        .astype(float)
-        .tolist(),
+            transform=lambda x: x.astype(float).tolist(),
+        ),
         "total_tax": total_tax,
         "total_state_tax": total_state_tax,
         "total_benefits": total_spending,
-        "household_net_income": simulation.calculate("household_net_income")
-        .astype(float)
-        .tolist(),
-        "equiv_household_net_income": simulation.calculate(
+        "household_net_income": safe_calculate_with_check(
+            simulation,
+            logger,
+            "household_net_income",
+            transform=lambda x: x.astype(float).tolist(),
+        ),
+        "equiv_household_net_income": safe_calculate_with_check(
+            simulation,
+            logger,
             "equiv_household_net_income",
-        )
-        .astype(float)
-        .tolist(),
-        "household_income_decile": simulation.calculate(
-            "household_income_decile"
-        )
-        .astype(int)
-        .tolist(),
-        "household_market_income": simulation.calculate(
-            "household_market_income"
-        )
-        .astype(float)
-        .tolist(),
+            transform=lambda x: x.astype(float).tolist(),
+        ),
+        "household_income_decile": safe_calculate_with_check(
+            simulation,
+            logger,
+            "household_income_decile",
+            transform=lambda x: x.astype(int).tolist(),
+        ),
+        "household_market_income": safe_calculate_with_check(
+            simulation,
+            logger,
+            "household_market_income",
+            transform=lambda x: x.astype(float).tolist(),
+        ),
         "household_wealth_decile": wealth_decile,
         "household_wealth": wealth,
-        "in_poverty": simulation.calculate("in_poverty").astype(bool).tolist(),
-        "person_in_poverty": simulation.calculate(
-            "in_poverty", map_to="person"
-        )
-        .astype(bool)
-        .tolist(),
-        "person_in_deep_poverty": simulation.calculate(
-            "in_deep_poverty", map_to="person"
-        )
-        .astype(bool)
-        .tolist(),
-        "poverty_gap": simulation.calculate("poverty_gap").sum(),
-        "deep_poverty_gap": simulation.calculate("deep_poverty_gap").sum(),
-        "person_weight": simulation.calculate("person_weight")
-        .astype(float)
-        .tolist(),
-        "age": simulation.calculate("age").astype(int).tolist(),
-        "household_weight": simulation.calculate("household_weight")
-        .astype(float)
-        .tolist(),
-        "household_count_people": simulation.calculate(
-            "household_count_people"
-        )
-        .astype(int)
-        .tolist(),
+        "in_poverty": safe_calculate_with_check(
+            simulation,
+            logger,
+            "in_poverty",
+            transform=lambda x: x.astype(bool).tolist(),
+        ),
+        "person_in_poverty": safe_calculate_with_check(
+            simulation,
+            logger,
+            "in_poverty",
+            map_to="person",
+            transform=lambda x: x.astype(bool).tolist(),
+        ),
+        "person_in_deep_poverty": safe_calculate_with_check(
+            simulation,
+            logger,
+            "in_deep_poverty",
+            map_to="person",
+            transform=lambda x: x.astype(bool).tolist(),
+        ),
+        "poverty_gap": safe_calculate_with_check(
+            simulation, logger, "poverty_gap", transform=lambda x: x.sum()
+        ),
+        "deep_poverty_gap": safe_calculate_with_check(
+            simulation, logger, "deep_poverty_gap", transform=lambda x: x.sum()
+        ),
+        "person_weight": safe_calculate_with_check(
+            simulation,
+            logger,
+            "person_weight",
+            transform=lambda x: x.astype(float).tolist(),
+        ),
+        "age": safe_calculate_with_check(
+            simulation,
+            logger,
+            "age",
+            transform=lambda x: x.astype(int).tolist(),
+        ),
+        "household_weight": safe_calculate_with_check(
+            simulation,
+            logger,
+            "household_weight",
+            transform=lambda x: x.astype(float).tolist(),
+        ),
+        "household_count_people": safe_calculate_with_check(
+            simulation,
+            logger,
+            "household_count_people",
+            transform=lambda x: x.astype(int).tolist(),
+        ),
         "gini": float(gini),
         "top_10_percent_share": float(top_10_percent_share),
         "top_1_percent_share": float(top_1_percent_share),
         "is_male": is_male,
         "race": race,
-        "substitution_lsr": float(substitution_lsr),
-        "income_lsr": float(income_lsr),
-        "budgetary_impact_lsr": float(budgetary_impact_lsr),
-        "income_lsr_hh": income_lsr_hh,
-        "substitution_lsr_hh": substitution_lsr_hh,
-        "weekly_hours": weekly_hours,
-        "weekly_hours_income_effect": weekly_hours_income_effect,
-        "weekly_hours_substitution_effect": weekly_hours_substitution_effect,
+        **lsr_values,
+        **hours_metrics,
         "type": "general",
         "programs": {},
     }
-    if country_id == "uk":
-        PROGRAMS = [
-            "income_tax",
-            "national_insurance",
-            "vat",
-            "council_tax",
-            "fuel_duty",
-            "tax_credits",
-            "universal_credit",
-            "child_benefit",
-            "state_pension",
-            "pension_credit",
-            "ni_employer",
-        ]
-        IS_POSITIVE = [True] * 5 + [False] * 5 + [True]
-        for program in PROGRAMS:
-            result["programs"][program] = simulation.calculate(
-                program, map_to="household"
-            ).sum() * (1 if IS_POSITIVE[PROGRAMS.index(program)] else -1)
-    logger.memory_monitor.stop()
-    logger.log("Finished computing general economy")
-    return result
 
 
 def compute_cliff_impact(

--- a/policyengine_api/endpoints/economy/single_economy.py
+++ b/policyengine_api/endpoints/economy/single_economy.py
@@ -15,7 +15,9 @@ def compute_general_economy(
     simulation: Microsimulation, country_id: str = None
 ) -> dict:
     current_job = get_current_job()
-    logger = WorkerLogger(current_job)
+    worker_id = current_job.worker_name
+    logger = WorkerLogger(job_id=current_job.id)
+    logger.log(f"Worker ID: {worker_id}")
     logger.memory_monitor.start()
     logger.log("Computing general economy")
 
@@ -255,7 +257,7 @@ def compute_economy(
 ):
     start = time.time()
     current_job = get_current_job()
-    logger = WorkerLogger(current_job)
+    logger = WorkerLogger(job_id=current_job.id)
     country = COUNTRIES.get(country_id)
     policy_data = json.loads(policy_json)
     if country_id == "us":

--- a/policyengine_api/utils/diagnostics.py
+++ b/policyengine_api/utils/diagnostics.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def check_for_nans(array: np.ndarray):
     """
     Check for NaNs in the array and log a warning if found

--- a/policyengine_api/utils/diagnostics.py
+++ b/policyengine_api/utils/diagnostics.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+def check_for_nans(array: np.ndarray):
+    """
+    Check for NaNs in the array and log a warning if found
+    """
+    return True if np.isnan(array).any() else False

--- a/policyengine_api/utils/worker_logs.py
+++ b/policyengine_api/utils/worker_logs.py
@@ -4,6 +4,7 @@ from rq import Worker, get_current_job
 from google.cloud import logging as cloud_logging
 from datetime import datetime
 
+
 class WorkerLogger:
     @staticmethod
     def get_worker_id():
@@ -21,7 +22,9 @@ class WorkerLogger:
 
         # Try to get from current worker
         try:
-            worker = Worker.find_by_key(Worker.worker_key_prefix + current_job.worker_name)
+            worker = Worker.find_by_key(
+                Worker.worker_key_prefix + current_job.worker_name
+            )
             if worker:
                 return worker.name
         except:
@@ -35,50 +38,55 @@ class WorkerLogger:
         Initialize logger with automatic worker ID detection if none provided
         """
         self.worker_id = worker_id or self.get_worker_id()
-        self.logger = logging.getLogger(f'worker_{self.worker_id}')
+        self.logger = logging.getLogger(f"worker_{self.worker_id}")
         self.logger.setLevel(logging.INFO)
-        
+
         # Prevent duplicate handlers
         if not self.logger.handlers:
             # File handler - logs to local file
-            file_handler = logging.FileHandler(f'logs/worker_{self.worker_id}.log')
+            file_handler = logging.FileHandler(
+                f"logs/worker_{self.worker_id}.log"
+            )
             file_handler.setFormatter(
-                logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                )
             )
             self.logger.addHandler(file_handler)
-            
+
             # Console handler
             console_handler = logging.StreamHandler(sys.stdout)
             console_handler.setFormatter(
-                logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+                logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+                )
             )
             self.logger.addHandler(console_handler)
-            
+
             # Google Cloud Logging handler
             if log_to_cloud:
                 cloud_client = cloud_logging.Client()
                 cloud_handler = cloud_logging.handlers.CloudLoggingHandler(
-                    cloud_client,
-                    name=f"worker_{self.worker_id}"
+                    cloud_client, name=f"worker_{self.worker_id}"
                 )
                 cloud_handler.setFormatter(
-                    logging.Formatter('%(levelname)s - %(message)s')
+                    logging.Formatter("%(levelname)s - %(message)s")
                 )
                 self.logger.addHandler(cloud_handler)
-    
-    def log(self, message, level='info', **context):
+
+    def log(self, message, level="info", **context):
         """
         Log a message with optional context data
         """
         # Add job ID to context if available
         current_job = get_current_job()
         if current_job:
-            context['job_id'] = current_job.id
-            
+            context["job_id"] = current_job.id
+
         # Format message with context if provided
         if context:
-            context_str = ' '.join(f'{k}={v}' for k, v in context.items())
-            message = f'{message} | {context_str}'
-            
+            context_str = " ".join(f"{k}={v}" for k, v in context.items())
+            message = f"{message} | {context_str}"
+
         log_func = getattr(self.logger, level.lower())
         log_func(message)

--- a/policyengine_api/utils/worker_logs.py
+++ b/policyengine_api/utils/worker_logs.py
@@ -1,0 +1,84 @@
+import logging
+import sys
+from rq import Worker, get_current_job
+from google.cloud import logging as cloud_logging
+from datetime import datetime
+
+class WorkerLogger:
+    @staticmethod
+    def get_worker_id():
+        """
+        Attempts to get the worker ID through various methods:
+        1. From current RQ job
+        2. From environment variable
+        3. From RQ worker name
+        4. Generates a default if none found
+        """
+        # Try to get from current job context
+        current_job = get_current_job()
+        if current_job and current_job.worker_name:
+            return current_job.worker_name
+
+        # Try to get from current worker
+        try:
+            worker = Worker.find_by_key(Worker.worker_key_prefix + current_job.worker_name)
+            if worker:
+                return worker.name
+        except:
+            pass
+
+        # Default to timestamp if no other ID found
+        return f'worker_{datetime.now().strftime("%Y%m%d_%H%M%S")}'
+
+    def __init__(self, worker_id=None, log_to_cloud=True):
+        """
+        Initialize logger with automatic worker ID detection if none provided
+        """
+        self.worker_id = worker_id or self.get_worker_id()
+        self.logger = logging.getLogger(f'worker_{self.worker_id}')
+        self.logger.setLevel(logging.INFO)
+        
+        # Prevent duplicate handlers
+        if not self.logger.handlers:
+            # File handler - logs to local file
+            file_handler = logging.FileHandler(f'logs/worker_{self.worker_id}.log')
+            file_handler.setFormatter(
+                logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            )
+            self.logger.addHandler(file_handler)
+            
+            # Console handler
+            console_handler = logging.StreamHandler(sys.stdout)
+            console_handler.setFormatter(
+                logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            )
+            self.logger.addHandler(console_handler)
+            
+            # Google Cloud Logging handler
+            if log_to_cloud:
+                cloud_client = cloud_logging.Client()
+                cloud_handler = cloud_logging.handlers.CloudLoggingHandler(
+                    cloud_client,
+                    name=f"worker_{self.worker_id}"
+                )
+                cloud_handler.setFormatter(
+                    logging.Formatter('%(levelname)s - %(message)s')
+                )
+                self.logger.addHandler(cloud_handler)
+    
+    def log(self, message, level='info', **context):
+        """
+        Log a message with optional context data
+        """
+        # Add job ID to context if available
+        current_job = get_current_job()
+        if current_job:
+            context['job_id'] = current_job.id
+            
+        # Format message with context if provided
+        if context:
+            context_str = ' '.join(f'{k}={v}' for k, v in context.items())
+            message = f'{message} | {context_str}'
+            
+        log_func = getattr(self.logger, level.lower())
+        log_func(message)

--- a/policyengine_api/worker.py
+++ b/policyengine_api/worker.py
@@ -1,5 +1,6 @@
 from redis import Redis
 from rq import Worker
+from datetime import datetime
 
 # Preload libraries
 import policyengine_uk
@@ -10,6 +11,10 @@ from policyengine_api.endpoints.economy.reform_impact import (
     set_reform_impact_data,
 )
 
+# Logger will append `worker_` to front for filename, hence we'll
+# define name as just the date and time
+worker_id = datetime.now().strftime('%Y%m%d_%H%M%S')
+
 # Provide the worker with the list of queues (str) to listen to.
-w = Worker(["default"], connection=Redis())
+w = Worker(["default"], connection=Redis(), name=worker_id)
 w.work()

--- a/policyengine_api/worker.py
+++ b/policyengine_api/worker.py
@@ -14,8 +14,8 @@ import os
 import sys
 
 # MacOS has a bug with forked processes and multiprocessing
-if sys.platform == 'darwin':
-    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
+if sys.platform == "darwin":
+    os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
 
 # Logger will append `worker_` to front for filename, hence we'll
 # define name as just the date and time

--- a/policyengine_api/worker.py
+++ b/policyengine_api/worker.py
@@ -13,7 +13,7 @@ from policyengine_api.endpoints.economy.reform_impact import (
 
 # Logger will append `worker_` to front for filename, hence we'll
 # define name as just the date and time
-worker_id = datetime.now().strftime('%Y%m%d_%H%M%S')
+worker_id = datetime.now().strftime("%Y%m%d_%H%M%S")
 
 # Provide the worker with the list of queues (str) to listen to.
 w = Worker(["default"], connection=Redis(), name=worker_id)

--- a/policyengine_api/worker.py
+++ b/policyengine_api/worker.py
@@ -10,6 +10,12 @@ import policyengine_ng
 from policyengine_api.endpoints.economy.reform_impact import (
     set_reform_impact_data,
 )
+import os
+import sys
+
+# MacOS has a bug with forked processes and multiprocessing
+if sys.platform == 'darwin':
+    os.environ['OBJC_DISABLE_INITIALIZE_FORK_SAFETY'] = 'YES'
 
 # Logger will append `worker_` to front for filename, hence we'll
 # define name as just the date and time


### PR DESCRIPTION
Fixes #1947. This code:
* Creates a new class, `WorkerLogger`, with a variety of methods related to logging, including one to push logs to GCP
* Creates a second class, `MemoryMonitor`, that opens a process on a new thread to monitor memory usage, logs usage stats, and logs a warning if system memory usage exceeds 75%
* Adds logging to worker runs, including accessing of worker and job IDs
* Refactors `compute_general_economy` to make it easier to embed a logger into its operations