### PR TITLE
Switch @validate_country to decorator

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Validate_country to decorator for validation on applicable functions

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     changed:
-    - Validate_country to decorator for validation on applicable functions
+    - validate_country to decorator for validation on applicable functions

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -82,6 +82,7 @@ def get_household_year(household):
     return household_year
 
 
+@validate_country
 def get_household(country_id: str, household_id: str) -> dict:
     """Get a household's input data with a given ID.
 
@@ -89,12 +90,8 @@ def get_household(country_id: str, household_id: str) -> dict:
         country_id (str): The country ID.
         household_id (str): The household ID.
     """
-    invalid_country = validate_country(country_id)
-    if invalid_country:
-        return invalid_country
 
     # Retrieve from the household table
-
     row = database.query(
         f"SELECT * FROM household WHERE id = ? AND country_id = ?",
         (household_id, country_id),
@@ -120,15 +117,13 @@ def get_household(country_id: str, household_id: str) -> dict:
         )
 
 
+@validate_country
 def post_household(country_id: str) -> dict:
     """Set a household's input data.
 
     Args:
         country_id (str): The country ID.
     """
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     payload = request.json
     label = payload.get("label")
@@ -169,16 +164,13 @@ def post_household(country_id: str) -> dict:
     )
 
 
+@validate_country
 def update_household(country_id: str, household_id: str) -> Response:
     """
     Update a household via UPDATE request
 
     Args: country_id (str): The country ID
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     # Fetch existing household first
     try:
@@ -258,6 +250,7 @@ def update_household(country_id: str, household_id: str) -> Response:
     )
 
 
+@validate_country
 def get_household_under_policy(
     country_id: str, household_id: str, policy_id: str
 ):
@@ -268,9 +261,6 @@ def get_household_under_policy(
         household_id (str): The household ID.
         policy_id (str): The policy ID.
     """
-    invalid_country = validate_country(country_id)
-    if invalid_country:
-        return invalid_country
 
     api_version = COUNTRY_PACKAGE_VERSIONS.get(country_id)
 
@@ -393,16 +383,13 @@ def get_household_under_policy(
     )
 
 
+@validate_country
 def get_calculate(country_id: str, add_missing: bool = False) -> dict:
     """Lightweight endpoint for passing in household and policy JSON objects and calculating without storing data.
 
     Args:
         country_id (str): The country ID.
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     payload = request.json
     household_json = payload.get("household", {})

--- a/policyengine_api/endpoints/metadata.py
+++ b/policyengine_api/endpoints/metadata.py
@@ -2,14 +2,11 @@ from policyengine_api.helpers import validate_country
 from policyengine_api.country import COUNTRIES
 
 
+@validate_country
 def get_metadata(country_id: str) -> dict:
     """Get metadata for a country.
 
     Args:
         country_id (str): The country ID.
     """
-    invalid_country = validate_country(country_id)
-    if invalid_country:
-        return invalid_country
-
     return COUNTRIES.get(country_id).metadata

--- a/policyengine_api/endpoints/policy.py
+++ b/policyengine_api/endpoints/policy.py
@@ -11,6 +11,7 @@ from flask import Response, request
 import sqlalchemy.exc
 
 
+@validate_country
 def get_policy(country_id: str, policy_id: int) -> dict:
     """
     Get policy data for a given country and policy ID.
@@ -22,9 +23,7 @@ def get_policy(country_id: str, policy_id: int) -> dict:
     Returns:
         dict: The policy record.
     """
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
+
     # Get the policy record for a given policy ID.
     row = database.query(
         f"SELECT * FROM policy WHERE country_id = ? AND id = ?",
@@ -49,6 +48,7 @@ def get_policy(country_id: str, policy_id: int) -> dict:
     )
 
 
+@validate_country
 def set_policy(
     country_id: str,
 ) -> dict:
@@ -60,9 +60,6 @@ def set_policy(
     Args:
         country_id (str): The country ID.
     """
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     payload = request.json
     label = payload.pop("label", None)
@@ -177,6 +174,7 @@ def set_policy(
     )
 
 
