### PR TITLE
Fixes #3106: Update model version check to only verify US versions

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Updated model version alignment check to use Modal gateway instead of GCP and only verify US versions.


### PR DESCRIPTION
## Summary

- Updates the model version alignment check script to use Modal gateway instead of GCP
- Removes UK version checking since policyengine-uk doesn't support the older Python versions that API v1 runs on
- Adds explanatory comments documenting why UK versions are not checked
- Maintains backwards compatibility by accepting but ignoring the `-uk` flag

## Test plan

- [x] Verified script works with US version check only
- [x] Confirmed script correctly ignores UK version flag
- [x] Tested failure case when US version doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)