### PR TITLE
Use gunicorn preload option, modify readiness checks

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Attempted to fix deployments using gunicorn preload option and modified readiness check timeouts

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -12,13 +12,19 @@ automatic_scaling:
     target_utilization: 0.8
 liveness_check:
   path: "/liveness-check"
-  check_interval_sec: 30
-  timeout_sec: 30
+  check_interval_sec: 30 # Check every 30 seconds
+  timeout_sec: 30 # Allow 30 seconds for a response
   failure_threshold: 5
   success_threshold: 2
+  initial_delay_sec: 60 # Don't check for first 60 seconds to allow full boot
 runtime_config:
   operating_system: "ubuntu22"
   runtime_version: "22"
 readiness_check:
   path: "/readiness-check"
-  app_start_timeout_sec: 600
+  check_interval_sec: 30
+  timeout_sec: 30
+  failure_threshold: 5
+  success_threshold: 2
+  initial_delay_sec: 60
+  app_start_timeout_sec: 900

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -5,7 +5,7 @@ WORKER_COUNT="${WORKER_COUNT:-3}"
 REDIS_PORT="${REDIS_PORT:-6379}"
 
 # Start the API
-gunicorn -b :"$PORT" policyengine_api.api --timeout 300 --workers 5 &
+gunicorn -b :"$PORT" policyengine_api.api --timeout 300 --workers 5 --preload &
 
 # Start Redis with configuration for multiple clients
 redis-server --protected-mode no \


### PR DESCRIPTION
Fixes #2182 

Uses gunicorn's "preload" feature to avoid causing 100% CPU utilization on boot. Modifies readiness checks to match liveness checks.