### PR TITLE
Add v1 and v2 country package versions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - API v1 and v2 country package version data to GCP logging

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -172,6 +172,11 @@ class CalculateEconomySimulationJob(BaseJob):
                     "baseline_policy_id": baseline_policy_id,
                     "time_period": time_period,
                     "dataset": dataset,
+                    "v1_country_package_version": COUNTRY_PACKAGE_VERSIONS[
+                        country_id
+                    ],
+                    "v2_id": None,  # Unavailable until job starts
+                    "v2_country_package_version": None,  # Unavailable until job completes
                 }
 
                 # Set up APIv2 job
@@ -257,6 +262,10 @@ class CalculateEconomySimulationJob(BaseJob):
                         api_v2_execution
                     )
 
+                    v2_country_package_version = api_v2_output[
+                        "country_package_version"
+                    ]
+
                     completion_log: V2V1Comparison = (
                         V2V1Comparison.model_validate(
                             {
@@ -264,6 +273,7 @@ class CalculateEconomySimulationJob(BaseJob):
                                 "v1_impact": impact,
                                 "v2_impact": api_v2_output,
                                 "v1_v2_diff": None,
+                                "v2_country_package_version": v2_country_package_version,
                                 "message": "APIv2 job completed",
                             }
                         )
@@ -284,6 +294,7 @@ class CalculateEconomySimulationJob(BaseJob):
                                 "v1_impact": impact,
                                 "v2_impact": api_v2_output,
                                 "v1_v2_diff": v1_v2_diff,
+                                "v2_country_package_version": v2_country_package_version,
                                 "message": "APIv2 job comparison with APIv1 completed",
                             }
                         )

--- a/policyengine_api/utils/v2_v1_comparison.py
+++ b/policyengine_api/utils/v2_v1_comparison.py
@@ -16,6 +16,9 @@ class V2V1Comparison(BaseModel):
     baseline_policy_id: int
     time_period: str
     dataset: str
+    v1_country_package_version: str
+    # v2_country_package_version comes from v2 API results, so unavailable during runtime errors
+    v2_country_package_version: str | None = None
     v2_id: str | None = None
     v2_error: Optional[str] = None
     v1_impact: dict[str, Any] | None = None

--- a/tests/fixtures/utils/v2_v1_comparison.py
+++ b/tests/fixtures/utils/v2_v1_comparison.py
@@ -9,6 +9,8 @@ valid_v2_v1_comparison = {
     "dataset": "test_dataset",
     "v2_id": "v2_workflow_id",
     "v2_error": None,
+    "v1_country_package_version": "1.0.0",
+    "v2_country_package_version": "2.0.0",
     "v1_impact": {"impact_value": 100},
     "v2_impact": {"impact_value": 120},
     "v1_v2_diff": {"impact_value": 20},

--- a/tests/unit/utils/test_v2_v1_comparison.py
+++ b/tests/unit/utils/test_v2_v1_comparison.py
@@ -60,6 +60,14 @@ class TestV2V1Comparison:
             == valid_v2_v1_comparison["v1_v2_diff"]
         )
         assert comparison_instance.message == valid_v2_v1_comparison["message"]
+        assert (
+            comparison_instance.v1_country_package_version
+            == valid_v2_v1_comparison["v1_country_package_version"]
+        )
+        assert (
+            comparison_instance.v2_country_package_version
+            == valid_v2_v1_comparison["v2_country_package_version"]
+        )
 
     def test__given_invalid_inputs__raises_validation_error(self):
 


### PR DESCRIPTION
Fixes #2473.

This code uses updates to `.py` to add v1 and v2 country package versions to the objects we log to GCP.