### PR TITLE
Add policyengine-claude plugin auto-install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "marketplaces": [
+      "PolicyEngine/policyengine-claude"
+    ],
+    "auto_install": [
+      "country-models@policyengine-claude"
+    ]
+  }
+}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+      - Added policyengine-claude plugin auto-install configuration.

--- a/policyengine_api/data/congressional_districts.py
+++ b/policyengine_api/data/congressional_districts.py
@@ -11,7 +11,6 @@ Census Data: https://www.census.gov/data/tables/2020/dec/2020-apportionment-data
 
 from pydantic import BaseModel, Field
 
-
 # Mapping of state codes to full state names
 STATE_CODE_TO_NAME = {
     "AL": "Alabama",

--- a/policyengine_api/libs/simulation_api.py
+++ b/policyengine_api/libs/simulation_api.py
@@ -8,7 +8,6 @@ from dotenv import load_dotenv
 from policyengine_api.gcp_logging import logger
 from google.cloud.workflows import executions_v1
 
-
 load_dotenv()
 
 ExecutionState = executions_v1.types.Execution.State

--- a/policyengine_api/routes/ai_prompt_routes.py
+++ b/policyengine_api/routes/ai_prompt_routes.py
@@ -8,7 +8,6 @@ from policyengine_api.utils.payload_validators.ai import (
 from werkzeug.exceptions import NotFound, BadRequest
 import json
 
-
 ai_prompt_bp = Blueprint("ai_prompt", __name__)
 ai_prompt_service = AIPromptService()
 

--- a/policyengine_api/routes/household_routes.py
+++ b/policyengine_api/routes/household_routes.py
@@ -8,7 +8,6 @@ from policyengine_api.utils.payload_validators import (
     validate_country,
 )
 
-
 household_bp = Blueprint("household", __name__)
 household_service = HouseholdService()
 

--- a/policyengine_api/routes/report_output_routes.py
+++ b/policyengine_api/routes/report_output_routes.py
@@ -6,7 +6,6 @@ from policyengine_api.services.report_output_service import ReportOutputService
 from policyengine_api.constants import CURRENT_YEAR
 from policyengine_api.utils.payload_validators import validate_country
 
-
 report_output_bp = Blueprint("report_output", __name__)
 report_output_service = ReportOutputService()
 

--- a/policyengine_api/routes/simulation_routes.py
+++ b/policyengine_api/routes/simulation_routes.py
@@ -6,7 +6,6 @@ from policyengine_api.services.simulation_service import SimulationService
 from policyengine_api.utils.payload_validators import validate_country
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 
-
 simulation_bp = Blueprint("simulation", __name__)
 simulation_service = SimulationService()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ import redis
 import pytest
 from policyengine_api.api import app
 
-
 # Add the project root directory to PYTHONPATH
 root_dir = Path(__file__).parent
 sys.path.append(str(root_dir))

--- a/tests/fixtures/libs/simulation_api_modal.py
+++ b/tests/fixtures/libs/simulation_api_modal.py
@@ -16,7 +16,6 @@ from policyengine_api.constants import (
     MODAL_EXECUTION_STATUS_FAILED,
 )
 
-
 # Mock data constants
 MOCK_MODAL_JOB_ID = "fc-abc123xyz"
 MOCK_MODAL_BASE_URL = "https://test-modal-api.modal.run"

--- a/tests/fixtures/services/household_fixtures.py
+++ b/tests/fixtures/services/household_fixtures.py
@@ -2,7 +2,6 @@ import pytest
 import json
 from unittest.mock import patch
 
-
 valid_request_body = {
     "data": {"people": {"person1": {"age": 30, "income": 50000}}},
     "label": "Test Household",

--- a/tests/fixtures/services/tracer_analysis_service.py
+++ b/tests/fixtures/services/tracer_analysis_service.py
@@ -5,7 +5,6 @@ from policyengine_api.services.tracer_analysis_service import (
 )
 from unittest.mock import patch
 
-
 valid_tracer_output = [
     "        snap<2027, (default)> = [6769.799]",
     "          snap<2027-01, (default)> = [561.117]",

--- a/tests/fixtures/services/user_service.py
+++ b/tests/fixtures/services/user_service.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 valid_user_record = {
     "user_id": 1,
     "auth0_id": "123",

--- a/tests/unit/services/test_tracer_analysis_service.py
+++ b/tests/unit/services/test_tracer_analysis_service.py
@@ -7,7 +7,6 @@ import logging
 
 from tests.fixtures.services.tracer_analysis_service import *
 
-
 logger = logging.getLogger(__name__)
 test_service = TracerAnalysisService()
 


### PR DESCRIPTION
## Summary

Adds auto-install configuration for the policyengine-claude plugin.

## What This Does

When you trust this repo in Claude Code, the [policyengine-claude plugin](https://github.com/PolicyEngine/policyengine-claude) auto-installs, providing:

- **15+ specialized agents** for PolicyEngine development
- **Slash commands** like `/encode-policy`, `/review-pr`
- **Skills** for simulation patterns and code standards

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)