### PR TITLE
Temporarily patch issues with decile outputs in state-level ECPS runs

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Temporarily patched errors in state-level ECPS decile data

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -345,12 +345,22 @@ def intra_decile_impact(baseline: dict, reform: dict) -> dict:
     for lower, upper, label in zip(BOUNDS[:-1], BOUNDS[1:], LABELS):
         outcome_groups[label] = []
         for i in range(1, 11):
-            in_decile = decile == i
-            in_group = (income_change > lower) & (income_change <= upper)
-            in_both = in_decile & in_group
-            outcome_groups[label].append(
-                float(people[in_both].sum() / people[in_decile].sum())
-            )
+            
+            in_decile: bool = decile == i
+            in_group: bool = (income_change > lower) & (income_change <= upper)
+            in_both: bool = in_decile & in_group
+
+            people_in_both: np.float64 = people[in_both].sum()
+            people_in_decile: np.float64 = people[in_decile].sum()
+
+            # np.float64 does not raise ZeroDivisionError, instead returns NaN
+            if people_in_decile == 0 and people_in_both == 0:
+                people_in_proportion: float = 0.0
+            else:
+                people_in_proportion: float = float(people_in_both / people_in_decile)
+            
+            outcome_groups[label].append(people_in_proportion)
+
         all_outcomes[label] = sum(outcome_groups[label]) / 10
     return dict(deciles=outcome_groups, all=all_outcomes)
 
@@ -395,12 +405,22 @@ def intra_wealth_decile_impact(baseline: dict, reform: dict) -> dict:
     for lower, upper, label in zip(BOUNDS[:-1], BOUNDS[1:], LABELS):
         outcome_groups[label] = []
         for i in range(1, 11):
-            in_decile = decile == i
-            in_group = (income_change > lower) & (income_change <= upper)
-            in_both = in_decile & in_group
-            outcome_groups[label].append(
-                float(people[in_both].sum() / people[in_decile].sum())
-            )
+            
+            in_decile: bool = decile == i
+            in_group: bool = (income_change > lower) & (income_change <= upper)
+            in_both: bool = in_decile & in_group
+
+            people_in_both: np.float64 = people[in_both].sum()
+            people_in_decile: np.float64 = people[in_decile].sum()
+
+            # np.float64 does not raise ZeroDivisionError, instead returns NaN
+            if people_in_decile == 0 and people_in_both == 0:
+                people_in_proportion = 0
+            else:
+                people_in_proportion: float = float(people_in_both / people_in_decile)
+            
+            outcome_groups[label].append(people_in_proportion)
+
         all_outcomes[label] = sum(outcome_groups[label]) / 10
     return dict(deciles=outcome_groups, all=all_outcomes)
 

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -345,7 +345,7 @@ def intra_decile_impact(baseline: dict, reform: dict) -> dict:
     for lower, upper, label in zip(BOUNDS[:-1], BOUNDS[1:], LABELS):
         outcome_groups[label] = []
         for i in range(1, 11):
-            
+
             in_decile: bool = decile == i
             in_group: bool = (income_change > lower) & (income_change <= upper)
             in_both: bool = in_decile & in_group
@@ -357,8 +357,10 @@ def intra_decile_impact(baseline: dict, reform: dict) -> dict:
             if people_in_decile == 0 and people_in_both == 0:
                 people_in_proportion: float = 0.0
             else:
-                people_in_proportion: float = float(people_in_both / people_in_decile)
-            
+                people_in_proportion: float = float(
+                    people_in_both / people_in_decile
+                )
+
             outcome_groups[label].append(people_in_proportion)
 
         all_outcomes[label] = sum(outcome_groups[label]) / 10
@@ -405,7 +407,7 @@ def intra_wealth_decile_impact(baseline: dict, reform: dict) -> dict:
     for lower, upper, label in zip(BOUNDS[:-1], BOUNDS[1:], LABELS):
         outcome_groups[label] = []
         for i in range(1, 11):
-            
+
             in_decile: bool = decile == i
             in_group: bool = (income_change > lower) & (income_change <= upper)
             in_both: bool = in_decile & in_group
@@ -417,8 +419,10 @@ def intra_wealth_decile_impact(baseline: dict, reform: dict) -> dict:
             if people_in_decile == 0 and people_in_both == 0:
                 people_in_proportion = 0
             else:
-                people_in_proportion: float = float(people_in_both / people_in_decile)
-            
+                people_in_proportion: float = float(
+                    people_in_both / people_in_decile
+                )
+
             outcome_groups[label].append(people_in_proportion)
 
         all_outcomes[label] = sum(outcome_groups[label]) / 10


### PR DESCRIPTION
Fixes #2167.

In the code for the "Winners and losers" chart, in situations where the number of individuals in a decile is 0 (due to a potential bug in `microdf`), this code calculates the number of people within a given affect group (e.g., "Gain by more than 5%") as 0. This does create minor visual disparities on the front end, but allows the baseline and reform comparison code to complete properly, enabling use of the tool outside of the decile impacts.

The below video demonstrates these visual issues with a local reproduction of the DC-based policy listed in #2164.

[AwesomeScreenshot-2_13_2025,12_11_36AM.webm](https://github.com/user-attachments/assets/1fdbc51a-01d4-4202-b399-5017ad28cc5b)
