### PR TITLE
Enable simulation impacts for US

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Allowed for None values in UK constituency impact outputs

--- a/policyengine_api/ai_prompts/simulation_analysis_prompt.py
+++ b/policyengine_api/ai_prompts/simulation_analysis_prompt.py
@@ -13,7 +13,7 @@ class InboundParameters(BaseModel):
     dataset: str | None
     selected_version: str
     time_period: str
-    impact: dict[str, dict[str, Any]]
+    impact: dict[str, dict[str, Any] | None]
     policy_label: str
     policy: dict[str, Any]
     region: str

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -5,7 +5,7 @@ from policyengine_core.tools.hugging_face import download_huggingface_dataset
 import pandas as pd
 import h5py
 from pydantic import BaseModel
-from typing import Dict
+from typing import Any
 
 
 def budgetary_impact(baseline: dict, reform: dict) -> dict:
@@ -544,8 +544,8 @@ class UKConstituencyBreakdownByConstituency(BaseModel):
 
 
 class UKConstituencyBreakdown(BaseModel):
-    by_constituency: Dict[str, UKConstituencyBreakdownByConstituency]
-    outcomes_by_region: Dict[str, Dict[str, int]]
+    by_constituency: dict[str, UKConstituencyBreakdownByConstituency]
+    outcomes_by_region: dict[str, dict[str, int]]
 
 
 def uk_constituency_breakdown(
@@ -657,8 +657,8 @@ def compare_economic_outputs(
         poverty_by_race_data = poverty_racial_breakdown(baseline, reform)
         intra_decile_impact_data = intra_decile_impact(baseline, reform)
         labor_supply_response_data = labor_supply_response(baseline, reform)
-        constituency_impact_data = uk_constituency_breakdown(
-            baseline, reform, country_id
+        constituency_impact_data: UKConstituencyBreakdown | None = (
+            uk_constituency_breakdown(baseline, reform, country_id)
         )
         if constituency_impact_data is not None:
             constituency_impact_data = constituency_impact_data.model_dump()


### PR DESCRIPTION
Fixes #2213 

In the interest of time, this PR does as little as necessary to fix this output. An improvement would be to fix #2214, which this PR does not do in favor of fixing it within API v2.

This PR allows for the UK constituency breakdown segment of a baseline-reform pair's economic impacts analysis to be `None`, which would be the case for the US.

Here's a video of the changes with a locally running version of the app on top:
[AwesomeScreenshot-2_25_2025,8_09_22PM.webm](https://github.com/user-attachments/assets/3db44614-d22c-49a2-8e32-d1405fd44f3b)
