### PR TITLE
Roll back simulation API to v1

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,7 @@
+- bump: minor
+  changes:
+    changed:
+    - Rolled back to simulation API v1
+    added:
+    - New logging structure
+    - New logging outputs for simulation API v1 and v2 runs

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -1,9 +1,9 @@
 runtime: custom
 env: flex
 resources:
-  cpu: 4
-  memory_gb: 16
-  disk_size_gb: 64
+  cpu: 24
+  memory_gb: 128
+  disk_size_gb: 128
 automatic_scaling:
   min_num_instances: 1
   max_num_instances: 1

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -2,12 +2,15 @@ import sqlite3
 from policyengine_api.constants import REPO, VERSION, COUNTRY_PACKAGE_VERSIONS
 from policyengine_api.utils import hash_object
 from pathlib import Path
+from dotenv import load_dotenv
 import json
 from google.cloud.sql.connector import Connector
 import sqlalchemy
 import sqlalchemy.exc
 import os
 import sys
+
+load_dotenv()
 
 
 class PolicyEngineDatabase:

--- a/policyengine_api/utils/v2_v1_comparison.py
+++ b/policyengine_api/utils/v2_v1_comparison.py
@@ -1,0 +1,158 @@
+import math
+from pydantic import BaseModel
+from typing import Any, Annotated, Optional
+
+
+class V2V1Comparison(BaseModel):
+    """
+    The entire v1/v2 comparison log
+    """
+
+    country_id: str
+    region: str
+    reform_policy: Annotated[str, "JSON deserialized to string"]
+    baseline_policy: Annotated[str, "JSON deserialized to string"]
+    reform_policy_id: int
+    baseline_policy_id: int
+    time_period: str
+    dataset: str
+    v2_id: str | None = None
+    v2_error: Optional[str]
+    v1_impact: dict[str, Any] | None = None
+    v2_impact: dict[str, Any] | None = None
+    v1_v2_diff: dict[str, Any] | None = None
+    message: Optional[str]
+
+
+def compute_difference(x, y, parent_name: str = ""):
+    """
+    Computes the difference between two values, recursively for nested structures.
+
+    For numbers (int/float), returns their difference.
+    For basic primitives (str, bool, None), returns a formatted string showing both values.
+    For lists, recursively computes differences for each element.
+    For dictionaries, recursively computes differences for all keys present in either dict.
+    Properly handles NaN values.
+
+    Args:
+        x: First value to compare
+        y: Second value to compare
+        parent_name: Path to the current value (for nested structures)
+
+    Returns:
+        Various types depending on input:
+        - For numbers: their difference (x - y)
+        - For primitives: string showing both values
+        - For lists: list of differences
+        - For dictionaries: dictionary of differences
+        - None if values are identical or difference is below threshold
+    """
+    # Handle None or empty dict values
+    if (x is None or x == {}) and (y is None or y == {}):
+        return None
+
+    # Handle None values
+    if x is None or y is None:
+        return f"v1: {x}, v2: {y}"
+
+    # Handle different types
+    if type(x) != type(y):
+        # Special case for int/float comparison
+        if float in ((type(x), type(y))) and int in ((type(x), type(y))):
+            # Convert both to float for comparison
+            x_float = float(x)
+            y_float = float(y)
+
+            # Handle NaN cases
+            if math.isnan(x_float) or math.isnan(y_float):
+                if math.isnan(x_float) and math.isnan(y_float):
+                    return None  # Both are NaN, consider them the same
+                return f"v1: {'NaN' if math.isnan(x_float) else x_float}, v2: {'NaN' if math.isnan(y_float) else y_float}"
+
+            diff = x_float - y_float
+            # Check if difference is significant (using same threshold as original)
+            if abs(diff) < 1e-2 or (
+                abs(diff) / abs(x_float) < 0.01 if x_float != 0 else False
+            ):
+                return None
+            return diff
+        else:
+            return f"v1: {x} (type: {type(x).__name__}), v2: {y} (type: {type(y).__name__})"
+
+    # Handle boolean values
+    elif isinstance(x, bool):
+        if x == y:
+            return None
+        return f"v1: {x}, v2: {y}"
+
+    # Handle string values
+    elif isinstance(x, str):
+        if x == y:
+            return None
+        return f"v1: {x}, v2: {y}"
+
+    # Handle numeric values
+    if isinstance(x, (int, float)):
+        # Handle NaN cases
+        if isinstance(x, float) and isinstance(y, float):
+            if math.isnan(x) or math.isnan(y):
+                if math.isnan(x) and math.isnan(y):
+                    return None  # Both are NaN, consider them the same
+                return f"v1: {'NaN' if math.isnan(x) else x}, v2: {'NaN' if math.isnan(y) else y}"
+
+        diff = x - y
+
+        # Check if difference is significant (using same threshold as original)
+        if abs(diff) < 1e-2 or (
+            abs(diff) / abs(x) < 0.01 if x != 0 else False
+        ):
+            return None
+        return diff
+
+    # Handle dictionaries
+    elif isinstance(x, dict):
+        result = {}
+        # Check all keys in either dictionary
+        all_keys = set(x.keys()) | set(y.keys())
+        for k in all_keys:
+            if k not in x:
+                result[k] = f"v1: <missing>, v2: {y[k]}"
+            elif k not in y:
+                result[k] = f"v1: {x[k]}, v2: <missing>"
+            else:
+                # Recursively compute difference for this key
+                diff = compute_difference(
+                    x[k], y[k], parent_name=parent_name + "/" + str(k)
+                )
+                if diff is not None:
+                    result[k] = diff
+
+        return result if result else None
+
+    # Handle lists
+    elif isinstance(x, list):
+        result = []
+        max_len = max(len(x), len(y))
+
+        for i in range(max_len):
+            if i < len(x) and i < len(y):
+                # Both lists have this index
+                diff = compute_difference(
+                    x[i], y[i], parent_name=parent_name + f"[{i}]"
+                )
+                if diff is not None:
+                    result.append(diff)
+            elif i < len(x):
+                # Only in x
+                result.append(f"v1: {x[i]}, v2: <missing>")
+            else:
+                # Only in y
+                result.append(f"v1: <missing>, v2: {y[i]}")
+
+        return result if result else None
+
+    # Handle other types
+    else:
+        if x == y:
+            return None
+        return f"v1: {x}, v2: {y}"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "policyengine_core>=3.16.6",
         "pydantic",
         "pymysql",
