### PR TITLE
Fix tracer parsing function to properly handle variables

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
-    changed:    
+    fixed:
     - Fixed tracer parsing function. It was not properly handle variable whose names are substrings of other variables.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
-    fixed:
+    changed:
     - Fixed tracer parsing function. It was not properly handle variable whose names are substrings of other variables.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:    
+    - Fixed tracer parsing function. It was not properly handle variable whose names are substrings of other variables.

--- a/policyengine_api/services/tracer_analysis_service.py
+++ b/policyengine_api/services/tracer_analysis_service.py
@@ -112,7 +112,10 @@ class TracerAnalysisService(AIAnalysisService):
         # Create a regex pattern to match the exact variable name
         # This will match the variable name followed by optional whitespace,
         # then optional angle brackets with any content, then optional whitespace
-        pattern = rf"^(\s*)({re.escape(target_variable)})\s*(?:<[^>]*>)?\s*"
+
+        pattern = (
+            rf"^(\s*)({re.escape(target_variable)})(?!\w)\s*(?:<[^>]*>)?\s*"
+        )
 
         for line in tracer_output:
             # Count leading spaces to determine indentation level

--- a/tests/fixtures/services/tracer_analysis_service.py
+++ b/tests/fixtures/services/tracer_analysis_service.py
@@ -21,4 +21,8 @@ spliced_valid_tracer_output_nested_variable = valid_tracer_output[2:3]
 
 spliced_valid_tracer_output_leaf_variable = valid_tracer_output[8:]
 
+spliced_valid_tracer_output_for_variable_that_is_substring_of_another = (
+    valid_tracer_output[7:8]
+)
+
 empty_tracer = []

--- a/tests/unit/services/test_tracer_analysis_service.py
+++ b/tests/unit/services/test_tracer_analysis_service.py
@@ -130,3 +130,21 @@ def test_tracer_output_for_leaf_variable():
     # Then: It should return only leaf variable since it has no children
     expected_output = spliced_valid_tracer_output_leaf_variable
     assert result == expected_output
+
+
+def test_tracer_output_for_variable_that_is_substring_of_another():
+    # Given: A tracer output with variables where one is a substring of another
+    # and the target variable that's a substring of another variable
+    target_variable = "snap_net_income"
+
+    # When: Extracting the segment for this variable
+    result = test_service._parse_tracer_output(
+        valid_tracer_output, target_variable
+    )
+
+    # Then: It should return only the exact match for "snap_net_income", not "snap_net_income_fpg_ratio"
+
+    expected_output = (
+        spliced_valid_tracer_output_for_variable_that_is_substring_of_another
+    )
+    assert result == expected_output


### PR DESCRIPTION
fixes #2304  
Fix tracer parsing function to properly handle variables whose names are substrings of other variables