### PR TITLE
Removed extra router for /simulations

### DIFF
--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -116,8 +116,6 @@ app.route("/<country_id>/user_profile", methods=["PUT"])(update_user_profile)
 
 app.route("/simulations", methods=["GET"])(get_simulations)
 
-app.route("/simulations", methods=["GET"])(get_simulations)
-
 app.route("/<country_id>/tracer-analysis", methods=["POST"])(
     execute_tracer_analysis
 )


### PR DESCRIPTION
The app.route declarations had two identical GET /simulations routes defined. This change simply removes the second one as unecessary.