### PR TITLE
Use new public Hugging Face model

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Altered UK constituency data addresses to use new public Hugging Face model

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -67,7 +67,7 @@ class PolicyEngineCountry:
         options = dict()
         if self.country_id == "uk":
             constituency_names_path = download_huggingface_dataset(
-                repo="policyengine/policyengine-uk-data",
+                repo="policyengine/policyengine-uk-data-public",
                 repo_filename="constituencies_2024.csv",
             )
             constituency_names = pd.read_csv(constituency_names_path)

--- a/policyengine_api/endpoints/economy/compare.py
+++ b/policyengine_api/endpoints/economy/compare.py
@@ -570,7 +570,7 @@ def uk_constituency_breakdown(
     reform_hnet = reform["household_net_income"]
 
     constituency_weights_path = download_huggingface_dataset(
-        repo="policyengine/policyengine-uk-data",
+        repo="policyengine/policyengine-uk-data-public",
         repo_filename="parliamentary_constituency_weights.h5",
     )
     with h5py.File(constituency_weights_path, "r") as f:
@@ -579,7 +579,7 @@ def uk_constituency_breakdown(
         ]  # {2025: array(650, 100180) where cell i, j is the weight of household record i in constituency j}
 
     constituency_names_path = download_huggingface_dataset(
-        repo="policyengine/policyengine-uk-data",
+        repo="policyengine/policyengine-uk-data-public",
         repo_filename="constituencies_2024.csv",
     )
     constituency_names = pd.read_csv(

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -270,11 +270,11 @@ class CalculateEconomySimulationJob(BaseJob):
         simulation.default_calculation_period = time_period
         if region != "uk":
             constituency_weights_path = download_huggingface_dataset(
-                repo="policyengine/policyengine-uk-data",
+                repo="policyengine/policyengine-uk-data-public",
                 repo_filename="parliamentary_constituency_weights.h5",
             )
             constituency_names_path = download_huggingface_dataset(
-                repo="policyengine/policyengine-uk-data",
+                repo="policyengine/policyengine-uk-data-public",
                 repo_filename="constituencies_2024.csv",
             )
             constituency_names = pd.read_csv(constituency_names_path)

--- a/tests/unit/fixtures/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/fixtures/jobs/test_calculate_economy_simulation_job.py
@@ -18,7 +18,7 @@ def mock_huggingface_downloads(monkeypatch):
         return repo_filename
 
     monkeypatch.setattr(
-        "policyengine_api.jobs.calculate_economy_simulation_job.download_huggingface_dataset",
+        "policyengine_api.jobs.calculate_economy_simulation_job.download_huggingface_dataset-public",
         mock_download,
     )
 

--- a/tests/unit/fixtures/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/fixtures/jobs/test_calculate_economy_simulation_job.py
@@ -18,7 +18,7 @@ def mock_huggingface_downloads(monkeypatch):
         return repo_filename
 
     monkeypatch.setattr(
-        "policyengine_api.jobs.calculate_economy_simulation_job.download_huggingface_dataset-public",
+        "policyengine_api.jobs.calculate_economy_simulation_job.download_huggingface_dataset",
         mock_download,
     )
 


### PR DESCRIPTION
Fixes #2210

This cannot be merged until `parliamentary_constituency_weights.h5` is successfully uploaded to the `policyengine/policyengine-uk-data-public` model on Hugging Face; it will remain in draft until that is complete.

For basic, public-access data files, this PR uses a new publicly available Hugging Face model to enable users to still run the package and run tests. 