### PR TITLE
Properly pass args to API v1 run method

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Properly pass args to API v1 run method

--- a/policyengine_api/jobs/calculate_economy_simulation_job.py
+++ b/policyengine_api/jobs/calculate_economy_simulation_job.py
@@ -228,9 +228,6 @@ class CalculateEconomySimulationJob(BaseJob):
                     }
                 )
                 impact = self._run_v1_job(
-                    job_id=job_id,
-                    baseline_policy_id=baseline_policy_id,
-                    reform_policy_id=policy_id,
                     country_id=country_id,
                     region=region,
                     dataset=dataset,
@@ -238,6 +235,7 @@ class CalculateEconomySimulationJob(BaseJob):
                     options=options,
                     baseline_policy=baseline_policy,
                     reform_policy=reform_policy,
+                    job_setup_options=job_setup_options,
                 )
                 reform_impacts_service.set_complete_reform_impact(
                     country_id=country_id,


### PR DESCRIPTION
Fixes #2566 

Properly pass args to API v1's run method to prevent error we're currently getting. This passes locally. Tests not added, since we aim to remove this feature by Monday of next week.