### PR TITLE
Properly pass dataset into sim options, refactor

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    added:
+    - Added setup method for simulation API config dict
+    - Added methods to convert API v1 to simulation API config items

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -577,7 +577,9 @@ class SimulationAPIv2:
             "baseline": json.loads(baseline_policy),
             "time_period": time_period,
             "region": self._setup_region(country_id=country_id, region=region),
-            "data": self._setup_data(dataset),
+            "data": self._setup_data(
+                dataset=dataset, country_id=country_id, region=region
+            ),
         }
 
     def _setup_region(self, country_id: str, region: str) -> str:

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -1,15 +1,14 @@
-from typing import Dict
+from typing import Dict, Annotated
 import json
 import traceback
 import datetime
 import time
 import os
-from typing import Type
+from typing import Type, Any, Literal
 import pandas as pd
 import numpy as np
 from google.cloud import workflows_v1
 from google.cloud.workflows import executions_v1
-from typing import Tuple
 
 from policyengine_api.jobs import BaseJob
 from policyengine_api.jobs.tasks import compute_general_economy
@@ -61,7 +60,7 @@ class CalculateEconomySimulationJob(BaseJob):
         time_period: str,
         options: dict,
         baseline_policy: dict,
-        reform_policy: dict,
+        reform_policy: Annotated[str, "String-formatted JSON"],
     ):
         print(f"Starting CalculateEconomySimulationJob.run")
         try:
@@ -151,25 +150,20 @@ class CalculateEconomySimulationJob(BaseJob):
 
             # Kick off APIv2 job
             if use_api_v2:
-                data = None
-                v2_region = region
-                if data == "enhanced_cps":
-                    data = "gs://policyengine-us-data/enhanced_cps_2024.h5"
-                elif country_id == "us" and region != "us":
-                    data = (
-                        "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
-                    )
-                    v2_region = "state/" + region
-                input_data = {
-                    "country": country_id,
-                    "scope": "macro",
-                    "reform": json.loads(reform_policy),
-                    "baseline": json.loads(baseline_policy),
-                    "time_period": time_period,
-                    "region": v2_region,
-                    "data": data,
-                }
-                execution = self.api_v2.run(input_data)
+                
+                # Set up APIv2 job
+                comment("Setting up APIv2 job")
+                sim_config: dict[str, Any] = self.api_v2._setup_sim_options(
+                  country_id=country_id,
+                  scope="macro",
+                  reform_policy=reform_policy,
+                  baseline_policy=baseline_policy,
+                  time_period=time_period,
+                  region=region,
+                  dataset=dataset,
+                )
+
+                execution = self.api_v2.run(sim_config)
 
                 impact = self.api_v2.wait_for_completion(execution)
             else:
@@ -561,3 +555,56 @@ class SimulationAPIv2:
             print("Waiting for APIv2 job to complete...")
 
         return self.get_execution_result(execution)
+
+    def _setup_sim_options(
+        self,
+        country_id: str,
+        reform_policy: Annotated[str, "String-formatted JSON"],
+        baseline_policy: Annotated[str, "String-formatted JSON"],
+        region: str,
+        dataset: str,
+        time_period: str,
+        scope: Literal["macro", "household"] = "macro",
+    ) -> dict[str, Any]:
+        """
+        Set up the simulation options for the APIv2 job.
+        """
+
+        return {
+            "country": country_id,
+            "scope": scope,
+            "reform": json.loads(reform_policy),
+            "baseline": json.loads(baseline_policy),
+            "time_period": time_period,
+            "region": self._setup_region(country_id=country_id, region=region),
+            "data": self._setup_data(dataset),
+        }
+
+    def _setup_region(self, country_id: str, region: str) -> str:
+        """
+        Convert API v1 'region' option to API v2-compatible 'region' option.
+        """
+
+        # For US, states must be prefixed with 'state/'
+        if country_id == "us" and region != "us":
+            return "state/" + region
+        
+        return region
+    
+    def _setup_data(self, dataset: str, country_id: str, region: str) -> str | None:
+        """
+        Take API v1 'data' string literals, which reference a dataset name,
+        and convert to relevant GCP filepath. In future, this should be 
+        redone to use a more robust method of accessing datasets.
+        """
+
+        # Enhanced CPS runs must reference ECPS dataset in Google Cloud bucket
+        if dataset == "enhanced_cps":
+            return "gs://policyengine-us-data/enhanced_cps_2024.h5"
+        
+        # US state-level simulations must reference pooled CPS dataset
+        if country_id == "us" and region != "us":
+            return "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
+        
+        # All others receive no sim API 'data' arg
+        return None

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -150,17 +150,17 @@ class CalculateEconomySimulationJob(BaseJob):
 
             # Kick off APIv2 job
             if use_api_v2:
