### PR TITLE
[Minor] Clean up unused imports & files

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    removed:
+      - unused imports for files in the 'policyengine_api/endpoints' diretory
+      - unused file 'policyengine_api/endpoints/analysis.py'
+      - unused copy of results list in 'policyengine_api/endpoints/policy.py'

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -16,6 +16,7 @@ from policyengine_core.model_api import Reform, Enum
 from policyengine_core.periods import instant
 import dpath
 import math
+
 # Note: The following policyengine_[xx] imports are probably redundant.
 # These modules are imported dynamically in the __init__ function below.
 import policyengine_uk
@@ -23,6 +24,7 @@ import policyengine_us
 import policyengine_canada
 import policyengine_ng
 import policyengine_il
+
 from policyengine_api.data import local_database
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -16,6 +16,13 @@ from policyengine_core.model_api import Reform, Enum
 from policyengine_core.periods import instant
 import dpath
 import math
+# Note: The following policyengine_[xx] imports are probably redundant.
+# These modules are imported dynamically in the __init__ function below.
+import policyengine_uk
+import policyengine_us
+import policyengine_canada
+import policyengine_ng
+import policyengine_il
 from policyengine_api.data import local_database
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -16,11 +16,6 @@ from policyengine_core.model_api import Reform, Enum
 from policyengine_core.periods import instant
 import dpath
 import math
-import policyengine_uk
-import policyengine_us
-import policyengine_canada
-import policyengine_ng
-import policyengine_il
 from policyengine_api.data import local_database
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -7,7 +7,6 @@ from flask import Response, request
 from policyengine_api.utils import hash_object
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 import sqlalchemy.exc
-from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 from policyengine_api.country import COUNTRIES
 import json
 import logging

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -1,6 +1,5 @@
 from policyengine_api.country import (
     COUNTRIES,
-    PolicyEngineCountry,
 )
 from policyengine_api.data import database, local_database
 import json
@@ -9,15 +8,9 @@ from policyengine_api.utils import hash_object
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 import sqlalchemy.exc
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
-from policyengine_core.parameters import get_parameter
-from policyengine_core.periods import instant
-from policyengine_core.enums import Enum
-from policyengine_api.country import PolicyEngineCountry, COUNTRIES
+from policyengine_api.country import COUNTRIES
 import json
-import dpath
-import math
 import logging
-import sys
 from datetime import date
 from policyengine_api.helpers import validate_country
 

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -1,4 +1,4 @@
-from policyengine_api.country import validate_country
+from policyengine_api.helpers import validate_country
 from policyengine_api.data import database
 from policyengine_api.utils import hash_object
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -1,14 +1,9 @@
-from policyengine_api.country import COUNTRIES
-from policyengine_api.helpers import validate_country
+from policyengine_api.country import validate_country
 from policyengine_api.data import database
 from policyengine_api.utils import hash_object
-from policyengine_api.constants import VERSION, COUNTRY_PACKAGE_VERSIONS
-from policyengine_core.reforms import Reform
-from policyengine_core.parameters import ParameterNode, Parameter
-from policyengine_core.periods import instant
+from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 import json
 from flask import Response, request
-import sqlalchemy.exc
 
 
 def get_policy(country_id: str, policy_id: int) -> dict:
@@ -233,7 +228,7 @@ def get_policy_search(country_id: str) -> dict:
             # Compare every label and hash to what's contained in processed_vals
             # If a label-hash set aren't already in processed_vals,
             # add them to new_results
-            for policy in results[:]:
+            for policy in results:
                 comparison_vals = policy["label"], policy["policy_hash"]
                 if comparison_vals not in processed_vals:
                     new_results.append(policy)

--- a/policyengine_api/endpoints/simulation_analysis.py
+++ b/policyengine_api/endpoints/simulation_analysis.py
@@ -1,9 +1,4 @@
-from policyengine_api.data import local_database
-from policyengine_api.utils import hash_object
 from flask import request, Response
-from rq import Queue
-from redis import Redis
-from typing import Optional
 from policyengine_api.utils.ai_analysis import (
     trigger_ai_analysis,
     get_existing_analysis,
@@ -12,8 +7,6 @@ from policyengine_api.ai_prompts import (
     generate_simulation_analysis_prompt,
     audience_descriptions,
 )
-
-queue = Queue(connection=Redis())
 
 
 def execute_simulation_analysis(country_id: str) -> Response:


### PR DESCRIPTION
## Overview ##
This PR contains some drive-by cleanup changes that should not impact functionality.

## Changes ##
- Removes unused imports from files in the `policyengine_api/endpoints` directory
- Removes empty file `policyengine_api/endpoints/analysis.py`
- Removes unused copy of results list in`policyengine_api/endpoints/policy.py`