### PR TITLE
Properly pass arguments from API call to request cliff impacts

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Passed include_cliffs value to simulation API to enable cliff impacts

--- a/policyengine_api/routes/economy_routes.py
+++ b/policyengine_api/routes/economy_routes.py
@@ -5,6 +5,7 @@ from policyengine_api.utils.payload_validators import validate_country
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 from flask import request
 import json
+from typing import Literal
 
 economy_bp = Blueprint("economy", __name__)
 economy_service = EconomyService()
@@ -31,18 +32,20 @@ def get_economic_impact(
     region = options.pop("region")
     dataset = options.pop("dataset", "default")
     time_period = options.pop("time_period")
+    target: Literal["general", "cliff"] = options.pop("target", "general")
     api_version = options.pop(
         "version", COUNTRY_PACKAGE_VERSIONS.get(country_id)
     )
 
     result = economy_service.get_economic_impact(
-        country_id,
-        policy_id,
-        baseline_policy_id,
-        region,
-        dataset,
-        time_period,
-        options,
-        api_version,
+        country_id=country_id,
+        policy_id=policy_id,
+        baseline_policy_id=baseline_policy_id,
+        region=region,
+        dataset=dataset,
+        time_period=time_period,
+        options=options,
+        api_version=api_version,
+        target=target,
     )
     return result

--- a/policyengine_api/services/economy_service.py
+++ b/policyengine_api/services/economy_service.py
@@ -6,6 +6,7 @@ from policyengine_api.services.reform_impacts_service import (
 from policyengine_api.data import local_database, database
 import json
 import datetime
+from typing import Literal
 
 policy_service = PolicyService()
 job_service = JobService()
@@ -29,6 +30,7 @@ class EconomyService:
         time_period: str,
         options: dict,
         api_version: str,
+        target: Literal["general", "cliff"] = "general",
     ):
         """
         Calculate the society-wide economic impact of a policy reform.
@@ -106,6 +108,7 @@ class EconomyService:
                     options=options,
                     baseline_policy=baseline_policy,
                     reform_policy=reform_policy,
+                    target=target,
                     job_id=job_id,
                     job_timeout=20 * 60,
                 )

--- a/tests/unit/jobs/test_calculate_economy_simulation_job.py
+++ b/tests/unit/jobs/test_calculate_economy_simulation_job.py
@@ -4,6 +4,7 @@ from policyengine_api.jobs.calculate_economy_simulation_job import (
     CalculateEconomySimulationJob,
     SimulationAPI,
 )
+from typing import Literal
 
 
 class TestSimulationAPI:
@@ -16,7 +17,7 @@ class TestSimulationAPI:
         test_region = "us"
         test_dataset = None
         test_time_period = "2025"
-        test_scope = "macro"
+        test_scope: Literal["macro"] = "macro"
 
         def test__given_valid_options__returns_correct_sim_options(self):
 
@@ -120,6 +121,45 @@ class TestSimulationAPI:
                 sim_options["data"]
                 == "gs://policyengine-us-data/enhanced_cps_2024.h5"
             )
+
+        def test__given_cliff_target__returns_correct_sim_options(self):
+            country_id = "us"
+            reform_policy = json.dumps(
+                {"sample_param": {"2024-01-01.2100-12-31": 15}}
+            )
+            current_law_baseline_policy = json.dumps({})
+            region = "us"
+            dataset = None
+            time_period = "2025"
+            scope = "macro"
+            target = "cliff"
+
+            # Create an instance of the class
+            sim_api = SimulationAPI()
+
+            # Call the method
+            sim_options = sim_api._setup_sim_options(
+                country_id,
+                reform_policy,
+                current_law_baseline_policy,
+                region,
+                dataset,
+                time_period,
+                scope,
+                include_cliffs=target == "cliff",
+            )
+
+            # Assert the expected values in the returned dictionary
+            assert sim_options["country"] == country_id
+            assert sim_options["scope"] == scope
+            assert sim_options["reform"] == json.loads(reform_policy)
+            assert sim_options["baseline"] == json.loads(
+                current_law_baseline_policy
+            )
+            assert sim_options["time_period"] == time_period
+            assert sim_options["region"] == region
+            assert sim_options["data"] == None
+            assert sim_options["include_cliffs"] == True
 
     class TestSetupRegion:
         def test__given_us_state__returns_correct_region(self):


### PR DESCRIPTION
Fixes #2605.

Does not need to be merged before handling https://github.com/PolicyEngine/policyengine-app/issues/2620. Will include screenshot of cliff impacts working in the PR opened to fix that issue.

This PR makes modifications to the `CalculateEconomySimulationJob` and the economy router and service to take the `target` URL parameter, check if it is equal to `cliff`, then pass that into the simulation API via the Boolean `include_cliffs` argument created as part of `.py`. It also makes minor typing fixes and code quality improvements.

This PR adds a test for the `SimulationAPI` class to ensure proper setup, but it does not add a test for the `CalculateEconomySimulationJob` class. I'm hoping to add more comprehensive testing as part of https://github.com/PolicyEngine/policyengine-api/issues/2600, which will substantially modify this class.