### PR TITLE
Increase RAM allocation to 24 GB

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Increase RAM back to 24 GB (matches deployment settings pre-Nov. 2025)

--- a/gcp/policyengine_api/app.yaml
+++ b/gcp/policyengine_api/app.yaml
@@ -2,7 +2,7 @@ runtime: custom
 env: flex
 resources:
   cpu: 4
-  memory_gb: 12
+  memory_gb: 24
   disk_size_gb: 32
 automatic_scaling:
   min_num_instances: 1


### PR DESCRIPTION
Fixes #3051

## Summary
- Increases RAM allocation from 12 GB to 24 GB in app.yaml
- This restores the RAM setting to match the September 2025 configuration when we last had 4 CPUs

## Test plan
- [ ] Deploy to GCP App Engine and verify the instance runs with the updated memory allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)