### PR TITLE
Increase App Engine timeout from 400s to 1000s

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Deployment readiness check timeout to 1000s.

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -21,4 +21,4 @@ runtime_config:
   runtime_version: "22"
 readiness_check:
   path: "/readiness_check"
-  app_start_timeout_sec: 400
+  app_start_timeout_sec: 1000


### PR DESCRIPTION
## Summary
* Increase App Engine timeout in app.yaml from 400s to 1000s to fix failing deployments

## Test plan
* Verify that deployments complete successfully with the increased timeout

Fixes #2324

🤖 Generated with [Claude Code](https://claude.ai/code)