### PR TITLE
Increase GCP timeout

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Increased GCP time to readiness threshold from 400 to 600 seconds.

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -21,4 +21,4 @@ runtime_config:
   runtime_version: "22"
 readiness_check:
   path: "/readiness-check"
-  app_start_timeout_sec: 400
+  app_start_timeout_sec: 600


### PR DESCRIPTION
Fixes #2615.

This PR increases the GCP readiness check success threshold from 400 seconds to 600. This is meant to prevent deployment failures like the one flagged in the original issue.