### PR TITLE
Remove duplicate route for /simulations (#1952)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 **/__pycache__
 *.egg-info
 .pytest_cache

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - removed redundant route declaration for GET /simulation.

--- a/policyengine_api/api.py
+++ b/policyengine_api/api.py
@@ -116,8 +116,6 @@ app.route("/<country_id>/user_profile", methods=["PUT"])(update_user_profile)
 
 app.route("/simulations", methods=["GET"])(get_simulations)
 
-app.route("/simulations", methods=["GET"])(get_simulations)
-
 app.route("/<country_id>/tracer-analysis", methods=["POST"])(
     execute_tracer_analysis
 )


### PR DESCRIPTION
The flask app defines the same GET operation on /simulations twice. This change simply removes one of them.