### PR TITLE
Increase API memory from 16GB to 24GB

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Increase API memory from 16GB to 24GB

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -2,7 +2,7 @@ runtime: custom
 env: flex
 resources:
   cpu: 4
-  memory_gb: 16
+  memory_gb: 24
   disk_size_gb: 32
 automatic_scaling:
   min_num_instances: 1


### PR DESCRIPTION
Fixes #2621.

Hopefully, doing this will re-enable API deployments.