-                
+
                 # Set up APIv2 job
                 comment("Setting up APIv2 job")
                 sim_config: dict[str, Any] = self.api_v2._setup_sim_options(
-                  country_id=country_id,
-                  scope="macro",
-                  reform_policy=reform_policy,
-                  baseline_policy=baseline_policy,
-                  time_period=time_period,
-                  region=region,
-                  dataset=dataset,
+                    country_id=country_id,
+                    scope="macro",
+                    reform_policy=reform_policy,
+                    baseline_policy=baseline_policy,
+                    time_period=time_period,
+                    region=region,
+                    dataset=dataset,
                 )
 
                 execution = self.api_v2.run(sim_config)
@@ -588,23 +588,25 @@ class SimulationAPIv2:
         # For US, states must be prefixed with 'state/'
         if country_id == "us" and region != "us":
             return "state/" + region
-        
+
         return region
-    
-    def _setup_data(self, dataset: str, country_id: str, region: str) -> str | None:
+
+    def _setup_data(
+        self, dataset: str, country_id: str, region: str
+    ) -> str | None:
         """
         Take API v1 'data' string literals, which reference a dataset name,
-        and convert to relevant GCP filepath. In future, this should be 
+        and convert to relevant GCP filepath. In future, this should be
         redone to use a more robust method of accessing datasets.
         """
 
         # Enhanced CPS runs must reference ECPS dataset in Google Cloud bucket
         if dataset == "enhanced_cps":
             return "gs://policyengine-us-data/enhanced_cps_2024.h5"
-        
+
         # US state-level simulations must reference pooled CPS dataset
         if country_id == "us" and region != "us":
             return "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
-        
+
         # All others receive no sim API 'data' arg
         return None

--- a/policyengine_api/services/policy_service.py
+++ b/policyengine_api/services/policy_service.py
@@ -54,7 +54,7 @@ class PolicyService:
             print(f"Error getting policy: {str(e)}")
             raise e
 
-    def get_policy_json(self, country_id: str, policy_id: int):
+    def get_policy_json(self, country_id: str, policy_id: int) -> str:
         """
         Fetch policy JSON based only on policy ID and country ID
         """

--- a/tests/fixtures/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/fixtures/jobs/test_calculate_economy_simulation_job.py
@@ -106,10 +106,12 @@ def mock_simulation():
 
     return simulation
 
+
 @pytest.fixture
 def mock_setup_region():
     """Mock _setup_region to always return 'valid_region'."""
     return "valid_region"
+
 
 @pytest.fixture
 def mock_setup_dataset():

--- a/tests/fixtures/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/fixtures/jobs/test_calculate_economy_simulation_job.py
@@ -105,3 +105,13 @@ def mock_simulation():
     }.get(name)
 
     return simulation
+
+@pytest.fixture
+def mock_setup_region():
+    """Mock _setup_region to always return 'valid_region'."""
+    return "valid_region"
+
+@pytest.fixture
+def mock_setup_dataset():
+    """Mock _setup_dataset to always return 'valid dataset'."""
+    return "valid_dataset"

--- a/tests/fixtures/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/fixtures/jobs/test_calculate_economy_simulation_job.py
@@ -105,15 +105,3 @@ def mock_simulation():
     }.get(name)
 
     return simulation
-
-
-@pytest.fixture
-def mock_setup_region():
-    """Mock _setup_region to always return 'valid_region'."""
-    return "valid_region"
-
-
-@pytest.fixture
-def mock_setup_dataset():
-    """Mock _setup_dataset to always return 'valid dataset'."""
-    return "valid_dataset"

--- a/tests/unit/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/jobs/test_calculate_economy_simulation_job.py
@@ -6,7 +6,7 @@ import json
 
 from policyengine_api.jobs.calculate_economy_simulation_job import (
     CalculateEconomySimulationJob,
-    SimulationAPIv2
+    SimulationAPIv2,
 )
 from tests.fixtures.jobs.test_calculate_economy_simulation_job import (
     mock_huggingface_downloads,
@@ -168,14 +168,13 @@ class TestUKCountryFilters:
         assert mock_simulation.calculate.call_count == 0
         assert mock_simulation.get_holder.call_count == 0
 
+
 class TestSimulationAPIv2:
     class TestSetupSimOptions:
         test_country_id = "us"
-        test_reform_policy = json.dumps({
-            "sample_param": {
-                "2024-01-01.2100-12-31": 15
-            }
-        })
+        test_reform_policy = json.dumps(
+            {"sample_param": {"2024-01-01.2100-12-31": 15}}
+        )
         test_current_law_baseline_policy = json.dumps({})
         test_region = "us"
         test_dataset = None
@@ -183,7 +182,7 @@ class TestSimulationAPIv2:
         test_scope = "macro"
 
         def test__given_valid_options__returns_correct_sim_options(self):
-            
+
             # Create an instance of the class
             sim_api = SimulationAPIv2()
 
@@ -201,14 +200,16 @@ class TestSimulationAPIv2:
                     self.test_region,
                     self.test_dataset,
                     self.test_time_period,
-                    self.test_scope
+                    self.test_scope,
                 )
 
             # Assert the expected values in the returned dictionary
             assert sim_options["country"] == self.test_country_id
             assert sim_options["scope"] == self.test_scope
             assert sim_options["reform"] == json.loads(self.test_reform_policy)
