### PR TITLE
Remove improperly netsted metadata JSON

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Refactored metadata endpoint to remove improperly nested result JSON

--- a/policyengine_api/routes/metadata_routes.py
+++ b/policyengine_api/routes/metadata_routes.py
@@ -16,16 +16,4 @@ def get_metadata(country_id: str) -> Response:
     Args:
         country_id (str): The country ID.
     """
-    metadata = metadata_service.get_metadata(country_id)
-
-    return Response(
-        json.dumps(
-            {
-                "status": "ok",
-                "message": None,
-                "result": metadata,
-            }
-        ),
-        status=200,
-        mimetype="application/json",
-    )
+    return metadata_service.get_metadata(country_id)


### PR DESCRIPTION
Fixes #PolicyEngine/issues#30

This issue was created by an improper assumption in #2038 whereby the metadata endpoint was improperly documented, and changes based upon the typing documentation created a doubly nested output that does not fit our intended schema. This reverts that, and a future issue will be opened to properly configure this so that the metadata route and service are configured as expected.