### PR TITLE
Extend Google Cloud build timeout to 40 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ format:
 
 deploy:
 	python gcp/export.py
-	gcloud config set app/cloud_build_timeout 1800
+	gcloud config set app/cloud_build_timeout 2400
 	cp gcp/policyengine_api/* .
 	y | gcloud app deploy --service-account=github-deployment@policyengine-api.iam.gserviceaccount.com
 	rm app.yaml

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Extended Google Cloud build timeout to 40 minutes


### PR DESCRIPTION
Fixes #2370

Extends Google Cloud build timeout to 40 minutes