### PR TITLE
Fix start.sh

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Modified GCP shell script to drop Bash-specific for loop

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -1,12 +1,11 @@
-#!/bin/bash
-
+#!/bin/sh
 # Environment variables
-export PORT=${PORT:-8080}
-export WORKER_COUNT=${WORKER_COUNT:-3}
-export REDIS_PORT=${REDIS_PORT:-6379}
+PORT="${PORT:-8080}"
+WORKER_COUNT="${WORKER_COUNT:-3}"
+REDIS_PORT="${REDIS_PORT:-6379}"
 
 # Start the API
-gunicorn -b :$PORT policyengine_api.api --timeout 300 --workers 5 &
+gunicorn -b :"$PORT" policyengine_api.api --timeout 300 --workers 5 &
 
 # Start Redis with configuration for multiple clients
 redis-server --protected-mode no \
@@ -16,13 +15,16 @@ redis-server --protected-mode no \
 # Wait for Redis to be ready
 sleep 2
 
-# Start multiple workers
-for (( i=1; i<=$WORKER_COUNT; i++ ))
+# Start multiple workers using POSIX-compliant loop
+i=1
+while [ $i -le "$WORKER_COUNT" ]
 do
     echo "Starting worker $i..."
     python3 policyengine_api/worker.py &
+    i=$((i + 1))
 done
 
 # Keep the script running and handle shutdown gracefully
-trap "pkill -P $$; exit 1" SIGINT SIGTERM
+trap "pkill -P $$; exit 1" INT TERM
+
 wait


### PR DESCRIPTION
Fixes #1963.
Ensures that `gcp/start.sh` works with standard shell utilities, instead of Bash-specific ones.