+        "python-dotenv",
         "redis",
         "rq",
         "sqlalchemy>=1.4,<2",

--- a/tests/fixtures/utils/v2_v1_comparison.py
+++ b/tests/fixtures/utils/v2_v1_comparison.py
@@ -1,0 +1,21 @@
+valid_v2_v1_comparison = {
+    "country_id": "us",
+    "region": "ca",
+    "reform_policy": '{"tax_rate": 0.2}',
+    "baseline_policy": '{"tax_rate": 0.15}',
+    "reform_policy_id": 1,
+    "baseline_policy_id": 7,
+    "time_period": "2023-01-01.2028-12-31",
+    "dataset": "test_dataset",
+    "v2_id": "v2_workflow_id",
+    "v2_error": None,
+    "v1_impact": {"impact_value": 100},
+    "v2_impact": {"impact_value": 120},
+    "v1_v2_diff": {"impact_value": 20},
+    "message": None,
+}
+
+invalid_v2_v1_comparison = {
+    **valid_v2_v1_comparison,
+    "reform_policy_id": "invalid_id",  # Invalid type
+}

--- a/tests/unit/utils/test_v2_v1_comparison.py
+++ b/tests/unit/utils/test_v2_v1_comparison.py
@@ -127,6 +127,41 @@ class TestComputeDifference:
         # Then: It should return None
         assert result is None
 
+    def test__given_identical_dicts_with_different_order__returns_none(self):
+        # Given: Two identical dictionaries with different key order
+        x = {"key1": "value1", "key2": "value2"}
+        y = {"key2": "value2", "key1": "value1"}
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
+    def test__given_identical_dicts_with_numerical_keys__returns_none(self):
+        # Given: Two identical dictionaries with numerical keys
+        x = {1: "value1", 2: "value2"}
+        y = {1: "value1", 2: "value2"}
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
+    def test__given_identical_dicts_with_numerical_keys_of_different_types_and_order__returns_none(
+        self,
+    ):
+        # Given: Two identical dictionaries with numerical keys of different types and order
+        x = {1: "value1", 2: "value2"}
+        y = {"2": "value2", "1": "value1"}
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
     def test__given_different_dicts__returns_dict_difference(self):
         # Given: Two different dictionaries
         x = {"key1": "value1", "key2": "value2"}

