### PR TITLE
Add logging for API v1 failures

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    added:
+    - Semi-structured logging for API v1 failures
+    changed:
+    - Updated .py version

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -338,6 +338,32 @@ class CalculateEconomySimulationJob(BaseJob):
                 options_hash,
                 message=traceback.format_exc(),
             )
+            if check_against_api_v2:
+                # Show that API v1 failed and API v2 was not run
+                error_log: V2V1Comparison = V2V1Comparison.model_validate(
+                    {
+                        "country_id": country_id,
+                        "region": region,
+                        "reform_policy": reform_policy,
+                        "baseline_policy": baseline_policy,
+                        "reform_policy_id": policy_id,
+                        "baseline_policy_id": baseline_policy_id,
+                        "time_period": time_period,
+                        "dataset": dataset,
+                        "v1_country_package_version": COUNTRY_PACKAGE_VERSIONS[
+                            country_id
+                        ],
+                        "v2_id": None,  # Unavailable until job starts
+                        "v2_country_package_version": None,  # Unavailable until job completes
+                        "v1_error": str(e),
+                        "v2_error": None,
+                        "v1_impact": None,
+                        "v2_impact": None,
+                        "v1_v2_diff": None,
+                        "message": "APIv1 job failed",
+                    }
+                )
+                logging.error(error_log.model_dump_json())
             print(f"Error setting reform impact: {str(e)}")
             raise e
 

--- a/policyengine_api/utils/v2_v1_comparison.py
+++ b/policyengine_api/utils/v2_v1_comparison.py
@@ -20,6 +20,7 @@ class V2V1Comparison(BaseModel):
     # v2_country_package_version comes from v2 API results, so unavailable during runtime errors
     v2_country_package_version: str | None = None
     v2_id: str | None = None
+    v1_error: Optional[str] = None
     v2_error: Optional[str] = None
     v1_impact: dict[str, Any] | None = None
     v2_impact: dict[str, Any] | None = None

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "policyengine_uk==2.24.2",
         "policyengine_us==1.281.0",
         "policyengine_core>=3.16.6",
+        "policyengine>=0.3.0",
         "pydantic",
         "pymysql",
         "python-dotenv",

--- a/tests/fixtures/jobs/calculate_economy_simulation_job.py
+++ b/tests/fixtures/jobs/calculate_economy_simulation_job.py
@@ -105,3 +105,19 @@ def mock_simulation():
     }.get(name)
 
     return simulation
+
+
+@pytest.fixture
+def mock_reform_impacts_service():
+    with mock.patch(
+        "policyengine_api.jobs.tasks.economy_simulation.reform_impacts_service"
+    ) as mock_service:
+        yield mock_service
+
+
+@pytest.fixture
+def mock_logging():
+    with mock.patch(
+        "policyengine_api.jobs.tasks.economy_simulation.logging"
+    ) as mock_logging:
+        yield mock_logging

--- a/tests/unit/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/jobs/test_calculate_economy_simulation_job.py
@@ -8,7 +8,7 @@ from policyengine_api.jobs.calculate_economy_simulation_job import (
     CalculateEconomySimulationJob,
     SimulationAPIv2,
 )
-from tests.fixtures.jobs.test_calculate_economy_simulation_job import (
+from tests.fixtures.jobs.calculate_economy_simulation_job import (
     mock_huggingface_downloads,
     mock_country,
     mock_h5py_weights,


### PR DESCRIPTION
Fixes #2476 
Fixes #2477 

## What Changed
- Added logging within `CalculateEconomySimulationJob.run()` to add semi-structured logging when API v1 fails
- Added a pinned update to `policyengine.py` version

## Why This Change
- The first change allows for better regression testing by allowing us to catch cases where API v1 fails before being able to run a v2 comparison
- The second change ensures API v2 logging can properly identify the country package version present within workflow logs