### PR TITLE
Upgrade FRS to 2023-24 version

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Upgraded FRS to 2023-24 version

--- a/policyengine_api/data/model_setup.py
+++ b/policyengine_api/data/model_setup.py
@@ -1,7 +1,7 @@
 from policyengine_api.utils.hugging_face import get_latest_commit_tag
 
 ENHANCED_FRS = "hf://policyengine/policyengine-uk-data/enhanced_frs_2023_24.h5"
-FRS = "hf://policyengine/policyengine-uk-data/frs_2022_23.h5"
+FRS = "hf://policyengine/policyengine-uk-data/frs_2023_24.h5"
 
 ENHANCED_CPS = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
 CPS = "hf://policyengine/policyengine-us-data/cps_2023.h5"


### PR DESCRIPTION
Partially addresses https://github.com/PolicyEngine/policyengine-api-v2/issues/297.

Updates the standard FRS address to the 2023-24 version.