### PR TITLE
Correct readiness check path, lower timeout back to 400s

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    changed:
+    - Corrected readiness check path in app.yaml
+    - Lowered readiness check timeout threshold

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -20,5 +20,5 @@ runtime_config:
   operating_system: "ubuntu22"
   runtime_version: "22"
 readiness_check:
-  path: "/readiness_check"
-  app_start_timeout_sec: 1000
+  path: "/readiness-check"
+  app_start_timeout_sec: 400


### PR DESCRIPTION
Fixes #2327 
Fixes #2328 

Corrects the path used by Google during deployment to ping readiness checks and lowers the failure timeout for said checks back to 400s