-            assert sim_options["baseline"] == json.loads(self.test_current_law_baseline_policy)
+            assert sim_options["baseline"] == json.loads(
+                self.test_current_law_baseline_policy
+            )
             assert sim_options["time_period"] == self.test_time_period
             assert sim_options["region"] == "valid_region"
             assert sim_options["data"] == "valid_data"
@@ -265,7 +266,9 @@ class TestSimulationAPIv2:
             # Call the method
             result = sim_api._setup_data(dataset, country_id, region)
             # Assert the expected value
-            assert result == "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
+            assert (
+                result == "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
+            )
 
         def test__given_us_nationwide_dataset__returns_none(self):
             # Test with US nationwide dataset

--- a/tests/unit/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/jobs/test_calculate_economy_simulation_job.py
@@ -187,21 +187,15 @@ class TestSimulationAPIv2:
             sim_api = SimulationAPIv2()
 
             # Call the method with the test data; patch setup_region and setup_data methods
-            with mock.patch.object(
-                SimulationAPIv2, "_setup_region", return_value="valid_region"
-            ), mock.patch.object(
-                SimulationAPIv2, "_setup_data", return_value="valid_data"
-            ):
-                # Call the method
-                sim_options = sim_api._setup_sim_options(
-                    self.test_country_id,
-                    self.test_reform_policy,
-                    self.test_current_law_baseline_policy,
-                    self.test_region,
-                    self.test_dataset,
-                    self.test_time_period,
-                    self.test_scope,
-                )
+            sim_options = sim_api._setup_sim_options(
+                self.test_country_id,
+                self.test_reform_policy,
+                self.test_current_law_baseline_policy,
+                self.test_region,
+                self.test_dataset,
+                self.test_time_period,
+                self.test_scope,
+            )
 
             # Assert the expected values in the returned dictionary
             assert sim_options["country"] == self.test_country_id
@@ -211,8 +205,84 @@ class TestSimulationAPIv2:
                 self.test_current_law_baseline_policy
             )
             assert sim_options["time_period"] == self.test_time_period
-            assert sim_options["region"] == "valid_region"
-            assert sim_options["data"] == "valid_data"
+            assert sim_options["region"] == "us"
+            assert sim_options["data"] == None
+
+        def test__given_us_state__returns_correct_sim_options(self):
+            # Test with a US state
+            country_id = "us"
+            reform_policy = json.dumps(
+                {"sample_param": {"2024-01-01.2100-12-31": 15}}
+            )
+            current_law_baseline_policy = json.dumps({})
+            region = "ca"
+            dataset = None
+            time_period = "2025"
+            scope = "macro"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            sim_options = sim_api._setup_sim_options(
+                country_id,
+                reform_policy,
+                current_law_baseline_policy,
+                region,
+                dataset,
+                time_period,
+                scope,
+            )
+            # Assert the expected values in the returned dictionary
+            assert sim_options["country"] == country_id
+            assert sim_options["scope"] == scope
+            assert sim_options["reform"] == json.loads(reform_policy)
+            assert sim_options["baseline"] == json.loads(
+                current_law_baseline_policy
+            )
+            assert sim_options["time_period"] == time_period
+            assert sim_options["region"] == "state/ca"
+            assert (
+                sim_options["data"]
+                == "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
+            )
+
+        def test__given_enhanced_cps_state__returns_correct_sim_options(self):
+            # Test with enhanced_cps dataset
+            country_id = "us"
+            reform_policy = json.dumps(
+                {"sample_param": {"2024-01-01.2100-12-31": 15}}
+            )
+            current_law_baseline_policy = json.dumps({})
+            region = "ut"
+            dataset = "enhanced_cps"
+            time_period = "2025"
+            scope = "macro"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            sim_options = sim_api._setup_sim_options(
+                country_id,
+                reform_policy,
+                current_law_baseline_policy,
+                region,
+                dataset,
+                time_period,
+                scope,
+            )
+            # Assert the expected values in the returned dictionary
+            assert sim_options["country"] == country_id
+            assert sim_options["scope"] == scope
+            assert sim_options["reform"] == json.loads(reform_policy)
+            assert sim_options["baseline"] == json.loads(
+                current_law_baseline_policy
+            )
+            assert sim_options["time_period"] == time_period
+            assert sim_options["region"] == "state/ut"
+            assert (
+                sim_options["data"]
+                == "gs://policyengine-us-data/enhanced_cps_2024.h5"
+            )
 
     class TestSetupRegion:
         def test__given_us_state__returns_correct_region(self):

