### PR TITLE
Run apt-get inline to fix `jq` install

### DIFF
--- a/.github/install-jq.sh
+++ b/.github/install-jq.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-
-set -e
-
-apt-get update
-apt-get install -y jq

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies (required for finding API model versions)
         run: make install
       - name: Install jq (required only for GitHub Actions)
-        run: ".github/install-jq.sh"
+        run: sudo apt-get install -y jq
       - name: Find API model versions and write to environment variable
         run: python3 .github/find-api-model-versions.py
       - name: Ensure full API and simulation API model versions are in sync


### PR DESCRIPTION
Fixes #2546 

Instead of using a Bash script, this code just runs `apt-get` inline in the GitHub Action based on advice [here](https://stackoverflow.com/questions/57982945/how-to-apt-get-install-in-a-github-actions-workflow).