### PR TITLE
Prevent concurrent deploys.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,9 @@ on:
 env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
+concurrency:
+  group: deploy
+
 jobs:
   Lint:
     runs-on: ubuntu-latest

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - github deploy actions can no longer run concurrently.


### PR DESCRIPTION
Fixes #2423

Running multiple deploys concurrently will result in race conditions. We believe this is currently causing the gcloud app deploy command to be confused about which previous version or versions to stop, but it could cause other issues as well.

This change uses a concurrency group to only permit a single deploy to execute at a time.