### PR TITLE
Increase CPU and RAM to prevent frequent crashing

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Increased CPU and RAM to prevent frequent crashing.

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -1,8 +1,8 @@
 runtime: custom
 env: flex
 resources:
-  cpu: 2
-  memory_gb: 8
+  cpu: 4
+  memory_gb: 12
   disk_size_gb: 32
 automatic_scaling:
   min_num_instances: 1


### PR DESCRIPTION
Fixes #3018

## Summary
- Increased CPU from 2 to 4 cores
- Increased RAM from 8 GB to 12 GB

This change addresses frequent crashing issues by providing more compute resources.

## Cost Impact

Rough, based on current billing rates:

* Current: ~$113/month
* After change: ~$207/month
* Increase: +$94/month

## Test plan
- [ ] Deploy to staging and monitor for crashes
- [ ] Verify application starts successfully with new resource allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)