### PR TITLE
Update simulations table and PATCH endpoint to contain output structures present in report_outputs

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Updated simulation table and PATCH endpoint to contain output structures present in report_outputs.

--- a/policyengine_api/data/initialise.sql
+++ b/policyengine_api/data/initialise.sql
@@ -112,9 +112,9 @@ CREATE TABLE IF NOT EXISTS simulations (
     population_id VARCHAR(255) NOT NULL,
     population_type VARCHAR(50) NOT NULL,
     policy_id INT NOT NULL,
-    -- output_json stores calculation results for household simulations only
-    -- For geography simulations, outputs are stored in report_outputs table
-    output_json JSON DEFAULT NULL
+    status VARCHAR(32) NOT NULL DEFAULT 'pending',
+    output JSON DEFAULT NULL,
+    error_message TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS report_outputs (

--- a/policyengine_api/data/initialise_local.sql
+++ b/policyengine_api/data/initialise_local.sql
@@ -121,9 +121,9 @@ CREATE TABLE IF NOT EXISTS simulations (
     population_id VARCHAR(255) NOT NULL,
     population_type VARCHAR(50) NOT NULL,
     policy_id INT NOT NULL,
-    -- output_json stores calculation results for household simulations only
-    -- For geography simulations, outputs are stored in report_outputs table
-    output_json JSON DEFAULT NULL
+    status VARCHAR(32) NOT NULL DEFAULT 'pending',
+    output JSON DEFAULT NULL,
+    error_message TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS report_outputs (

--- a/tests/fixtures/services/simulation_fixtures.py
+++ b/tests/fixtures/services/simulation_fixtures.py
@@ -22,14 +22,15 @@ def existing_simulation_record(test_db):
     """Insert an existing simulation record into the database."""
     test_db.query(
         """INSERT INTO simulations
-        (country_id, api_version, population_id, population_type, policy_id)
-        VALUES (?, ?, ?, ?, ?)""",
+        (country_id, api_version, population_id, population_type, policy_id, status)
+        VALUES (?, ?, ?, ?, ?, ?)""",
         (
             valid_simulation_data["country_id"],
             valid_simulation_data["api_version"],
             valid_simulation_data["population_id"],
             valid_simulation_data["population_type"],
             valid_simulation_data["policy_id"],
+            "pending",
         ),
     )
 


### PR DESCRIPTION
Fixes #2853.

Note that this cannot be merged until `simulations` table has been manually dropped and recreated using new structure.