--- a/tests/unit/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/jobs/test_calculate_economy_simulation_job.py
@@ -2,9 +2,11 @@ import pytest
 import unittest.mock as mock
 import numpy as np
 import pandas as pd
+import json
 
 from policyengine_api.jobs.calculate_economy_simulation_job import (
     CalculateEconomySimulationJob,
+    SimulationAPIv2
 )
 from tests.fixtures.jobs.test_calculate_economy_simulation_job import (
     mock_huggingface_downloads,
@@ -165,3 +167,128 @@ class TestUKCountryFilters:
         # Only default simulation creation should happen, no constituency filtering
         assert mock_simulation.calculate.call_count == 0
         assert mock_simulation.get_holder.call_count == 0
+
+class TestSimulationAPIv2:
+    class TestSetupSimOptions:
+        test_country_id = "us"
+        test_reform_policy = json.dumps({
+            "sample_param": {
+                "2024-01-01.2100-12-31": 15
+            }
+        })
+        test_current_law_baseline_policy = json.dumps({})
+        test_region = "us"
+        test_dataset = None
+        test_time_period = "2025"
+        test_scope = "macro"
+
+        def test__given_valid_options__returns_correct_sim_options(self):
+            
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+
+            # Call the method with the test data; patch setup_region and setup_data methods
+            with mock.patch.object(
+                SimulationAPIv2, "_setup_region", return_value="valid_region"
+            ), mock.patch.object(
+                SimulationAPIv2, "_setup_data", return_value="valid_data"
+            ):
+                # Call the method
+                sim_options = sim_api._setup_sim_options(
+                    self.test_country_id,
+                    self.test_reform_policy,
+                    self.test_current_law_baseline_policy,
+                    self.test_region,
+                    self.test_dataset,
+                    self.test_time_period,
+                    self.test_scope
+                )
+
+            # Assert the expected values in the returned dictionary
+            assert sim_options["country"] == self.test_country_id
+            assert sim_options["scope"] == self.test_scope
+            assert sim_options["reform"] == json.loads(self.test_reform_policy)
+            assert sim_options["baseline"] == json.loads(self.test_current_law_baseline_policy)
+            assert sim_options["time_period"] == self.test_time_period
+            assert sim_options["region"] == "valid_region"
+            assert sim_options["data"] == "valid_data"
+
+    class TestSetupRegion:
+        def test__given_us_state__returns_correct_region(self):
+            # Test with a US state
+            country_id = "us"
+            # US states always lowercase two-letter codes
+            region = "ca"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+
+            # Call the method
+            result = sim_api._setup_region(country_id, region)
+            # Assert the expected value
+            assert result == "state/ca"
+
+        def test__given_non_us_state__returns_correct_region(self):
+            # Test with non-US region
+            country_id = "uk"
+            region = "country/england"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            result = sim_api._setup_region(country_id, region)
+            # Assert the expected value
+            assert result == region
+
+    class TestSetupData:
+        def test__given_enhanced_cps_dataset__returns_correct_gcp_path(self):
+            # Test with enhanced_cps dataset
+            dataset = "enhanced_cps"
+            country_id = "us"
+            region = "us"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            result = sim_api._setup_data(dataset, country_id, region)
+            # Assert the expected value
+            assert result == "gs://policyengine-us-data/enhanced_cps_2024.h5"
+
+        def test__given_us_state_dataset__returns_correct_gcp_path(self):
+            # Test with US state dataset
+            dataset = "us_state"
+            country_id = "us"
+            region = "ca"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            result = sim_api._setup_data(dataset, country_id, region)
+            # Assert the expected value
+            assert result == "gs://policyengine-us-data/pooled_3_year_cps_2023.h5"
+
+        def test__given_us_nationwide_dataset__returns_none(self):
+            # Test with US nationwide dataset
+            dataset = "us_nationwide"
+            country_id = "us"
+            region = "us"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            result = sim_api._setup_data(dataset, country_id, region)
+            # Assert the expected value
+            assert result is None
+
+        def test__given_uk_dataset__returns_none(self):
+            # Test with UK dataset
+            dataset = "uk_dataset"
+            country_id = "uk"
+            region = "country/england"
+
+            # Create an instance of the class
+            sim_api = SimulationAPIv2()
+            # Call the method
+            result = sim_api._setup_data(dataset, country_id, region)
+            # Assert the expected value
+            assert result is None


### PR DESCRIPTION
Fixes #2445 

This code refactors how we handle simulation API job setup. It creates methods specific to converting API v1's "dataset" option to the simulation API's "data" option and API v1's "region" to API v2's "region." It also adds tests for all added/refactored methods.