### PR TITLE
Update policyengine dependency constraint

### DIFF
--- a/changelog.d/update-policyengine-constraint.changed.md
+++ b/changelog.d/update-policyengine-constraint.changed.md
@@ -1,0 +1,1 @@
+Bumped the `policyengine` dependency constraint to require at least 0.12.0 and stay below 1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "policyengine_uk==2.39.0",
     "policyengine_us==1.632.5",
     "policyengine_core>=3.16.6",
-    "policyengine>=0.7.0",
+    "policyengine>=0.12.0,<1",
     "pydantic",
     "pymysql",
     "python-dotenv",


### PR DESCRIPTION
Fixes #3381

## Summary
- Updated the policyengine dependency constraint to >=0.12.0,<1.
- Added a changelog fragment.

## Checks
- make format
- ruff format --check .
- ruff check . (fails on existing repo-wide lint issues; first example: gcp/export.py F841)