### PR TITLE
Temporarily downgrade Claude to 3.5 Sonnet

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Temporarily downgraded Claude to 3.5 Sonnet.

--- a/policyengine_api/services/ai_analysis_service.py
+++ b/policyengine_api/services/ai_analysis_service.py
@@ -52,8 +52,12 @@ class AIAnalysisService:
         def generate():
             response_text = ""
 
+            # Temporarily downgrading Claude to 3.5 Sonnet to prevent unwanted
+            # quotes in Explain with AI feature responses.
+            # If Claude is still at 3.5 Sonnet on July 1, 2025, file an issue.
+            # See https://github.com/PolicyEngine/policyengine-app/issues/2584
             with claude_client.messages.stream(
-                model="claude-sonnet-4-20250514",
+                model="claude-3-5-sonnet-20240620",
                 max_tokens=1500,
                 temperature=0.0,
                 system="Respond with a historical quote",


### PR DESCRIPTION
Fixes #2519.

## What Changed
- Temporarily downgraded Claude to 3.5 Sonnet

## Why This Change
- Claude 4.0 sometimes inserts unwanted quotes into Explain with AI outputs (see https://github.com/PolicyEngine/policyengine-app/issues/2584); we don't want to fully downgrade from Claude 4.0, but we want to temporarily prevent the quotes issue, then re-upgrade and add a more durable fix.

## Technical Details
N/A