### PR TITLE
Test: Currency symbol display in AI explainer

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Currency symbol display in AI explainer now shows correct symbol for each country (£ for UK, $ for US/CA, etc)

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,4 +1,4 @@
 - bump: patch
   changes:
     fixed:
-      - Currency symbol display in AI explainer now shows correct symbol for each country (£ for UK, $ for US/CA, etc)
+      - Currency symbol display in AI explainer now shows correct symbol for each country (pound for UK, dollar for US/CA, etc)

--- a/policyengine_api/services/tracer_analysis_service.py
+++ b/policyengine_api/services/tracer_analysis_service.py
@@ -53,7 +53,7 @@ class TracerAnalysisService(AIAnalysisService):
 
         # Get the appropriate prompt template based on country
         prompt_template = self._get_prompt_template(country_id)
-        
+
         # Add the parsed tracer output to the prompt
         prompt = prompt_template.format(
             variable=variable, tracer_segment=tracer_segment
@@ -140,7 +140,7 @@ class TracerAnalysisService(AIAnalysisService):
 
     def _get_prompt_template(self, country_id: str) -> str:
         """Get the appropriate prompt template with correct currency symbol based on country."""
-        
+
         # Determine currency instruction based on country
         currency_instructions = {
             "uk": "The response will be rendered as markdown, so preface £ with \\.",
@@ -149,12 +149,11 @@ class TracerAnalysisService(AIAnalysisService):
             "il": "The response will be rendered as markdown, so preface ₪ with \\.",
             "ng": "The response will be rendered as markdown, so preface ₦ with \\.",
         }
-        
+
         currency_note = currency_instructions.get(
-            country_id, 
-            "The response will be rendered as markdown."
+            country_id, "The response will be rendered as markdown."
         )
-        
+
         return f"""{anthropic.HUMAN_PROMPT} You are an AI assistant explaining policy calculations. 
   The user has run a simulation for the variable '{{variable}}'.
   Here's the tracer output:

--- a/tests/unit/services/test_tracer_analysis_service.py
+++ b/tests/unit/services/test_tracer_analysis_service.py
@@ -153,10 +153,10 @@ def test_tracer_output_for_variable_that_is_substring_of_another():
 def test_get_prompt_template_for_uk():
     # Given: UK country code
     country_id = "uk"
-    
+
     # When: Getting the prompt template
     template = test_service._get_prompt_template(country_id)
-    
+
     # Then: It should include £ currency symbol instruction
     assert "preface £ with \\." in template
     assert "preface $" not in template
@@ -165,10 +165,10 @@ def test_get_prompt_template_for_uk():
 def test_get_prompt_template_for_us():
     # Given: US country code
     country_id = "us"
-    
+
     # When: Getting the prompt template
     template = test_service._get_prompt_template(country_id)
-    
+
     # Then: It should include $ currency symbol instruction
     assert "preface $ with \\." in template
     assert "preface £" not in template
@@ -177,10 +177,10 @@ def test_get_prompt_template_for_us():
 def test_get_prompt_template_for_canada():
     # Given: Canada country code
     country_id = "ca"
-    
+
     # When: Getting the prompt template
     template = test_service._get_prompt_template(country_id)
-    
+
     # Then: It should include $ currency symbol instruction
     assert "preface $ with \\." in template
 
@@ -188,10 +188,10 @@ def test_get_prompt_template_for_canada():
 def test_get_prompt_template_for_israel():
     # Given: Israel country code
     country_id = "il"
-    
+
     # When: Getting the prompt template
     template = test_service._get_prompt_template(country_id)
-    
+
     # Then: It should include ₪ currency symbol instruction
     assert "preface ₪ with \\." in template
 
@@ -199,10 +199,10 @@ def test_get_prompt_template_for_israel():
 def test_get_prompt_template_for_nigeria():
     # Given: Nigeria country code
     country_id = "ng"
-    
+
     # When: Getting the prompt template
     template = test_service._get_prompt_template(country_id)
-    
+
     # Then: It should include ₦ currency symbol instruction
     assert "preface ₦ with \\." in template
 
@@ -210,10 +210,10 @@ def test_get_prompt_template_for_nigeria():
 def test_get_prompt_template_for_unknown_country():
     # Given: Unknown country code
     country_id = "xx"
-    
+
     # When: Getting the prompt template
     template = test_service._get_prompt_template(country_id)
-    
+
     # Then: It should still return a valid template without currency-specific instruction
     assert "The response will be rendered as markdown." in template
     assert "preface" not in template or "with \\." not in template

--- a/tests/unit/services/test_tracer_analysis_service.py
+++ b/tests/unit/services/test_tracer_analysis_service.py
@@ -148,3 +148,72 @@ def test_tracer_output_for_variable_that_is_substring_of_another():
         spliced_valid_tracer_output_for_variable_that_is_substring_of_another
     )
     assert result == expected_output
+
+
+def test_get_prompt_template_for_uk():
+    # Given: UK country code
+    country_id = "uk"
+    
+    # When: Getting the prompt template
+    template = test_service._get_prompt_template(country_id)
+    
+    # Then: It should include £ currency symbol instruction
+    assert "preface £ with \\." in template
+    assert "preface $" not in template
+
+
+def test_get_prompt_template_for_us():
+    # Given: US country code
+    country_id = "us"
+    
+    # When: Getting the prompt template
+    template = test_service._get_prompt_template(country_id)
+    
+    # Then: It should include $ currency symbol instruction
+    assert "preface $ with \\." in template
+    assert "preface £" not in template
+
+
+def test_get_prompt_template_for_canada():
+    # Given: Canada country code
+    country_id = "ca"
+    
+    # When: Getting the prompt template
+    template = test_service._get_prompt_template(country_id)
+    
+    # Then: It should include $ currency symbol instruction
+    assert "preface $ with \\." in template
+
+
+def test_get_prompt_template_for_israel():
+    # Given: Israel country code
+    country_id = "il"
+    
+    # When: Getting the prompt template
+    template = test_service._get_prompt_template(country_id)
+    
+    # Then: It should include ₪ currency symbol instruction
+    assert "preface ₪ with \\." in template
+
+
+def test_get_prompt_template_for_nigeria():
+    # Given: Nigeria country code
+    country_id = "ng"
+    
+    # When: Getting the prompt template
+    template = test_service._get_prompt_template(country_id)
+    
+    # Then: It should include ₦ currency symbol instruction
+    assert "preface ₦ with \\." in template
+
+
+def test_get_prompt_template_for_unknown_country():
+    # Given: Unknown country code
+    country_id = "xx"
+    
+    # When: Getting the prompt template
+    template = test_service._get_prompt_template(country_id)
+    
+    # Then: It should still return a valid template without currency-specific instruction
+    assert "The response will be rendered as markdown." in template
+    assert "preface" not in template or "with \\." not in template


### PR DESCRIPTION
## Summary
This PR adds comprehensive tests for the currency symbol fix that was directly pushed to master in commit e18e0f31.

## Changes
- Add unit tests for `_get_prompt_template` method
- Test correct currency symbols for UK (£), US ($), CA ($), IL (₪), NG (₦)
- Test fallback behavior for unknown countries

## Testing
The tests verify that:
- UK households see £ in AI explanations
- US/Canadian households see $
- Israeli households see ₪
- Nigerian households see ₦
- Unknown countries get generic markdown instructions

## Related
- Fixes the issue where UK AI explanations incorrectly displayed $ instead of £
- Tests the changes from commit e18e0f31

🤖 Generated with Claude Code