+@validate_country
 def get_policy_search(country_id: str) -> dict:
     """
     Search for policies for a specified country
@@ -196,16 +194,13 @@ def get_policy_search(country_id: str) -> dict:
     Example:
         GET /api/policies/us?query=tax&unique_only=true
     """
+
     query = request.args.get("query", "")
     # The "json.loads" default type is added to convert lowercase
     # "true" and "false" to Python-friendly bool values
     unique_only = request.args.get(
         "unique_only", default=False, type=json.loads
     )
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     try:
         results = database.query(
@@ -261,6 +256,7 @@ def get_policy_search(country_id: str) -> dict:
         )
 
 
+@validate_country
 def set_user_policy(country_id: str) -> dict:
     """
     Adds a record (if unique, barring type) to the user_policy table
@@ -268,10 +264,6 @@ def set_user_policy(country_id: str) -> dict:
     policies"; this table also contains an optional "type" column that
     is currently unused
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     payload = request.json
     reform_label = payload.pop("reform_label", None)
@@ -428,14 +420,12 @@ def set_user_policy(country_id: str) -> dict:
     )
 
 
+@validate_country
 def get_user_policy(country_id: str, user_id: str) -> dict:
     """
     Fetch all saved user policies by user id
     """
 
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
     # Get the policy record for a given policy ID.
     rows = database.query(
         f"SELECT * FROM user_policies WHERE country_id = ? AND user_id = ?",
@@ -480,14 +470,11 @@ def get_user_policy(country_id: str, user_id: str) -> dict:
     )
 
 
+@validate_country
 def update_user_policy(country_id: str) -> dict:
     """
     Update any parts of a user_policy, given a user_policy ID
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     # Construct the relevant UPDATE request
     setter_array = []

--- a/policyengine_api/endpoints/tracer_analysis.py
+++ b/policyengine_api/endpoints/tracer_analysis.py
@@ -20,6 +20,7 @@ from typing import Generator
 # TODO: Add the prompt in a new variable; this could even be duplicated from the Streamlit
 
 
+@validate_country
 def execute_tracer_analysis(
     country_id: str,
 ):
@@ -28,10 +29,6 @@ def execute_tracer_analysis(
     Args:
         country_id (str): The country ID.
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     payload = request.json
 

--- a/policyengine_api/endpoints/user_profile.py
+++ b/policyengine_api/endpoints/user_profile.py
@@ -4,13 +4,11 @@ from policyengine_api.data import database
 import json
 
 
+@validate_country
 def set_user_profile(country_id: str) -> dict:
     """
     Creates a new user_profile
     """
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     payload = request.json
     primary_country = country_id
@@ -86,16 +84,13 @@ def set_user_profile(country_id: str) -> dict:
     )
 
 
+@validate_country
 def get_user_profile(country_id: str) -> dict:
     """
     Get a user profile in one of two ways: by auth0_id,
     which returns all data, and by user_id, which returns
     all data except auth0_id
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     if len(request.args) != 1:
         return Response(
@@ -175,16 +170,13 @@ def get_user_profile(country_id: str) -> dict:
     )
 
 
+@validate_country
 def update_user_profile(country_id: str) -> dict:
     """
     Update any part of a user_profile, given a user_id,
     except the auth0_id value; any attempt to edit this
     will assume malicious intent and 403
     """
-
-    country_not_found = validate_country(country_id)
-    if country_not_found:
-        return country_not_found
 
     # Construct the relevant UPDATE request
     setter_array = []

--- a/policyengine_api/helpers/validate_country.py
+++ b/policyengine_api/helpers/validate_country.py
@@ -1,22 +1,30 @@
+from functools import wraps
 from typing import Union
 from flask import Response
 import json
 from policyengine_api.constants import COUNTRIES
 
 
-def validate_country(country_id: str) -> Union[None, Response]:
+def validate_country(func):
     """Validate that a country ID is valid. If not, return a 404 response.
 
     Args:
         country_id (str): The country ID to validate.
 
     Returns:
