### PR TITLE
Removed seed method from PolicyEngineDatabase class

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    removed:
+      - seed method from PolicyEngineDatabase class

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -37,8 +37,6 @@ class PolicyEngineDatabase:
             if initialize:
                 self.initialize()
 
-        self.seed()
-
     def _create_pool(self):
         instance_connection_name = (
             "policyengine-api:us-central1:policyengine-api-data"
@@ -100,31 +98,6 @@ class PolicyEngineDatabase:
                     return self.pool.execute(*query)
                 except Exception as e:
                     raise e
-
-    def seed(self):
-        """
-        Pre-seed the database with records in the relevant folder
-        """
-
-        folder = REPO / "policyengine_api" / "data" / "seed"
-
-        # Recursively loop through all SQL scripts in folder
-        for dirpath, dirnames, filenames in os.walk(folder):
-            for filename in filenames:
-                full_filepath = os.path.join(dirpath, filename)
-                with open(full_filepath, "r") as file:
-                    try:
-                        full_query = file.read()
-                        queries = full_query.split(";")
-                        for query in queries:
-                            self.query(query)
-
-                    except Exception as e:
-                        continue
-                        print(
-                            f"Error while seeding database with record {filename}: {e}",
-                            file=sys.stdout,
-                        )
 
     def initialize(self):
         """


### PR DESCRIPTION
Fixes #1362 

* What: Removed the definition for _seed_ method from _PolicyEngineDatabase_ class as well as any calls to the method from within the class.

* Why:  Test code that is no longer required.