### PR TITLE
Remove deprecated enhanced_us options

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    removed:
+      - The deprecated enhanced_us region method. Set region to us and dataset to enhanced_cps instead.

--- a/policyengine_api/ai_prompts/simulation_analysis_prompt.py
+++ b/policyengine_api/ai_prompts/simulation_analysis_prompt.py
@@ -52,8 +52,7 @@ def generate_simulation_analysis_prompt(params: InboundParameters) -> str:
         """- Explicitly mention that this analysis uses PolicyEngine Enhanced CPS, constructed 
     from the 2023 Current Population Survey and the 2015 IRS Public Use File, and calibrated 
     to tax, benefit, income, and demographic aggregates."""
-        if "enhanced_us" in parameters.region
-        or parameters.dataset == "enhanced_cps"
+        if parameters.dataset == "enhanced_cps"
         else ""
     )
 
@@ -73,7 +72,7 @@ def generate_simulation_analysis_prompt(params: InboundParameters) -> str:
 
     poverty_rate_change_text: str = (
         "- After the racial breakdown of poverty rate changes, include the text: '{{povertyImpact.regular.byRace}}'"
-        if parameters.region == "us" or parameters.region == "enhanced_us"
+        if parameters.region == "us"
         else ""
     )
 

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -101,9 +101,6 @@ class PolicyEngineCountry:
         elif self.country_id == "us":
             region = [
                 dict(name="us", label="the US"),
-                # enhanced_us is a legacy option maintained for users
-                # accessing via an outdated URL
-                dict(name="enhanced_us", label="the US (enhanced CPS)"),
                 dict(name="al", label="Alabama"),
                 dict(name="ak", label="Alaska"),
                 dict(name="az", label="Arizona"),

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -511,16 +511,13 @@ class CalculateEconomySimulationJob(BaseJob):
         # Permitted dataset settings
         DATASETS = ["enhanced_cps"]
 
-        # Second statement provides backwards compatibility option
-        # for running a simulation with the "enhanced_us" region
-        if dataset in DATASETS or region == "enhanced_us":
+        if dataset in DATASETS:
             print(f"Running an enhanced CPS simulation")
 
             sim_options["dataset"] = ENHANCED_CPS
 
-        # Handle region settings; need to be mindful not to place
-        # legacy enhanced_us region in this block
-        if region not in ["us", "enhanced_us"]:
+        # Handle region settings
+        if region != "us":
             print(f"Filtering US dataset down to region {region}")
 
             # This is only run to allow for filtering by region

--- a/tests/fixtures/simulation_analysis_prompt_fixtures.py
+++ b/tests/fixtures/simulation_analysis_prompt_fixtures.py
@@ -211,12 +211,6 @@ invalid_data_missing_input_field = {
 }
 
 
-def given_valid_data_and_region_is_enhanced_us(data):
-    modified_data = deepcopy(data)
-    modified_data["region"] = "enhanced_us"
-    return modified_data
-
-
 def given_valid_data_and_dataset_is_enhanced_cps(data):
     modified_data = deepcopy(data)
     modified_data["dataset"] = "enhanced_cps"

--- a/tests/to_refactor/python/test_simulation_analysis_routes.py
+++ b/tests/to_refactor/python/test_simulation_analysis_routes.py
@@ -69,14 +69,15 @@ def test_execute_simulation_analysis_error(rest_client):
 def test_execute_simulation_analysis_enhanced_cps(rest_client):
     policy_details = dict(policy_json="policy details")
 
-    test_json_enhanced_us = {
+    test_json_enhanced_cps = {
         "currency": "USD",
         "selected_version": "2023",
         "time_period": "2023",
         "impact": test_impact,
         "policy_label": "Test Policy",
         "policy": policy_details,
-        "region": "enhanced_us",
+        "region": "us",
+        "dataset": "enhanced_cps",
         "relevant_parameters": ["param1", "param2"],
         "relevant_parameter_baseline_values": [
             {"param1": 100},
@@ -99,7 +100,7 @@ def test_execute_simulation_analysis_enhanced_cps(rest_client):
                 )
 
                 response = rest_client.post(
-                    "/us/simulation-analysis", json=test_json_enhanced_us
+                    "/us/simulation-analysis", json=test_json_enhanced_cps
                 )
 
                 assert response.status_code == 200

--- a/tests/unit/ai_prompts/test_simulation_analysis_prompt.py
+++ b/tests/unit/ai_prompts/test_simulation_analysis_prompt.py
@@ -6,7 +6,6 @@ from tests.fixtures.simulation_analysis_prompt_fixtures import (
     valid_input_us,
     valid_input_uk,
     invalid_data_missing_input_field,
-    given_valid_data_and_region_is_enhanced_us,
     given_valid_data_and_dataset_is_enhanced_cps,
 )
 
@@ -26,20 +25,6 @@ class TestGenerateSimulationAnalysisPrompt:
 
         prompt = generate_simulation_analysis_prompt(valid_input_uk)
         snapshot.assert_match(prompt, "simulation_analysis_prompt_uk.txt")
-
-    def test_given_region_is_enhanced_us(self, snapshot):
-
-        snapshot.snapshot_dir = "tests/snapshots"
-        valid_enhanced_us_input_data = (
-            given_valid_data_and_region_is_enhanced_us(valid_input_us)
-        )
-
-        prompt = generate_simulation_analysis_prompt(
-            valid_enhanced_us_input_data
-        )
-        snapshot.assert_match(
-            prompt, "simulation_analysis_prompt_region_enhanced_us.txt"
-        )
 
     def test_given_dataset_is_enhanced_cps(self, snapshot):
 


### PR DESCRIPTION
Fixes #2486.

## What Changed
- Removed `enhanced_us` as a region option from the metadata
- Removed AI simulation explanation sub-feature that gave description of Enhanced CPS runs when region set to `enhanced_us`
- Remove irrelevant tests

## Why This Change
- Enables complete migration to separation of `region` simulation option from `dataset` option