-
+        Response(404) if country is not valid, else continues
     """
-    if country_id not in COUNTRIES:
-        body = dict(
-            status="error",
-            message=f"Country {country_id} not found. Available countries are: {', '.join(COUNTRIES)}",
-        )
-        return Response(json.dumps(body), status=404)
-    return None
+
+    @wraps(func)
+    def validate_country_wrapper(
+        country_id: str, *args, **kwargs
+    ) -> Union[None, Response]:
+        if country_id not in COUNTRIES:
+            body = dict(
+                status="error",
+                message=f"Country {country_id} not found. Available countries are: {', '.join(COUNTRIES.keys())}",
+            )
+            return Response(json.dumps(body), status=404)
+        return func(country_id, *args, **kwargs)
+
+    return validate_country_wrapper

--- a/policyengine_api/helpers/validate_country.py
+++ b/policyengine_api/helpers/validate_country.py
@@ -22,7 +22,7 @@ def validate_country(func):
         if country_id not in COUNTRIES:
             body = dict(
                 status="error",
-                message=f"Country {country_id} not found. Available countries are: {', '.join(COUNTRIES.keys())}",
+                message=f"Country {country_id} not found. Available countries are: {', '.join(COUNTRIES)}",
             )
             return Response(json.dumps(body), status=404)
         return func(country_id, *args, **kwargs)

--- a/policyengine_api/routes/economy_routes.py
+++ b/policyengine_api/routes/economy_routes.py
@@ -12,14 +12,9 @@ economy_bp = Blueprint("economy", __name__)
 economy_service = EconomyService()
 
 
+@validate_country
 @economy_bp.route("/<policy_id>/over/<baseline_policy_id>", methods=["GET"])
 def get_economic_impact(country_id, policy_id, baseline_policy_id):
-
-    print(f"Got request for {country_id} {policy_id} {baseline_policy_id}")
-    # Validate inbound data
-    invalid_country = validate_country(country_id)
-    if invalid_country:
-        return invalid_country
 
     policy_id = int(policy_id or get_current_law_policy_id(country_id))
     baseline_policy_id = int(

--- a/tests/python/test_country.py
+++ b/tests/python/test_country.py
@@ -1,0 +1,27 @@
+from flask import Response
+from policyengine_api.country import validate_country
+
+
+@validate_country
+def foo(country_id, other):
+    """
+    A simple dummy test method for validation testing. Must be defined outside of the class (or within
+    the test functions themselves) due to complications with the `self` parameter for class methods.
+    """
+    return "bar"
+
+
+class TestValidateCountry:
+    """
+    Test that the @validate_country decorator returns 404 if the country does not exist, otherwise
+    continues execution of the function.
+    """
+
+    def test_valid_country(self):
+        result = foo("us", "extra_arg")
+        assert result == "bar"
+
+    def test_invalid_country(self):
+        result = foo("baz", "extra_arg")
+        assert isinstance(result, Response)
+        assert result.status_code == 404

--- a/tests/python/test_policy.py
+++ b/tests/python/test_policy.py
@@ -44,6 +44,10 @@ class TestPolicyCreation:
             (self.policy_hash, self.label, self.country_id),
         )
 
+    def test_create_policy_invalid_country(self, rest_client):
+        res = rest_client.post("/au/policy", json=self.test_policy)
+        assert res.status_code == 404
+
 
 class TestPolicySearch:
     country_id = "us"

--- a/tests/python/test_validate_country.py
+++ b/tests/python/test_validate_country.py
@@ -1,5 +1,5 @@
 from flask import Response
-from policyengine_api.country import validate_country
+from policyengine_api.helpers import validate_country
 
 
 @validate_country


### PR DESCRIPTION
### Overview ###
Currently, there is a repeated check and short-circuit in many functions to validate existence of the given country ID. This PR refactors `validate_country` as a decorator to DRY the code. We may consider transitioning this to a `before_request` hook to further reduce code repetition.

This is essentially a refactor. There should be no functional change.

### Changes ###
- Update `validate_country` to change it into a decorator/wrapper
- Replace instances of `validate_country()` check & short circuit -> `@validate_country` decorator
- Add unit tests for the `validate_country` function
- Add a sanity test in `test_policy.py` to ensure that the decorator functionality works