### PR TITLE
Make error_message optional in reports

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Make error_message optional within report service

--- a/policyengine_api/routes/report_output_routes.py
+++ b/policyengine_api/routes/report_output_routes.py
@@ -157,10 +157,6 @@ def update_report_output(country_id: str) -> Response:
     if status == "complete" and output is None:
         raise BadRequest("output is required when status is 'complete'")
 
-    # Validate that error status has error_message
-    if status == "error" and error_message is None:
-        raise BadRequest("error_message is required when status is 'error'")
-
     try:
         # First check if the report output exists
         existing_report = report_output_service.get_report_output(report_id)


### PR DESCRIPTION
Fixes #2785.

Removes validation check for `error_message` so that that value can be optional moving forward. This prevents API 500s when an error occurs, but an error message isn't provided.