--- a/tests/unit/utils/test_v2_v1_comparison.py
+++ b/tests/unit/utils/test_v2_v1_comparison.py
@@ -1,0 +1,197 @@
+import pytest
+from policyengine_api.utils.v2_v1_comparison import (
+    V2V1Comparison,
+    compute_difference,
+)
+from tests.fixtures.utils.v2_v1_comparison import (
+    valid_v2_v1_comparison,
+    invalid_v2_v1_comparison,
+)
+
+
+class TestV2V1Comparison:
+
+    def test__given_valid_inputs__returns_schema(self):
+
+        # When: Creating an instance of V2V1Comparison
+        comparison_instance = V2V1Comparison(**valid_v2_v1_comparison)
+
+        # Then: It should return a valid schema
+        assert (
+            comparison_instance.country_id
+            == valid_v2_v1_comparison["country_id"]
+        )
+        assert comparison_instance.region == valid_v2_v1_comparison["region"]
+        assert (
+            comparison_instance.reform_policy
+            == valid_v2_v1_comparison["reform_policy"]
+        )
+        assert (
+            comparison_instance.baseline_policy
+            == valid_v2_v1_comparison["baseline_policy"]
+        )
+        assert (
+            comparison_instance.reform_policy_id
+            == valid_v2_v1_comparison["reform_policy_id"]
+        )
+        assert (
+            comparison_instance.baseline_policy_id
+            == valid_v2_v1_comparison["baseline_policy_id"]
+        )
+        assert (
+            comparison_instance.time_period
+            == valid_v2_v1_comparison["time_period"]
+        )
+        assert comparison_instance.dataset == valid_v2_v1_comparison["dataset"]
+        assert comparison_instance.v2_id == valid_v2_v1_comparison["v2_id"]
+        assert (
+            comparison_instance.v2_error == valid_v2_v1_comparison["v2_error"]
+        )
+        assert (
+            comparison_instance.v1_impact
+            == valid_v2_v1_comparison["v1_impact"]
+        )
+        assert (
+            comparison_instance.v2_impact
+            == valid_v2_v1_comparison["v2_impact"]
+        )
+        assert (
+            comparison_instance.v1_v2_diff
+            == valid_v2_v1_comparison["v1_v2_diff"]
+        )
+        assert comparison_instance.message == valid_v2_v1_comparison["message"]
+
+    def test__given_invalid_inputs__raises_validation_error(self):
+
+        # When: Creating an instance of V2V1Comparison with invalid inputs
+        with pytest.raises(
+            Exception, match=r"validation errors? for V2V1Comparison"
+        ):
+            V2V1Comparison(**invalid_v2_v1_comparison)
+
+
+class TestComputeDifference:
+
+    def test__given_identical_numbers__returns_0(self):
+        # Given: Two identical numbers
+        x = 10
+        y = 10
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return 0
+        assert result is None
+
+    def test__given_different_numbers__returns_difference(self):
+        # Given: Two different numbers
+        x = 10
+        y = 5
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return the difference
+        assert result == 5
+
+    def test__given_identical_strings__returns_none(self):
+        # Given: Two identical strings
+        x = "hello"
+        y = "hello"
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
+    def test__given_different_strings__returns_strings(self):
+        # Given: Two different strings
+        x = "hello"
+        y = "world"
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return a formatted string
+        assert result == "v1: hello, v2: world"
+
+    def test__given_identical_dicts__returns_none(self):
+        # Given: Two identical dictionaries
+        x = {"key": "value"}
+        y = {"key": "value"}
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
+    def test__given_different_dicts__returns_dict_difference(self):
+        # Given: Two different dictionaries
+        x = {"key1": "value1", "key2": "value2"}
+        y = {"key1": "value1", "key3": "value3"}
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return a dictionary with differences
+        assert result == {
+            "key2": "v1: value2, v2: <missing>",
+            "key3": "v1: <missing>, v2: value3",
+        }
+
+    def test__given_identical_bools__returns_none(self):
+        # Given: Two identical booleans
+        x = True
+        y = True
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
+    def test__given_different_bools__returns_bools(self):
+        # Given: Two different booleans
+        x = True
+        y = False
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return a formatted string
+        assert result == "v1: True, v2: False"
+
+    def test__given_nan_values__returns_nan_string(self):
+        # Given: Two NaN values
+        x = float("nan")
+        y = float("nan")
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return None
+        assert result is None
+
+    def test__given_nan_and_number__returns_nan_string(self):
+        # Given: A NaN value and a number
+        x = float("nan")
+        y = 10
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return a formatted string
+        assert result == "v1: NaN, v2: 10.0"
+
+    def test__given_none_and_int__returns_none_string(self):
+        # Given: A None value and an integer
+        x = None
+        y = 10
+
+        # When: Computing the difference
+        result = compute_difference(x, y)
+
+        # Then: It should return a formatted string
+        assert result == "v1: None, v2: 10"


### PR DESCRIPTION
Fixes https://github.com/PolicyEngine/issues/issues/363
Fixes https://github.com/PolicyEngine/issues/issues/364

This code does the following:
* Rolls back the society-wide simulation code to use API v1 by default
* Increases the GCP resourcing for API v1 back to pre-v2 levels
* Re-enables running API v1 and v2 in tandem in order to compare results
* Adds a new logging structure designed to make it easy to programmatically pull the results from GCP for analysis and comparison
* Adds tests for the new structures

I was unable to test running the simulation API v2 workflow locally alongside the full API itself. Would love advice on configuration for that procedure moving forward.