### PR TITLE
Add internal services for report output runs

### DIFF
--- a/changelog.d/report-output-run-stage-2.changed.md
+++ b/changelog.d/report-output-run-stage-2.changed.md
@@ -1,0 +1,1 @@
+Add internal report and simulation spec, alias, and run services for the report-output run migration.

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -1,5 +1,5 @@
 import sqlite3
-from policyengine_api.constants import REPO, VERSION, COUNTRY_PACKAGE_VERSIONS
+from policyengine_api.constants import REPO, COUNTRY_PACKAGE_VERSIONS
 from policyengine_api.utils import hash_object
 from pathlib import Path
 from dotenv import load_dotenv
@@ -41,6 +41,29 @@ class _ResultProxy:
         return remaining
 
 
+class _TransactionProxy:
+    """Execute queries against an existing connection inside a transaction."""
+
+    def __init__(self, connection, local: bool):
+        self._connection = connection
+        self._local = local
+
+    def query(self, *query):
+        if self._local:
+            cursor = self._connection.cursor()
+            return cursor.execute(*query)
+
+        query = list(query)
+        main_query = query[0].replace("?", "%s")
+        query[0] = main_query
+        params = query[1] if len(query) > 1 else None
+        if params is not None:
+            result = self._connection.exec_driver_sql(main_query, params)
+        else:
+            result = self._connection.exec_driver_sql(main_query)
+        return _ResultProxy(result)
+
+
 class PolicyEngineDatabase:
     """
     A wrapper around the database connection.
@@ -49,6 +72,13 @@ class PolicyEngineDatabase:
     """
 
     household_cache: dict = {}
+
+    @staticmethod
+    def _dict_factory(cursor, row):
+        d = {}
+        for idx, col in enumerate(cursor.description):
+            d[col[0]] = row[idx]
+        return d
 
     def __init__(
         self,
@@ -91,7 +121,7 @@ class PolicyEngineDatabase:
         try:
             self.pool.dispose()
             self.connector.close()
-        except:
+        except Exception:
             pass
 
     def _execute_remote(self, query_args):
@@ -110,17 +140,22 @@ class PolicyEngineDatabase:
             # connection context closing
             return _ResultProxy(result)
 
+    def _execute_remote_transaction(self, callback):
+        with self.pool.connect() as conn:
+            transaction = conn.begin()
+            proxy = _TransactionProxy(conn, local=False)
+            try:
+                result = callback(proxy)
+                transaction.commit()
+                return result
+            except Exception:
+                transaction.rollback()
+                raise
+
     def query(self, *query):
         if self.local:
             with sqlite3.connect(self.db_url) as conn:
-
-                def dict_factory(cursor, row):
-                    d = {}
-                    for idx, col in enumerate(cursor.description):
-                        d[col[0]] = row[idx]
-                    return d
-
-                conn.row_factory = dict_factory
+                conn.row_factory = self._dict_factory
                 cursor = conn.cursor()
                 return cursor.execute(*query)
         else:
@@ -134,13 +169,43 @@ class PolicyEngineDatabase:
             except (
                 sqlalchemy.exc.InterfaceError,
                 sqlalchemy.exc.OperationalError,
-            ) as e:
+            ):
                 try:
                     self._close_pool()
                     self._create_pool()
                     return self._execute_remote(query)
                 except Exception as e:
                     raise e
+
+    def transaction(self, callback):
+        if self.local:
+            connection = getattr(self, "_connection", None)
+            owns_connection = connection is None
+            if owns_connection:
+                connection = sqlite3.connect(self.db_url)
+            connection.row_factory = self._dict_factory
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                proxy = _TransactionProxy(connection, local=True)
+                result = callback(proxy)
+                connection.commit()
+                return result
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                if owns_connection:
+                    connection.close()
+
+        try:
+            return self._execute_remote_transaction(callback)
+        except (
+            sqlalchemy.exc.InterfaceError,
+            sqlalchemy.exc.OperationalError,
+        ):
+            self._close_pool()
+            self._create_pool()
+            return self._execute_remote_transaction(callback)
 
     def initialize(self):
         """
@@ -175,7 +240,7 @@ class PolicyEngineDatabase:
             range(1, 1 + len(COUNTRY_PACKAGE_VERSIONS)),
         ):
             self.query(
-                f"INSERT INTO policy (id, country_id, label, api_version, policy_json, policy_hash) VALUES (?, ?, ?, ?, ?, ?)",
+                "INSERT INTO policy (id, country_id, label, api_version, policy_json, policy_hash) VALUES (?, ?, ?, ?, ?, ?)",
                 (
                     policy_id,
                     country_id,

--- a/policyengine_api/services/report_output_alias_service.py
+++ b/policyengine_api/services/report_output_alias_service.py
@@ -4,12 +4,16 @@ from policyengine_api.data import database
 
 
 class ReportOutputAliasService:
-    def _report_output_exists(self, report_output_id: int) -> bool:
+    def _get_report_output_row(self, report_output_id: int) -> dict | None:
         row: Row | None = database.query(
-            "SELECT id FROM report_outputs WHERE id = ?",
+            """
+            SELECT id, country_id, simulation_1_id, simulation_2_id, year
+            FROM report_outputs
+            WHERE id = ?
+            """,
             (report_output_id,),
         ).fetchone()
-        return row is not None
+        return dict(row) if row is not None else None
 
     def get_alias(self, legacy_report_output_id: int) -> dict | None:
         row: Row | None = database.query(
@@ -27,7 +31,7 @@ class ReportOutputAliasService:
         alias = self.get_alias(requested_report_output_id)
         if alias is not None:
             canonical_report_output_id = alias["canonical_report_output_id"]
-            if not self._report_output_exists(canonical_report_output_id):
+            if self._get_report_output_row(canonical_report_output_id) is None:
                 raise ValueError(
                     "Alias points to missing canonical report output "
                     f"#{canonical_report_output_id}"
@@ -45,29 +49,49 @@ class ReportOutputAliasService:
         legacy_report_output_id: int,
         canonical_report_output_id: int,
     ) -> bool:
-        if not self._report_output_exists(canonical_report_output_id):
+        legacy_report_output = self._get_report_output_row(legacy_report_output_id)
+        if legacy_report_output is None:
+            raise ValueError(
+                f"Legacy report output #{legacy_report_output_id} not found"
+            )
+
+        canonical_report_output = self._get_report_output_row(
+            canonical_report_output_id
+        )
+        if canonical_report_output is None:
             raise ValueError(
                 f"Canonical report output #{canonical_report_output_id} not found"
             )
+        if legacy_report_output_id == canonical_report_output_id:
+            raise ValueError("Legacy and canonical report outputs must be different")
 
         existing_alias = self.get_alias(legacy_report_output_id)
-        if existing_alias is None:
-            database.query(
-                """
-                INSERT INTO legacy_report_output_aliases
-                (legacy_report_output_id, canonical_report_output_id)
-                VALUES (?, ?)
-                """,
-                (legacy_report_output_id, canonical_report_output_id),
+        if existing_alias is not None:
+            if (
+                existing_alias["canonical_report_output_id"]
+                == canonical_report_output_id
+            ):
+                return True
+
+            raise ValueError(
+                "Legacy report output alias already points to canonical report output "
+                f"#{existing_alias['canonical_report_output_id']}"
             )
-            return True
 
-        if existing_alias["canonical_report_output_id"] == canonical_report_output_id:
-            return True
-
-        raise ValueError(
-            "Legacy report output alias already points to canonical report output "
-            f"#{existing_alias['canonical_report_output_id']}"
+        logical_key = ("country_id", "simulation_1_id", "simulation_2_id", "year")
+        if any(
+            legacy_report_output[field] != canonical_report_output[field]
+            for field in logical_key
+        ):
+            raise ValueError(
+                "Legacy and canonical report outputs must describe the same report"
+            )
+        database.query(
+            """
+            INSERT INTO legacy_report_output_aliases
+            (legacy_report_output_id, canonical_report_output_id)
+            VALUES (?, ?)
+            """,
+            (legacy_report_output_id, canonical_report_output_id),
         )
-
         return True

--- a/policyengine_api/services/report_output_alias_service.py
+++ b/policyengine_api/services/report_output_alias_service.py
@@ -1,0 +1,55 @@
+from sqlalchemy.engine.row import Row
+
+from policyengine_api.data import database
+
+
+class ReportOutputAliasService:
+    def get_alias(self, legacy_report_output_id: int) -> dict | None:
+        row: Row | None = database.query(
+            """
+            SELECT * FROM legacy_report_output_aliases
+            WHERE legacy_report_output_id = ?
+            """,
+            (legacy_report_output_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def resolve_canonical_report_output_id(
+        self, requested_report_output_id: int
+    ) -> int | None:
+        alias = self.get_alias(requested_report_output_id)
+        if alias is not None:
+            return alias["canonical_report_output_id"]
+
+        row: Row | None = database.query(
+            "SELECT id FROM report_outputs WHERE id = ?",
+            (requested_report_output_id,),
+        ).fetchone()
+        return row["id"] if row is not None else None
+
+    def set_alias(
+        self,
+        legacy_report_output_id: int,
+        canonical_report_output_id: int,
+    ) -> bool:
+        existing_alias = self.get_alias(legacy_report_output_id)
+        if existing_alias is None:
+            database.query(
+                """
+                INSERT INTO legacy_report_output_aliases
+                (legacy_report_output_id, canonical_report_output_id)
+                VALUES (?, ?)
+                """,
+                (legacy_report_output_id, canonical_report_output_id),
+            )
+            return True
+
+        database.query(
+            """
+            UPDATE legacy_report_output_aliases
+            SET canonical_report_output_id = ?
+            WHERE legacy_report_output_id = ?
+            """,
+            (canonical_report_output_id, legacy_report_output_id),
+        )
+        return True

--- a/policyengine_api/services/report_output_alias_service.py
+++ b/policyengine_api/services/report_output_alias_service.py
@@ -4,6 +4,13 @@ from policyengine_api.data import database
 
 
 class ReportOutputAliasService:
+    def _report_output_exists(self, report_output_id: int) -> bool:
+        row: Row | None = database.query(
+            "SELECT id FROM report_outputs WHERE id = ?",
+            (report_output_id,),
+        ).fetchone()
+        return row is not None
+
     def get_alias(self, legacy_report_output_id: int) -> dict | None:
         row: Row | None = database.query(
             """
@@ -19,7 +26,13 @@ class ReportOutputAliasService:
     ) -> int | None:
         alias = self.get_alias(requested_report_output_id)
         if alias is not None:
-            return alias["canonical_report_output_id"]
+            canonical_report_output_id = alias["canonical_report_output_id"]
+            if not self._report_output_exists(canonical_report_output_id):
+                raise ValueError(
+                    "Alias points to missing canonical report output "
+                    f"#{canonical_report_output_id}"
+                )
+            return canonical_report_output_id
 
         row: Row | None = database.query(
             "SELECT id FROM report_outputs WHERE id = ?",
@@ -32,6 +45,11 @@ class ReportOutputAliasService:
         legacy_report_output_id: int,
         canonical_report_output_id: int,
     ) -> bool:
+        if not self._report_output_exists(canonical_report_output_id):
+            raise ValueError(
+                f"Canonical report output #{canonical_report_output_id} not found"
+            )
+
         existing_alias = self.get_alias(legacy_report_output_id)
         if existing_alias is None:
             database.query(
@@ -44,12 +62,12 @@ class ReportOutputAliasService:
             )
             return True
 
-        database.query(
-            """
-            UPDATE legacy_report_output_aliases
-            SET canonical_report_output_id = ?
-            WHERE legacy_report_output_id = ?
-            """,
-            (canonical_report_output_id, legacy_report_output_id),
+        if existing_alias["canonical_report_output_id"] == canonical_report_output_id:
+            return True
+
+        raise ValueError(
+            "Legacy report output alias already points to canonical report output "
+            f"#{existing_alias['canonical_report_output_id']}"
         )
+
         return True

--- a/policyengine_api/services/report_run_service.py
+++ b/policyengine_api/services/report_run_service.py
@@ -1,7 +1,9 @@
 import json
+import sqlite3
 import uuid
 from typing import Any
 
+import sqlalchemy.exc
 from sqlalchemy.engine.row import Row
 
 from policyengine_api.data import database
@@ -18,9 +20,17 @@ REPORT_RUN_VERSION_FIELDS = (
     "resolved_dataset",
     "resolved_options_hash",
 )
+MAX_CREATE_RUN_ATTEMPTS = 3
 
 
 class ReportRunService:
+    def _report_output_exists(self, report_output_id: int) -> bool:
+        row: Row | None = database.query(
+            "SELECT id FROM report_outputs WHERE id = ?",
+            (report_output_id,),
+        ).fetchone()
+        return row is not None
+
     def _next_run_sequence(self, report_output_id: int) -> int:
         row: Row | None = database.query(
             """
@@ -50,6 +60,14 @@ class ReportRunService:
             )
         return run
 
+    def _is_sequence_conflict(self, error: Exception) -> bool:
+        message = str(error)
+        return (
+            "report_output_run_sequence_idx" in message
+            or "report_output_runs.report_output_id, report_output_runs.run_sequence"
+            in message
+        )
+
     def create_report_output_run(
         self,
         report_output_id: int,
@@ -62,35 +80,53 @@ class ReportRunService:
         version_manifest: dict[str, str | None] | None = None,
         run_id: str | None = None,
     ) -> dict:
+        if not self._report_output_exists(report_output_id):
+            raise ValueError(f"Report output #{report_output_id} not found")
+
         run_id = run_id or str(uuid.uuid4())
-        run_sequence = self._next_run_sequence(report_output_id)
         version_manifest = version_manifest or {}
 
-        database.query(
-            f"""
-            INSERT INTO report_output_runs (
-                id, report_output_id, run_sequence, status, output, error_message,
-                trigger_type, requested_at, started_at, finished_at, source_run_id,
-                report_spec_snapshot_json, {", ".join(REPORT_RUN_VERSION_FIELDS)}
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                run_id,
-                report_output_id,
-                run_sequence,
-                status,
-                self._serialize_json(output),
-                error_message,
-                trigger_type,
-                None,
-                None,
-                None,
-                source_run_id,
-                self._serialize_json(report_spec_snapshot),
-                *[version_manifest.get(field) for field in REPORT_RUN_VERSION_FIELDS],
-            ),
+        for attempt in range(MAX_CREATE_RUN_ATTEMPTS):
+            run_sequence = self._next_run_sequence(report_output_id)
+            try:
+                database.query(
+                    f"""
+                    INSERT INTO report_output_runs (
+                        id, report_output_id, run_sequence, status, output, error_message,
+                        trigger_type, requested_at, started_at, finished_at, source_run_id,
+                        report_spec_snapshot_json, {", ".join(REPORT_RUN_VERSION_FIELDS)}
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id,
+                        report_output_id,
+                        run_sequence,
+                        status,
+                        self._serialize_json(output),
+                        error_message,
+                        trigger_type,
+                        None,
+                        None,
+                        None,
+                        source_run_id,
+                        self._serialize_json(report_spec_snapshot),
+                        *[
+                            version_manifest.get(field)
+                            for field in REPORT_RUN_VERSION_FIELDS
+                        ],
+                    ),
+                )
+                return self.get_report_output_run(run_id)
+            except (sqlite3.IntegrityError, sqlalchemy.exc.IntegrityError) as error:
+                if (
+                    attempt == MAX_CREATE_RUN_ATTEMPTS - 1
+                    or not self._is_sequence_conflict(error)
+                ):
+                    raise
+
+        raise RuntimeError(
+            f"Unable to allocate report output run sequence for #{report_output_id}"
         )
-        return self.get_report_output_run(run_id)
 
     def get_report_output_run(self, run_id: str) -> dict | None:
         row: Row | None = database.query(
@@ -124,7 +160,13 @@ class ReportRunService:
 
     def select_display_run(self, report_output: dict) -> dict | None:
         if report_output.get("active_run_id"):
-            return self.get_report_output_run(report_output["active_run_id"])
+            active_run = self.get_report_output_run(report_output["active_run_id"])
+            if active_run is not None:
+                return active_run
         if report_output.get("latest_successful_run_id"):
-            return self.get_report_output_run(report_output["latest_successful_run_id"])
+            latest_successful_run = self.get_report_output_run(
+                report_output["latest_successful_run_id"]
+            )
+            if latest_successful_run is not None:
+                return latest_successful_run
         return self.get_newest_report_output_run(report_output["id"])

--- a/policyengine_api/services/report_run_service.py
+++ b/policyengine_api/services/report_run_service.py
@@ -1,9 +1,7 @@
 import json
-import sqlite3
 import uuid
 from typing import Any
 
-import sqlalchemy.exc
 from sqlalchemy.engine.row import Row
 
 from policyengine_api.data import database
@@ -20,28 +18,9 @@ REPORT_RUN_VERSION_FIELDS = (
     "resolved_dataset",
     "resolved_options_hash",
 )
-MAX_CREATE_RUN_ATTEMPTS = 3
 
 
 class ReportRunService:
-    def _report_output_exists(self, report_output_id: int) -> bool:
-        row: Row | None = database.query(
-            "SELECT id FROM report_outputs WHERE id = ?",
-            (report_output_id,),
-        ).fetchone()
-        return row is not None
-
-    def _next_run_sequence(self, report_output_id: int) -> int:
-        row: Row | None = database.query(
-            """
-            SELECT COALESCE(MAX(run_sequence), 0) AS max_run_sequence
-            FROM report_output_runs
-            WHERE report_output_id = ?
-            """,
-            (report_output_id,),
-        ).fetchone()
-        return int(row["max_run_sequence"]) + 1 if row is not None else 1
-
     def _serialize_json(
         self, value: dict[str, Any] | list[Any] | str | None
     ) -> str | None:
@@ -60,14 +39,6 @@ class ReportRunService:
             )
         return run
 
-    def _is_sequence_conflict(self, error: Exception) -> bool:
-        message = str(error)
-        return (
-            "report_output_run_sequence_idx" in message
-            or "report_output_runs.report_output_id, report_output_runs.run_sequence"
-            in message
-        )
-
     def create_report_output_run(
         self,
         report_output_id: int,
@@ -80,53 +51,62 @@ class ReportRunService:
         version_manifest: dict[str, str | None] | None = None,
         run_id: str | None = None,
     ) -> dict:
-        if not self._report_output_exists(report_output_id):
-            raise ValueError(f"Report output #{report_output_id} not found")
-
         run_id = run_id or str(uuid.uuid4())
         version_manifest = version_manifest or {}
+        lock_clause = "" if database.local else " FOR UPDATE"
 
-        for attempt in range(MAX_CREATE_RUN_ATTEMPTS):
-            run_sequence = self._next_run_sequence(report_output_id)
-            try:
-                database.query(
-                    f"""
-                    INSERT INTO report_output_runs (
-                        id, report_output_id, run_sequence, status, output, error_message,
-                        trigger_type, requested_at, started_at, finished_at, source_run_id,
-                        report_spec_snapshot_json, {", ".join(REPORT_RUN_VERSION_FIELDS)}
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        run_id,
-                        report_output_id,
-                        run_sequence,
-                        status,
-                        self._serialize_json(output),
-                        error_message,
-                        trigger_type,
-                        None,
-                        None,
-                        None,
-                        source_run_id,
-                        self._serialize_json(report_spec_snapshot),
-                        *[
-                            version_manifest.get(field)
-                            for field in REPORT_RUN_VERSION_FIELDS
-                        ],
-                    ),
-                )
-                return self.get_report_output_run(run_id)
-            except (sqlite3.IntegrityError, sqlalchemy.exc.IntegrityError) as error:
-                if (
-                    attempt == MAX_CREATE_RUN_ATTEMPTS - 1
-                    or not self._is_sequence_conflict(error)
-                ):
-                    raise
+        def create_run_transaction(tx) -> None:
+            parent_row: Row | None = tx.query(
+                f"SELECT id FROM report_outputs WHERE id = ?{lock_clause}",
+                (report_output_id,),
+            ).fetchone()
+            if parent_row is None:
+                raise ValueError(f"Report output #{report_output_id} not found")
 
-        raise RuntimeError(
-            f"Unable to allocate report output run sequence for #{report_output_id}"
-        )
+            run_sequence_row: Row | None = tx.query(
+                """
+                SELECT COALESCE(MAX(run_sequence), 0) AS max_run_sequence
+                FROM report_output_runs
+                WHERE report_output_id = ?
+                """,
+                (report_output_id,),
+            ).fetchone()
+            run_sequence = (
+                int(run_sequence_row["max_run_sequence"]) + 1
+                if run_sequence_row is not None
+                else 1
+            )
+
+            tx.query(
+                f"""
+                INSERT INTO report_output_runs (
+                    id, report_output_id, run_sequence, status, output, error_message,
+                    trigger_type, requested_at, started_at, finished_at, source_run_id,
+                    report_spec_snapshot_json, {", ".join(REPORT_RUN_VERSION_FIELDS)}
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    report_output_id,
+                    run_sequence,
+                    status,
+                    self._serialize_json(output),
+                    error_message,
+                    trigger_type,
+                    None,
+                    None,
+                    None,
+                    source_run_id,
+                    self._serialize_json(report_spec_snapshot),
+                    *[
+                        version_manifest.get(field)
+                        for field in REPORT_RUN_VERSION_FIELDS
+                    ],
+                ),
+            )
+
+        database.transaction(create_run_transaction)
+        return self.get_report_output_run(run_id)
 
     def get_report_output_run(self, run_id: str) -> dict | None:
         row: Row | None = database.query(

--- a/policyengine_api/services/report_run_service.py
+++ b/policyengine_api/services/report_run_service.py
@@ -1,0 +1,130 @@
+import json
+import uuid
+from typing import Any
+
+from sqlalchemy.engine.row import Row
+
+from policyengine_api.data import database
+
+
+REPORT_RUN_VERSION_FIELDS = (
+    "country_package_version",
+    "policyengine_version",
+    "data_version",
+    "runtime_app_name",
+    "report_cache_version",
+    "simulation_cache_version",
+    "requested_version_override",
+    "resolved_dataset",
+    "resolved_options_hash",
+)
+
+
+class ReportRunService:
+    def _next_run_sequence(self, report_output_id: int) -> int:
+        row: Row | None = database.query(
+            """
+            SELECT COALESCE(MAX(run_sequence), 0) AS max_run_sequence
+            FROM report_output_runs
+            WHERE report_output_id = ?
+            """,
+            (report_output_id,),
+        ).fetchone()
+        return int(row["max_run_sequence"]) + 1 if row is not None else 1
+
+    def _serialize_json(
+        self, value: dict[str, Any] | list[Any] | str | None
+    ) -> str | None:
+        if value is None or isinstance(value, str):
+            return value
+        return json.dumps(value)
+
+    def _parse_run_row(self, row: Row | dict | None) -> dict | None:
+        if row is None:
+            return None
+
+        run = dict(row)
+        if isinstance(run.get("report_spec_snapshot_json"), str):
+            run["report_spec_snapshot_json"] = json.loads(
+                run["report_spec_snapshot_json"]
+            )
+        return run
+
+    def create_report_output_run(
+        self,
+        report_output_id: int,
+        status: str = "pending",
+        trigger_type: str = "initial",
+        output: dict[str, Any] | list[Any] | str | None = None,
+        error_message: str | None = None,
+        source_run_id: str | None = None,
+        report_spec_snapshot: dict[str, Any] | str | None = None,
+        version_manifest: dict[str, str | None] | None = None,
+        run_id: str | None = None,
+    ) -> dict:
+        run_id = run_id or str(uuid.uuid4())
+        run_sequence = self._next_run_sequence(report_output_id)
+        version_manifest = version_manifest or {}
+
+        database.query(
+            f"""
+            INSERT INTO report_output_runs (
+                id, report_output_id, run_sequence, status, output, error_message,
+                trigger_type, requested_at, started_at, finished_at, source_run_id,
+                report_spec_snapshot_json, {", ".join(REPORT_RUN_VERSION_FIELDS)}
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                report_output_id,
+                run_sequence,
+                status,
+                self._serialize_json(output),
+                error_message,
+                trigger_type,
+                None,
+                None,
+                None,
+                source_run_id,
+                self._serialize_json(report_spec_snapshot),
+                *[version_manifest.get(field) for field in REPORT_RUN_VERSION_FIELDS],
+            ),
+        )
+        return self.get_report_output_run(run_id)
+
+    def get_report_output_run(self, run_id: str) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM report_output_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        return self._parse_run_row(row)
+
+    def list_report_output_runs(self, report_output_id: int) -> list[dict]:
+        rows = database.query(
+            """
+            SELECT * FROM report_output_runs
+            WHERE report_output_id = ?
+            ORDER BY run_sequence ASC
+            """,
+            (report_output_id,),
+        ).fetchall()
+        return [self._parse_run_row(row) for row in rows]
+
+    def get_newest_report_output_run(self, report_output_id: int) -> dict | None:
+        row: Row | None = database.query(
+            """
+            SELECT * FROM report_output_runs
+            WHERE report_output_id = ?
+            ORDER BY run_sequence DESC
+            LIMIT 1
+            """,
+            (report_output_id,),
+        ).fetchone()
+        return self._parse_run_row(row)
+
+    def select_display_run(self, report_output: dict) -> dict | None:
+        if report_output.get("active_run_id"):
+            return self.get_report_output_run(report_output["active_run_id"])
+        if report_output.get("latest_successful_run_id"):
+            return self.get_report_output_run(report_output["latest_successful_run_id"])
+        return self.get_newest_report_output_run(report_output["id"])

--- a/policyengine_api/services/report_spec_service.py
+++ b/policyengine_api/services/report_spec_service.py
@@ -1,0 +1,183 @@
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+from sqlalchemy.engine.row import Row
+
+from policyengine_api.data import database
+
+REPORT_SPEC_SCHEMA_VERSION = 1
+REPORT_SPEC_STATUSES = {"explicit", "backfilled_assumed"}
+HOUSEHOLD_REPORT_KINDS = {"household_single", "household_comparison"}
+ECONOMY_REPORT_KINDS = {"economy_single", "economy_comparison"}
+
+
+class ReportSimulationInput(BaseModel):
+    population_type: Literal["household", "geography"]
+    population_id: str
+    policy_id: int
+
+
+class HouseholdReportSpec(BaseModel):
+    country_id: str
+    report_kind: Literal["household_single", "household_comparison"]
+    time_period: str
+    simulation_1: ReportSimulationInput
+    simulation_2: ReportSimulationInput | None = None
+
+
+class EconomyReportSpec(BaseModel):
+    country_id: str
+    report_kind: Literal["economy_single", "economy_comparison"]
+    time_period: str
+    region: str
+    baseline_policy_id: int
+    reform_policy_id: int
+    dataset: str = "default"
+    target: Literal["general", "cliff"] = "general"
+    options: dict[str, Any] = Field(default_factory=dict)
+
+
+ReportSpec = HouseholdReportSpec | EconomyReportSpec
+
+
+class ReportSpecService:
+    def _get_report_output_row(self, report_output_id: int) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def infer_report_kind(
+        self,
+        simulation_1: dict,
+        simulation_2: dict | None = None,
+    ) -> str:
+        population_type = simulation_1["population_type"]
+        if (
+            simulation_2 is not None
+            and simulation_2["population_type"] != population_type
+        ):
+            raise ValueError(
+                "Simulation population types must match to build a report spec"
+            )
+
+        if population_type == "household":
+            return (
+                "household_comparison"
+                if simulation_2 is not None
+                else "household_single"
+            )
+
+        if population_type == "geography":
+            return (
+                "economy_comparison" if simulation_2 is not None else "economy_single"
+            )
+
+        raise ValueError(f"Unsupported simulation population type: {population_type}")
+
+    def build_report_spec(
+        self,
+        report_output: dict,
+        simulation_1: dict,
+        simulation_2: dict | None = None,
+        dataset: str = "default",
+        target: Literal["general", "cliff"] = "general",
+        options: dict[str, Any] | None = None,
+    ) -> ReportSpec:
+        report_kind = self.infer_report_kind(simulation_1, simulation_2)
+        time_period = report_output["year"]
+
+        if report_kind in HOUSEHOLD_REPORT_KINDS:
+            return HouseholdReportSpec.model_validate(
+                {
+                    "country_id": report_output["country_id"],
+                    "report_kind": report_kind,
+                    "time_period": time_period,
+                    "simulation_1": {
+                        "population_type": simulation_1["population_type"],
+                        "population_id": simulation_1["population_id"],
+                        "policy_id": simulation_1["policy_id"],
+                    },
+                    "simulation_2": (
+                        {
+                            "population_type": simulation_2["population_type"],
+                            "population_id": simulation_2["population_id"],
+                            "policy_id": simulation_2["policy_id"],
+                        }
+                        if simulation_2 is not None
+                        else None
+                    ),
+                }
+            )
+
+        return EconomyReportSpec.model_validate(
+            {
+                "country_id": report_output["country_id"],
+                "report_kind": report_kind,
+                "time_period": time_period,
+                "region": simulation_1["population_id"],
+                "baseline_policy_id": simulation_1["policy_id"],
+                "reform_policy_id": (
+                    simulation_2["policy_id"]
+                    if simulation_2 is not None
+                    else simulation_1["policy_id"]
+                ),
+                "dataset": dataset,
+                "target": target,
+                "options": options or {},
+            }
+        )
+
+    def _parse_json_field(self, value: str | dict | None) -> dict | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
+
+    def _parse_report_spec(self, report_kind: str, raw_spec: dict) -> ReportSpec:
+        if report_kind in HOUSEHOLD_REPORT_KINDS:
+            return HouseholdReportSpec.model_validate(raw_spec)
+        if report_kind in ECONOMY_REPORT_KINDS:
+            return EconomyReportSpec.model_validate(raw_spec)
+        raise ValueError(f"Unsupported report kind: {report_kind}")
+
+    def get_report_spec(self, report_output_id: int) -> ReportSpec | None:
+        report_output = self._get_report_output_row(report_output_id)
+        if report_output is None or report_output["report_spec_json"] is None:
+            return None
+
+        raw_spec = self._parse_json_field(report_output["report_spec_json"])
+        return self._parse_report_spec(report_output["report_kind"], raw_spec)
+
+    def set_report_spec(
+        self,
+        report_output_id: int,
+        report_spec: ReportSpec,
+        report_spec_status: Literal["explicit", "backfilled_assumed"],
+        schema_version: int = REPORT_SPEC_SCHEMA_VERSION,
+    ) -> bool:
+        if report_spec_status not in REPORT_SPEC_STATUSES:
+            raise ValueError(f"Unsupported report spec status: {report_spec_status}")
+
+        report_output = self._get_report_output_row(report_output_id)
+        if report_output is None:
+            raise ValueError(f"Report output #{report_output_id} not found")
+
+        database.query(
+            """
+            UPDATE report_outputs
+            SET report_kind = ?, report_spec_json = ?, report_spec_schema_version = ?, report_spec_status = ?
+            WHERE id = ?
+            """,
+            (
+                report_spec.report_kind,
+                report_spec.model_dump_json(),
+                schema_version,
+                report_spec_status,
+                report_output_id,
+            ),
+        )
+        return True

--- a/policyengine_api/services/report_spec_service.py
+++ b/policyengine_api/services/report_spec_service.py
@@ -55,6 +55,61 @@ class ReportSpecService:
         ).fetchone()
         return dict(row) if row is not None else None
 
+    def _get_simulation_row(self, simulation_id: int) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def _get_linked_simulations(self, report_output: dict) -> tuple[dict, dict | None]:
+        simulation_1 = self._get_simulation_row(report_output["simulation_1_id"])
+        if simulation_1 is None:
+            raise ValueError(
+                "Report output references missing simulation "
+                f"#{report_output['simulation_1_id']}"
+            )
+
+        simulation_2 = None
+        if report_output["simulation_2_id"] is not None:
+            simulation_2 = self._get_simulation_row(report_output["simulation_2_id"])
+            if simulation_2 is None:
+                raise ValueError(
+                    "Report output references missing simulation "
+                    f"#{report_output['simulation_2_id']}"
+                )
+
+        return simulation_1, simulation_2
+
+    def _validate_report_simulation_linkage(
+        self,
+        report_output: dict,
+        simulation_1: dict,
+        simulation_2: dict | None = None,
+    ) -> None:
+        if simulation_1.get("id") != report_output["simulation_1_id"]:
+            raise ValueError(
+                "Simulation 1 must match report_output.simulation_1_id to build a "
+                "report spec"
+            )
+
+        report_simulation_2_id = report_output["simulation_2_id"]
+        if report_simulation_2_id is None:
+            if simulation_2 is not None:
+                raise ValueError("Report output does not reference a second simulation")
+            return
+
+        if simulation_2 is None:
+            raise ValueError(
+                "Report output requires a second simulation to build a comparison "
+                "report spec"
+            )
+        if simulation_2.get("id") != report_simulation_2_id:
+            raise ValueError(
+                "Simulation 2 must match report_output.simulation_2_id to build a "
+                "report spec"
+            )
+
     def _validate_report_country(
         self,
         report_output: dict,
@@ -152,6 +207,67 @@ class ReportSpecService:
             }
         )
 
+    def _validate_report_spec_matches_row(
+        self, report_output: dict, report_spec: ReportSpec
+    ) -> None:
+        simulation_1, simulation_2 = self._get_linked_simulations(report_output)
+        inferred_report_kind = self.infer_report_kind(simulation_1, simulation_2)
+        if report_spec.country_id != report_output["country_id"]:
+            raise ValueError("Report spec country must match report output country")
+        if report_spec.time_period != report_output["year"]:
+            raise ValueError("Report spec time_period must match report output year")
+        if report_spec.report_kind != inferred_report_kind:
+            raise ValueError("Report spec kind must match linked simulations")
+
+        if isinstance(report_spec, HouseholdReportSpec):
+            if report_spec.simulation_1.model_dump() != {
+                "population_type": simulation_1["population_type"],
+                "population_id": simulation_1["population_id"],
+                "policy_id": simulation_1["policy_id"],
+            }:
+                raise ValueError(
+                    "Report spec simulation_1 must match linked simulation 1"
+                )
+
+            expected_simulation_2 = (
+                {
+                    "population_type": simulation_2["population_type"],
+                    "population_id": simulation_2["population_id"],
+                    "policy_id": simulation_2["policy_id"],
+                }
+                if simulation_2 is not None
+                else None
+            )
+            actual_simulation_2 = (
+                report_spec.simulation_2.model_dump()
+                if report_spec.simulation_2 is not None
+                else None
+            )
+            if actual_simulation_2 != expected_simulation_2:
+                raise ValueError(
+                    "Report spec simulation_2 must match linked simulation 2"
+                )
+            return
+
+        expected_region = simulation_1["population_id"]
+        expected_baseline_policy_id = simulation_1["policy_id"]
+        expected_reform_policy_id = (
+            simulation_2["policy_id"]
+            if simulation_2 is not None
+            else simulation_1["policy_id"]
+        )
+
+        if report_spec.region != expected_region:
+            raise ValueError("Report spec region must match linked simulations")
+        if report_spec.baseline_policy_id != expected_baseline_policy_id:
+            raise ValueError(
+                "Report spec baseline_policy_id must match linked simulations"
+            )
+        if report_spec.reform_policy_id != expected_reform_policy_id:
+            raise ValueError(
+                "Report spec reform_policy_id must match linked simulations"
+            )
+
     def infer_report_kind(
         self,
         simulation_1: dict,
@@ -189,6 +305,9 @@ class ReportSpecService:
         target: Literal["general", "cliff"] = "general",
         options: dict[str, Any] | None = None,
     ) -> ReportSpec:
+        self._validate_report_simulation_linkage(
+            report_output, simulation_1, simulation_2
+        )
         report_kind = self.infer_report_kind(simulation_1, simulation_2)
         time_period = report_output["year"]
         self._validate_report_country(report_output, simulation_1, simulation_2)
@@ -234,7 +353,9 @@ class ReportSpecService:
 
         self._validate_schema_version(report_output["report_spec_schema_version"])
         raw_spec = self._parse_json_field(report_output["report_spec_json"])
-        return self._parse_report_spec(report_output["report_kind"], raw_spec)
+        report_spec = self._parse_report_spec(report_output["report_kind"], raw_spec)
+        self._validate_report_spec_matches_row(report_output, report_spec)
+        return report_spec
 
     def set_report_spec(
         self,
@@ -250,6 +371,7 @@ class ReportSpecService:
         report_output = self._get_report_output_row(report_output_id)
         if report_output is None:
             raise ValueError(f"Report output #{report_output_id} not found")
+        self._validate_report_spec_matches_row(report_output, report_spec)
 
         database.query(
             """

--- a/policyengine_api/services/report_spec_service.py
+++ b/policyengine_api/services/report_spec_service.py
@@ -42,12 +42,115 @@ ReportSpec = HouseholdReportSpec | EconomyReportSpec
 
 
 class ReportSpecService:
+    def _validate_schema_version(self, schema_version: int | None) -> None:
+        if schema_version != REPORT_SPEC_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported report spec schema version: {schema_version}"
+            )
+
     def _get_report_output_row(self, report_output_id: int) -> dict | None:
         row: Row | None = database.query(
             "SELECT * FROM report_outputs WHERE id = ?",
             (report_output_id,),
         ).fetchone()
         return dict(row) if row is not None else None
+
+    def _validate_report_country(
+        self,
+        report_output: dict,
+        simulation_1: dict,
+        simulation_2: dict | None = None,
+    ) -> None:
+        report_country_id = report_output["country_id"]
+        if simulation_1["country_id"] != report_country_id:
+            raise ValueError(
+                "Simulation 1 country must match report output country to build a "
+                "report spec"
+            )
+        if simulation_2 is not None and simulation_2["country_id"] != report_country_id:
+            raise ValueError(
+                "Simulation 2 country must match report output country to build a "
+                "report spec"
+            )
+
+    def _build_household_report_spec(
+        self,
+        report_output: dict,
+        report_kind: str,
+        simulation_1: dict,
+        simulation_2: dict | None,
+        time_period: str,
+    ) -> HouseholdReportSpec:
+        if simulation_1["population_type"] != "household":
+            raise ValueError("Household report specs require household simulations")
+        if (
+            simulation_2 is not None
+            and simulation_2["population_id"] != simulation_1["population_id"]
+        ):
+            raise ValueError(
+                "Household comparison report specs require matching household IDs"
+            )
+
+        return HouseholdReportSpec.model_validate(
+            {
+                "country_id": report_output["country_id"],
+                "report_kind": report_kind,
+                "time_period": time_period,
+                "simulation_1": {
+                    "population_type": simulation_1["population_type"],
+                    "population_id": simulation_1["population_id"],
+                    "policy_id": simulation_1["policy_id"],
+                },
+                "simulation_2": (
+                    {
+                        "population_type": simulation_2["population_type"],
+                        "population_id": simulation_2["population_id"],
+                        "policy_id": simulation_2["policy_id"],
+                    }
+                    if simulation_2 is not None
+                    else None
+                ),
+            }
+        )
+
+    def _build_economy_report_spec(
+        self,
+        report_output: dict,
+        report_kind: str,
+        simulation_1: dict,
+        simulation_2: dict | None,
+        time_period: str,
+        dataset: str,
+        target: Literal["general", "cliff"],
+        options: dict[str, Any] | None,
+    ) -> EconomyReportSpec:
+        if simulation_1["population_type"] != "geography":
+            raise ValueError("Economy report specs require geography simulations")
+        if (
+            simulation_2 is not None
+            and simulation_2["population_id"] != simulation_1["population_id"]
+        ):
+            raise ValueError(
+                "Economy comparison report specs require matching geography IDs"
+            )
+
+        return EconomyReportSpec.model_validate(
+            {
+                "country_id": report_output["country_id"],
+                "report_kind": report_kind,
+                "time_period": time_period,
+                "region": simulation_1["population_id"],
+                "baseline_policy_id": simulation_1["policy_id"],
+                "reform_policy_id": (
+                    simulation_2["policy_id"]
+                    if simulation_2 is not None
+                    else simulation_1["policy_id"]
+                ),
+                "dataset": dataset,
+                "target": target,
+                "options": options or {},
+            }
+        )
 
     def infer_report_kind(
         self,
@@ -88,46 +191,26 @@ class ReportSpecService:
     ) -> ReportSpec:
         report_kind = self.infer_report_kind(simulation_1, simulation_2)
         time_period = report_output["year"]
+        self._validate_report_country(report_output, simulation_1, simulation_2)
 
         if report_kind in HOUSEHOLD_REPORT_KINDS:
-            return HouseholdReportSpec.model_validate(
-                {
-                    "country_id": report_output["country_id"],
-                    "report_kind": report_kind,
-                    "time_period": time_period,
-                    "simulation_1": {
-                        "population_type": simulation_1["population_type"],
-                        "population_id": simulation_1["population_id"],
-                        "policy_id": simulation_1["policy_id"],
-                    },
-                    "simulation_2": (
-                        {
-                            "population_type": simulation_2["population_type"],
-                            "population_id": simulation_2["population_id"],
-                            "policy_id": simulation_2["policy_id"],
-                        }
-                        if simulation_2 is not None
-                        else None
-                    ),
-                }
+            return self._build_household_report_spec(
+                report_output=report_output,
+                report_kind=report_kind,
+                simulation_1=simulation_1,
+                simulation_2=simulation_2,
+                time_period=time_period,
             )
 
-        return EconomyReportSpec.model_validate(
-            {
-                "country_id": report_output["country_id"],
-                "report_kind": report_kind,
-                "time_period": time_period,
-                "region": simulation_1["population_id"],
-                "baseline_policy_id": simulation_1["policy_id"],
-                "reform_policy_id": (
-                    simulation_2["policy_id"]
-                    if simulation_2 is not None
-                    else simulation_1["policy_id"]
-                ),
-                "dataset": dataset,
-                "target": target,
-                "options": options or {},
-            }
+        return self._build_economy_report_spec(
+            report_output=report_output,
+            report_kind=report_kind,
+            simulation_1=simulation_1,
+            simulation_2=simulation_2,
+            time_period=time_period,
+            dataset=dataset,
+            target=target,
+            options=options,
         )
 
     def _parse_json_field(self, value: str | dict | None) -> dict | None:
@@ -149,6 +232,7 @@ class ReportSpecService:
         if report_output is None or report_output["report_spec_json"] is None:
             return None
 
+        self._validate_schema_version(report_output["report_spec_schema_version"])
         raw_spec = self._parse_json_field(report_output["report_spec_json"])
         return self._parse_report_spec(report_output["report_kind"], raw_spec)
 
@@ -161,6 +245,7 @@ class ReportSpecService:
     ) -> bool:
         if report_spec_status not in REPORT_SPEC_STATUSES:
             raise ValueError(f"Unsupported report spec status: {report_spec_status}")
+        self._validate_schema_version(schema_version)
 
         report_output = self._get_report_output_row(report_output_id)
         if report_output is None:

--- a/policyengine_api/services/simulation_run_service.py
+++ b/policyengine_api/services/simulation_run_service.py
@@ -1,7 +1,9 @@
 import json
+import sqlite3
 import uuid
 from typing import Any
 
+import sqlalchemy.exc
 from sqlalchemy.engine.row import Row
 
 from policyengine_api.data import database
@@ -14,9 +16,17 @@ SIMULATION_RUN_VERSION_FIELDS = (
     "runtime_app_name",
     "simulation_cache_version",
 )
+MAX_CREATE_RUN_ATTEMPTS = 3
 
 
 class SimulationRunService:
+    def _simulation_exists(self, simulation_id: int) -> bool:
+        row: Row | None = database.query(
+            "SELECT id FROM simulations WHERE id = ?",
+            (simulation_id,),
+        ).fetchone()
+        return row is not None
+
     def _next_run_sequence(self, simulation_id: int) -> int:
         row: Row | None = database.query(
             """
@@ -46,6 +56,13 @@ class SimulationRunService:
             )
         return run
 
+    def _is_sequence_conflict(self, error: Exception) -> bool:
+        message = str(error)
+        return (
+            "simulation_run_sequence_idx" in message
+            or "simulation_runs.simulation_id, simulation_runs.run_sequence" in message
+        )
+
     def create_simulation_run(
         self,
         simulation_id: int,
@@ -60,41 +77,56 @@ class SimulationRunService:
         version_manifest: dict[str, str | None] | None = None,
         run_id: str | None = None,
     ) -> dict:
+        if not self._simulation_exists(simulation_id):
+            raise ValueError(f"Simulation #{simulation_id} not found")
+
         run_id = run_id or str(uuid.uuid4())
-        run_sequence = self._next_run_sequence(simulation_id)
         version_manifest = version_manifest or {}
 
-        database.query(
-            f"""
-            INSERT INTO simulation_runs (
-                id, simulation_id, report_output_run_id, input_position, run_sequence,
-                status, output, error_message, trigger_type, requested_at, started_at,
-                finished_at, source_run_id, simulation_spec_snapshot_json,
-                {", ".join(SIMULATION_RUN_VERSION_FIELDS)}
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                run_id,
-                simulation_id,
-                report_output_run_id,
-                input_position,
-                run_sequence,
-                status,
-                self._serialize_json(output),
-                error_message,
-                trigger_type,
-                None,
-                None,
-                None,
-                source_run_id,
-                self._serialize_json(simulation_spec_snapshot),
-                *[
-                    version_manifest.get(field)
-                    for field in SIMULATION_RUN_VERSION_FIELDS
-                ],
-            ),
+        for attempt in range(MAX_CREATE_RUN_ATTEMPTS):
+            run_sequence = self._next_run_sequence(simulation_id)
+            try:
+                database.query(
+                    f"""
+                    INSERT INTO simulation_runs (
+                        id, simulation_id, report_output_run_id, input_position, run_sequence,
+                        status, output, error_message, trigger_type, requested_at, started_at,
+                        finished_at, source_run_id, simulation_spec_snapshot_json,
+                        {", ".join(SIMULATION_RUN_VERSION_FIELDS)}
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id,
+                        simulation_id,
+                        report_output_run_id,
+                        input_position,
+                        run_sequence,
+                        status,
+                        self._serialize_json(output),
+                        error_message,
+                        trigger_type,
+                        None,
+                        None,
+                        None,
+                        source_run_id,
+                        self._serialize_json(simulation_spec_snapshot),
+                        *[
+                            version_manifest.get(field)
+                            for field in SIMULATION_RUN_VERSION_FIELDS
+                        ],
+                    ),
+                )
+                return self.get_simulation_run(run_id)
+            except (sqlite3.IntegrityError, sqlalchemy.exc.IntegrityError) as error:
+                if (
+                    attempt == MAX_CREATE_RUN_ATTEMPTS - 1
+                    or not self._is_sequence_conflict(error)
+                ):
+                    raise
+
+        raise RuntimeError(
+            f"Unable to allocate simulation run sequence for #{simulation_id}"
         )
-        return self.get_simulation_run(run_id)
 
     def get_simulation_run(self, run_id: str) -> dict | None:
         row: Row | None = database.query(
@@ -128,7 +160,13 @@ class SimulationRunService:
 
     def select_display_run(self, simulation: dict) -> dict | None:
         if simulation.get("active_run_id"):
-            return self.get_simulation_run(simulation["active_run_id"])
+            active_run = self.get_simulation_run(simulation["active_run_id"])
+            if active_run is not None:
+                return active_run
         if simulation.get("latest_successful_run_id"):
-            return self.get_simulation_run(simulation["latest_successful_run_id"])
+            latest_successful_run = self.get_simulation_run(
+                simulation["latest_successful_run_id"]
+            )
+            if latest_successful_run is not None:
+                return latest_successful_run
         return self.get_newest_simulation_run(simulation["id"])

--- a/policyengine_api/services/simulation_run_service.py
+++ b/policyengine_api/services/simulation_run_service.py
@@ -1,9 +1,7 @@
 import json
-import sqlite3
 import uuid
 from typing import Any
 
-import sqlalchemy.exc
 from sqlalchemy.engine.row import Row
 
 from policyengine_api.data import database
@@ -16,28 +14,9 @@ SIMULATION_RUN_VERSION_FIELDS = (
     "runtime_app_name",
     "simulation_cache_version",
 )
-MAX_CREATE_RUN_ATTEMPTS = 3
 
 
 class SimulationRunService:
-    def _simulation_exists(self, simulation_id: int) -> bool:
-        row: Row | None = database.query(
-            "SELECT id FROM simulations WHERE id = ?",
-            (simulation_id,),
-        ).fetchone()
-        return row is not None
-
-    def _next_run_sequence(self, simulation_id: int) -> int:
-        row: Row | None = database.query(
-            """
-            SELECT COALESCE(MAX(run_sequence), 0) AS max_run_sequence
-            FROM simulation_runs
-            WHERE simulation_id = ?
-            """,
-            (simulation_id,),
-        ).fetchone()
-        return int(row["max_run_sequence"]) + 1 if row is not None else 1
-
     def _serialize_json(
         self, value: dict[str, Any] | list[Any] | str | None
     ) -> str | None:
@@ -56,13 +35,6 @@ class SimulationRunService:
             )
         return run
 
-    def _is_sequence_conflict(self, error: Exception) -> bool:
-        message = str(error)
-        return (
-            "simulation_run_sequence_idx" in message
-            or "simulation_runs.simulation_id, simulation_runs.run_sequence" in message
-        )
-
     def create_simulation_run(
         self,
         simulation_id: int,
@@ -77,56 +49,65 @@ class SimulationRunService:
         version_manifest: dict[str, str | None] | None = None,
         run_id: str | None = None,
     ) -> dict:
-        if not self._simulation_exists(simulation_id):
-            raise ValueError(f"Simulation #{simulation_id} not found")
-
         run_id = run_id or str(uuid.uuid4())
         version_manifest = version_manifest or {}
+        lock_clause = "" if database.local else " FOR UPDATE"
 
-        for attempt in range(MAX_CREATE_RUN_ATTEMPTS):
-            run_sequence = self._next_run_sequence(simulation_id)
-            try:
-                database.query(
-                    f"""
-                    INSERT INTO simulation_runs (
-                        id, simulation_id, report_output_run_id, input_position, run_sequence,
-                        status, output, error_message, trigger_type, requested_at, started_at,
-                        finished_at, source_run_id, simulation_spec_snapshot_json,
-                        {", ".join(SIMULATION_RUN_VERSION_FIELDS)}
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        run_id,
-                        simulation_id,
-                        report_output_run_id,
-                        input_position,
-                        run_sequence,
-                        status,
-                        self._serialize_json(output),
-                        error_message,
-                        trigger_type,
-                        None,
-                        None,
-                        None,
-                        source_run_id,
-                        self._serialize_json(simulation_spec_snapshot),
-                        *[
-                            version_manifest.get(field)
-                            for field in SIMULATION_RUN_VERSION_FIELDS
-                        ],
-                    ),
-                )
-                return self.get_simulation_run(run_id)
-            except (sqlite3.IntegrityError, sqlalchemy.exc.IntegrityError) as error:
-                if (
-                    attempt == MAX_CREATE_RUN_ATTEMPTS - 1
-                    or not self._is_sequence_conflict(error)
-                ):
-                    raise
+        def create_run_transaction(tx) -> None:
+            parent_row: Row | None = tx.query(
+                f"SELECT id FROM simulations WHERE id = ?{lock_clause}",
+                (simulation_id,),
+            ).fetchone()
+            if parent_row is None:
+                raise ValueError(f"Simulation #{simulation_id} not found")
 
-        raise RuntimeError(
-            f"Unable to allocate simulation run sequence for #{simulation_id}"
-        )
+            run_sequence_row: Row | None = tx.query(
+                """
+                SELECT COALESCE(MAX(run_sequence), 0) AS max_run_sequence
+                FROM simulation_runs
+                WHERE simulation_id = ?
+                """,
+                (simulation_id,),
+            ).fetchone()
+            run_sequence = (
+                int(run_sequence_row["max_run_sequence"]) + 1
+                if run_sequence_row is not None
+                else 1
+            )
+
+            tx.query(
+                f"""
+                INSERT INTO simulation_runs (
+                    id, simulation_id, report_output_run_id, input_position, run_sequence,
+                    status, output, error_message, trigger_type, requested_at, started_at,
+                    finished_at, source_run_id, simulation_spec_snapshot_json,
+                    {", ".join(SIMULATION_RUN_VERSION_FIELDS)}
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    simulation_id,
+                    report_output_run_id,
+                    input_position,
+                    run_sequence,
+                    status,
+                    self._serialize_json(output),
+                    error_message,
+                    trigger_type,
+                    None,
+                    None,
+                    None,
+                    source_run_id,
+                    self._serialize_json(simulation_spec_snapshot),
+                    *[
+                        version_manifest.get(field)
+                        for field in SIMULATION_RUN_VERSION_FIELDS
+                    ],
+                ),
+            )
+
+        database.transaction(create_run_transaction)
+        return self.get_simulation_run(run_id)
 
     def get_simulation_run(self, run_id: str) -> dict | None:
         row: Row | None = database.query(

--- a/policyengine_api/services/simulation_run_service.py
+++ b/policyengine_api/services/simulation_run_service.py
@@ -1,0 +1,134 @@
+import json
+import uuid
+from typing import Any
+
+from sqlalchemy.engine.row import Row
+
+from policyengine_api.data import database
+
+
+SIMULATION_RUN_VERSION_FIELDS = (
+    "country_package_version",
+    "policyengine_version",
+    "data_version",
+    "runtime_app_name",
+    "simulation_cache_version",
+)
+
+
+class SimulationRunService:
+    def _next_run_sequence(self, simulation_id: int) -> int:
+        row: Row | None = database.query(
+            """
+            SELECT COALESCE(MAX(run_sequence), 0) AS max_run_sequence
+            FROM simulation_runs
+            WHERE simulation_id = ?
+            """,
+            (simulation_id,),
+        ).fetchone()
+        return int(row["max_run_sequence"]) + 1 if row is not None else 1
+
+    def _serialize_json(
+        self, value: dict[str, Any] | list[Any] | str | None
+    ) -> str | None:
+        if value is None or isinstance(value, str):
+            return value
+        return json.dumps(value)
+
+    def _parse_run_row(self, row: Row | dict | None) -> dict | None:
+        if row is None:
+            return None
+
+        run = dict(row)
+        if isinstance(run.get("simulation_spec_snapshot_json"), str):
+            run["simulation_spec_snapshot_json"] = json.loads(
+                run["simulation_spec_snapshot_json"]
+            )
+        return run
+
+    def create_simulation_run(
+        self,
+        simulation_id: int,
+        report_output_run_id: str | None = None,
+        input_position: int | None = None,
+        status: str = "pending",
+        trigger_type: str = "initial",
+        output: dict[str, Any] | list[Any] | str | None = None,
+        error_message: str | None = None,
+        source_run_id: str | None = None,
+        simulation_spec_snapshot: dict[str, Any] | str | None = None,
+        version_manifest: dict[str, str | None] | None = None,
+        run_id: str | None = None,
+    ) -> dict:
+        run_id = run_id or str(uuid.uuid4())
+        run_sequence = self._next_run_sequence(simulation_id)
+        version_manifest = version_manifest or {}
+
+        database.query(
+            f"""
+            INSERT INTO simulation_runs (
+                id, simulation_id, report_output_run_id, input_position, run_sequence,
+                status, output, error_message, trigger_type, requested_at, started_at,
+                finished_at, source_run_id, simulation_spec_snapshot_json,
+                {", ".join(SIMULATION_RUN_VERSION_FIELDS)}
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                simulation_id,
+                report_output_run_id,
+                input_position,
+                run_sequence,
+                status,
+                self._serialize_json(output),
+                error_message,
+                trigger_type,
+                None,
+                None,
+                None,
+                source_run_id,
+                self._serialize_json(simulation_spec_snapshot),
+                *[
+                    version_manifest.get(field)
+                    for field in SIMULATION_RUN_VERSION_FIELDS
+                ],
+            ),
+        )
+        return self.get_simulation_run(run_id)
+
+    def get_simulation_run(self, run_id: str) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM simulation_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        return self._parse_run_row(row)
+
+    def list_simulation_runs(self, simulation_id: int) -> list[dict]:
+        rows = database.query(
+            """
+            SELECT * FROM simulation_runs
+            WHERE simulation_id = ?
+            ORDER BY run_sequence ASC
+            """,
+            (simulation_id,),
+        ).fetchall()
+        return [self._parse_run_row(row) for row in rows]
+
+    def get_newest_simulation_run(self, simulation_id: int) -> dict | None:
+        row: Row | None = database.query(
+            """
+            SELECT * FROM simulation_runs
+            WHERE simulation_id = ?
+            ORDER BY run_sequence DESC
+            LIMIT 1
+            """,
+            (simulation_id,),
+        ).fetchone()
+        return self._parse_run_row(row)
+
+    def select_display_run(self, simulation: dict) -> dict | None:
+        if simulation.get("active_run_id"):
+            return self.get_simulation_run(simulation["active_run_id"])
+        if simulation.get("latest_successful_run_id"):
+            return self.get_simulation_run(simulation["latest_successful_run_id"])
+        return self.get_newest_simulation_run(simulation["id"])

--- a/policyengine_api/services/simulation_spec_service.py
+++ b/policyengine_api/services/simulation_spec_service.py
@@ -30,6 +30,18 @@ class SimulationSpecService:
         ).fetchone()
         return dict(row) if row is not None else None
 
+    def _validate_simulation_spec_matches_row(
+        self, simulation: dict, simulation_spec: SimulationSpec
+    ) -> None:
+        expected_spec = {
+            "country_id": simulation["country_id"],
+            "population_id": simulation["population_id"],
+            "population_type": simulation["population_type"],
+            "policy_id": simulation["policy_id"],
+        }
+        if simulation_spec.model_dump() != expected_spec:
+            raise ValueError("Simulation spec must match the linked simulation row")
+
     def build_simulation_spec(self, simulation: dict) -> SimulationSpec:
         return SimulationSpec.model_validate(
             {
@@ -49,7 +61,9 @@ class SimulationSpecService:
         raw_spec = simulation["simulation_spec_json"]
         if isinstance(raw_spec, str):
             raw_spec = json.loads(raw_spec)
-        return SimulationSpec.model_validate(raw_spec)
+        simulation_spec = SimulationSpec.model_validate(raw_spec)
+        self._validate_simulation_spec_matches_row(simulation, simulation_spec)
+        return simulation_spec
 
     def set_simulation_spec(
         self,
@@ -61,6 +75,7 @@ class SimulationSpecService:
         simulation = self._get_simulation_row(simulation_id)
         if simulation is None:
             raise ValueError(f"Simulation #{simulation_id} not found")
+        self._validate_simulation_spec_matches_row(simulation, simulation_spec)
 
         database.query(
             """

--- a/policyengine_api/services/simulation_spec_service.py
+++ b/policyengine_api/services/simulation_spec_service.py
@@ -17,6 +17,12 @@ class SimulationSpec(BaseModel):
 
 
 class SimulationSpecService:
+    def _validate_schema_version(self, schema_version: int | None) -> None:
+        if schema_version != SIMULATION_SPEC_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported simulation spec schema version: {schema_version}"
+            )
+
     def _get_simulation_row(self, simulation_id: int) -> dict | None:
         row: Row | None = database.query(
             "SELECT * FROM simulations WHERE id = ?",
@@ -39,6 +45,7 @@ class SimulationSpecService:
         if simulation is None or simulation["simulation_spec_json"] is None:
             return None
 
+        self._validate_schema_version(simulation["simulation_spec_schema_version"])
         raw_spec = simulation["simulation_spec_json"]
         if isinstance(raw_spec, str):
             raw_spec = json.loads(raw_spec)
@@ -50,6 +57,7 @@ class SimulationSpecService:
         simulation_spec: SimulationSpec,
         schema_version: int = SIMULATION_SPEC_SCHEMA_VERSION,
     ) -> bool:
+        self._validate_schema_version(schema_version)
         simulation = self._get_simulation_row(simulation_id)
         if simulation is None:
             raise ValueError(f"Simulation #{simulation_id} not found")

--- a/policyengine_api/services/simulation_spec_service.py
+++ b/policyengine_api/services/simulation_spec_service.py
@@ -1,0 +1,69 @@
+import json
+from typing import Literal
+
+from pydantic import BaseModel
+from sqlalchemy.engine.row import Row
+
+from policyengine_api.data import database
+
+SIMULATION_SPEC_SCHEMA_VERSION = 1
+
+
+class SimulationSpec(BaseModel):
+    country_id: str
+    population_id: str
+    population_type: Literal["household", "geography"]
+    policy_id: int
+
+
+class SimulationSpecService:
+    def _get_simulation_row(self, simulation_id: int) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def build_simulation_spec(self, simulation: dict) -> SimulationSpec:
+        return SimulationSpec.model_validate(
+            {
+                "country_id": simulation["country_id"],
+                "population_id": simulation["population_id"],
+                "population_type": simulation["population_type"],
+                "policy_id": simulation["policy_id"],
+            }
+        )
+
+    def get_simulation_spec(self, simulation_id: int) -> SimulationSpec | None:
+        simulation = self._get_simulation_row(simulation_id)
+        if simulation is None or simulation["simulation_spec_json"] is None:
+            return None
+
+        raw_spec = simulation["simulation_spec_json"]
+        if isinstance(raw_spec, str):
+            raw_spec = json.loads(raw_spec)
+        return SimulationSpec.model_validate(raw_spec)
+
+    def set_simulation_spec(
+        self,
+        simulation_id: int,
+        simulation_spec: SimulationSpec,
+        schema_version: int = SIMULATION_SPEC_SCHEMA_VERSION,
+    ) -> bool:
+        simulation = self._get_simulation_row(simulation_id)
+        if simulation is None:
+            raise ValueError(f"Simulation #{simulation_id} not found")
+
+        database.query(
+            """
+            UPDATE simulations
+            SET simulation_spec_json = ?, simulation_spec_schema_version = ?
+            WHERE id = ?
+            """,
+            (
+                simulation_spec.model_dump_json(),
+                schema_version,
+                simulation_id,
+            ),
+        )
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "policyengine_uk==2.78.0",
     "policyengine_us==1.634.9",
     "policyengine_core>=3.16.6",
-    "policyengine>=0.7.0",
+    "policyengine>0.12.0,<1",
     "pydantic",
     "pymysql",
     "python-dotenv",

--- a/scripts/smoke_test_local_boot.py
+++ b/scripts/smoke_test_local_boot.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Boot smoke test for the local PolicyEngine API app.
+
+Starts the real Flask app in debug/local-db mode, waits for it to come up,
+hits health endpoints, then shuts it down. If startup fails, prints captured
+stdout/stderr to make the failure actionable.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEALTH_PATHS = ("/liveness-check", "/readiness-check")
+BOOT_TIMEOUT_SECONDS = 45
+HTTP_TIMEOUT_SECONDS = 2
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def fetch(url: str) -> tuple[int, str]:
+    request = urllib.request.Request(url, method="GET")
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        body = response.read().decode("utf-8", errors="replace")
+        return response.getcode(), body
+
+
+def print_section(title: str, body: str) -> None:
+    print(f"\n=== {title} ===")
+    print(body.rstrip() if body else "(empty)")
+
+
+def main() -> int:
+    port = find_free_port()
+    stdout_file = tempfile.NamedTemporaryFile(
+        mode="w+", encoding="utf-8", delete=False, prefix="policyengine-api-boot-", suffix=".stdout.log"
+    )
+    stderr_file = tempfile.NamedTemporaryFile(
+        mode="w+", encoding="utf-8", delete=False, prefix="policyengine-api-boot-", suffix=".stderr.log"
+    )
+    stdout_path = Path(stdout_file.name)
+    stderr_path = Path(stderr_file.name)
+    stdout_file.close()
+    stderr_file.close()
+
+    env = os.environ.copy()
+    env["FLASK_DEBUG"] = "1"
+    env.setdefault("PYTHONUNBUFFERED", "1")
+
+    try:
+        policyengine_version = importlib.metadata.version("policyengine")
+    except importlib.metadata.PackageNotFoundError:
+        policyengine_version = "not installed"
+
+    print(f"repo: {REPO_ROOT}")
+    print(f"python: {sys.executable}")
+    print(f"policyengine: {policyengine_version}")
+    print(f"port: {port}")
+    print(f"stdout log: {stdout_path}")
+    print(f"stderr log: {stderr_path}")
+
+    with stdout_path.open("w", encoding="utf-8") as stdout_handle, stderr_path.open(
+        "w", encoding="utf-8"
+    ) as stderr_handle:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "flask",
+                "--app",
+                "policyengine_api.api",
+                "run",
+                "--without-threads",
+                "--no-reload",
+                "--port",
+                str(port),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            text=True,
+        )
+
+    try:
+        deadline = time.time() + BOOT_TIMEOUT_SECONDS
+        ready = False
+        while time.time() < deadline:
+            if process.poll() is not None:
+                break
+
+            try:
+                status, body = fetch(f"http://127.0.0.1:{port}/liveness-check")
+                if status == 200 and body.strip() == "OK":
+                    ready = True
+                    break
+            except (urllib.error.URLError, TimeoutError, ConnectionError):
+                time.sleep(0.5)
+                continue
+
+            time.sleep(0.5)
+
+        if not ready:
+            process.wait(timeout=5) if process.poll() is not None else process.terminate()
+            if process.poll() is None:
+                process.wait(timeout=5)
+            print("\nBoot smoke test failed: app did not become ready.")
+            print_section("stdout", read_text(stdout_path))
+            print_section("stderr", read_text(stderr_path))
+            return 1
+
+        print("\nBoot smoke test reached a live app. Probing health endpoints:")
+        for path in HEALTH_PATHS:
+            status, body = fetch(f"http://127.0.0.1:{port}{path}")
+            print(f"{path}: {status} {body.strip()}")
+            if status != 200 or body.strip() != "OK":
+                print("\nHealth endpoint probe failed.")
+                print_section("stdout", read_text(stdout_path))
+                print_section("stderr", read_text(stderr_path))
+                return 1
+
+        print("\nBoot smoke test passed.")
+        return 0
+    finally:
+        if "process" in locals() and process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_local_boot.py
+++ b/scripts/smoke_test_local_boot.py
@@ -53,10 +53,18 @@ def print_section(title: str, body: str) -> None:
 def main() -> int:
     port = find_free_port()
     stdout_file = tempfile.NamedTemporaryFile(
-        mode="w+", encoding="utf-8", delete=False, prefix="policyengine-api-boot-", suffix=".stdout.log"
+        mode="w+",
+        encoding="utf-8",
+        delete=False,
+        prefix="policyengine-api-boot-",
+        suffix=".stdout.log",
     )
     stderr_file = tempfile.NamedTemporaryFile(
-        mode="w+", encoding="utf-8", delete=False, prefix="policyengine-api-boot-", suffix=".stderr.log"
+        mode="w+",
+        encoding="utf-8",
+        delete=False,
+        prefix="policyengine-api-boot-",
+        suffix=".stderr.log",
     )
     stdout_path = Path(stdout_file.name)
     stderr_path = Path(stderr_file.name)
@@ -79,9 +87,10 @@ def main() -> int:
     print(f"stdout log: {stdout_path}")
     print(f"stderr log: {stderr_path}")
 
-    with stdout_path.open("w", encoding="utf-8") as stdout_handle, stderr_path.open(
-        "w", encoding="utf-8"
-    ) as stderr_handle:
+    with (
+        stdout_path.open("w", encoding="utf-8") as stdout_handle,
+        stderr_path.open("w", encoding="utf-8") as stderr_handle,
+    ):
         process = subprocess.Popen(
             [
                 sys.executable,
@@ -121,7 +130,9 @@ def main() -> int:
             time.sleep(0.5)
 
         if not ready:
-            process.wait(timeout=5) if process.poll() is not None else process.terminate()
+            process.wait(
+                timeout=5
+            ) if process.poll() is not None else process.terminate()
             if process.poll() is None:
                 process.wait(timeout=5)
             print("\nBoot smoke test failed: app did not become ready.")

--- a/tests/unit/services/test_report_output_alias_service.py
+++ b/tests/unit/services/test_report_output_alias_service.py
@@ -1,0 +1,57 @@
+from policyengine_api.services.report_output_alias_service import (
+    ReportOutputAliasService,
+)
+from policyengine_api.services.report_output_service import ReportOutputService
+from policyengine_api.services.simulation_service import SimulationService
+
+alias_service = ReportOutputAliasService()
+report_output_service = ReportOutputService()
+simulation_service = SimulationService()
+
+
+class TestReportOutputAliasService:
+    def test_resolves_to_canonical_report_output_id_when_alias_exists(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        alias_service.set_alias(
+            legacy_report_output_id=999,
+            canonical_report_output_id=canonical_report["id"],
+        )
+
+        resolved_id = alias_service.resolve_canonical_report_output_id(999)
+
+        assert resolved_id == canonical_report["id"]
+
+    def test_returns_requested_id_when_alias_is_not_needed(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_2",
+            population_type="household",
+            policy_id=2,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        resolved_id = alias_service.resolve_canonical_report_output_id(
+            report_output["id"]
+        )
+
+        assert resolved_id == report_output["id"]
+
+    def test_returns_none_for_unknown_report_output(self, test_db):
+        assert alias_service.resolve_canonical_report_output_id(123456) is None

--- a/tests/unit/services/test_report_output_alias_service.py
+++ b/tests/unit/services/test_report_output_alias_service.py
@@ -12,6 +12,30 @@ simulation_service = SimulationService()
 
 
 class TestReportOutputAliasService:
+    def _insert_legacy_report_output(
+        self,
+        test_db,
+        legacy_report_output_id: int,
+        canonical_report: dict,
+        api_version: str = "legacy-version",
+    ) -> None:
+        test_db.query(
+            """
+            INSERT INTO report_outputs (
+                id, country_id, simulation_1_id, simulation_2_id, api_version, status, year
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                legacy_report_output_id,
+                canonical_report["country_id"],
+                canonical_report["simulation_1_id"],
+                canonical_report["simulation_2_id"],
+                api_version,
+                canonical_report["status"],
+                canonical_report["year"],
+            ),
+        )
+
     def test_resolves_to_canonical_report_output_id_when_alias_exists(self, test_db):
         simulation = simulation_service.create_simulation(
             country_id="us",
@@ -25,6 +49,7 @@ class TestReportOutputAliasService:
             simulation_2_id=None,
             year="2025",
         )
+        self._insert_legacy_report_output(test_db, 999, canonical_report)
 
         alias_service.set_alias(
             legacy_report_output_id=999,
@@ -71,6 +96,7 @@ class TestReportOutputAliasService:
             simulation_2_id=None,
             year="2025",
         )
+        self._insert_legacy_report_output(test_db, 1001, canonical_report)
 
         assert (
             alias_service.set_alias(
@@ -88,6 +114,20 @@ class TestReportOutputAliasService:
         )
 
     def test_rejects_alias_to_missing_canonical_report_output(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_3a",
+            population_type="household",
+            policy_id=3,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        self._insert_legacy_report_output(test_db, 1002, canonical_report)
+
         with pytest.raises(ValueError) as exc_info:
             alias_service.set_alias(
                 legacy_report_output_id=1002,
@@ -115,6 +155,7 @@ class TestReportOutputAliasService:
             simulation_2_id=None,
             year="2026",
         )
+        self._insert_legacy_report_output(test_db, 1003, canonical_report)
         alias_service.set_alias(
             legacy_report_output_id=1003,
             canonical_report_output_id=canonical_report["id"],
@@ -131,6 +172,80 @@ class TestReportOutputAliasService:
             f"#{canonical_report['id']}"
         ) in str(exc_info.value)
 
+    def test_rejects_alias_when_legacy_report_output_is_missing(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4a",
+            population_type="household",
+            policy_id=4,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            alias_service.set_alias(
+                legacy_report_output_id=10030,
+                canonical_report_output_id=canonical_report["id"],
+            )
+
+        assert "Legacy report output #10030 not found" in str(exc_info.value)
+
+    def test_rejects_alias_when_legacy_and_canonical_reports_do_not_match(
+        self, test_db
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4b",
+            population_type="household",
+            policy_id=4,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        mismatched_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2026",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            alias_service.set_alias(
+                legacy_report_output_id=mismatched_report["id"],
+                canonical_report_output_id=canonical_report["id"],
+            )
+
+        assert "must describe the same report" in str(exc_info.value)
+
+    def test_rejects_alias_when_legacy_and_canonical_ids_match(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4c",
+            population_type="household",
+            policy_id=4,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            alias_service.set_alias(
+                legacy_report_output_id=canonical_report["id"],
+                canonical_report_output_id=canonical_report["id"],
+            )
+
+        assert "must be different" in str(exc_info.value)
+
     def test_rejects_alias_resolution_when_canonical_report_output_is_missing(
         self, test_db
     ):
@@ -146,6 +261,7 @@ class TestReportOutputAliasService:
             simulation_2_id=None,
             year="2025",
         )
+        self._insert_legacy_report_output(test_db, 1004, canonical_report)
         alias_service.set_alias(
             legacy_report_output_id=1004,
             canonical_report_output_id=canonical_report["id"],

--- a/tests/unit/services/test_report_output_alias_service.py
+++ b/tests/unit/services/test_report_output_alias_service.py
@@ -1,3 +1,5 @@
+import pytest
+
 from policyengine_api.services.report_output_alias_service import (
     ReportOutputAliasService,
 )
@@ -55,3 +57,107 @@ class TestReportOutputAliasService:
 
     def test_returns_none_for_unknown_report_output(self, test_db):
         assert alias_service.resolve_canonical_report_output_id(123456) is None
+
+    def test_set_alias_is_idempotent_for_same_canonical_report_output(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_3",
+            population_type="household",
+            policy_id=3,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        assert (
+            alias_service.set_alias(
+                legacy_report_output_id=1001,
+                canonical_report_output_id=canonical_report["id"],
+            )
+            is True
+        )
+        assert (
+            alias_service.set_alias(
+                legacy_report_output_id=1001,
+                canonical_report_output_id=canonical_report["id"],
+            )
+            is True
+        )
+
+    def test_rejects_alias_to_missing_canonical_report_output(self, test_db):
+        with pytest.raises(ValueError) as exc_info:
+            alias_service.set_alias(
+                legacy_report_output_id=1002,
+                canonical_report_output_id=999999,
+            )
+
+        assert "Canonical report output #999999 not found" in str(exc_info.value)
+
+    def test_rejects_conflicting_alias_remap(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4",
+            population_type="household",
+            policy_id=4,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        other_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2026",
+        )
+        alias_service.set_alias(
+            legacy_report_output_id=1003,
+            canonical_report_output_id=canonical_report["id"],
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            alias_service.set_alias(
+                legacy_report_output_id=1003,
+                canonical_report_output_id=other_report["id"],
+            )
+
+        assert (
+            "Legacy report output alias already points to canonical report output "
+            f"#{canonical_report['id']}"
+        ) in str(exc_info.value)
+
+    def test_rejects_alias_resolution_when_canonical_report_output_is_missing(
+        self, test_db
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_5",
+            population_type="household",
+            policy_id=5,
+        )
+        canonical_report = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        alias_service.set_alias(
+            legacy_report_output_id=1004,
+            canonical_report_output_id=canonical_report["id"],
+        )
+        test_db.query(
+            "DELETE FROM report_outputs WHERE id = ?",
+            (canonical_report["id"],),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            alias_service.resolve_canonical_report_output_id(1004)
+
+        assert (
+            f"Alias points to missing canonical report output #{canonical_report['id']}"
+        ) in str(exc_info.value)

--- a/tests/unit/services/test_report_run_service.py
+++ b/tests/unit/services/test_report_run_service.py
@@ -1,0 +1,180 @@
+from policyengine_api.services.report_output_service import ReportOutputService
+from policyengine_api.services.report_run_service import ReportRunService
+from policyengine_api.services.simulation_service import SimulationService
+
+report_output_service = ReportOutputService()
+report_run_service = ReportRunService()
+simulation_service = SimulationService()
+
+
+class TestCreateReportOutputRun:
+    def test_creates_report_runs_with_incrementing_sequence(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        first_run = report_run_service.create_report_output_run(
+            report_output["id"],
+            trigger_type="initial",
+            report_spec_snapshot={"country_id": "us"},
+            version_manifest={
+                "country_package_version": "us-1.0.0",
+                "report_cache_version": "r123",
+            },
+        )
+        second_run = report_run_service.create_report_output_run(
+            report_output["id"],
+            trigger_type="rerun",
+        )
+
+        assert first_run["run_sequence"] == 1
+        assert first_run["trigger_type"] == "initial"
+        assert first_run["report_spec_snapshot_json"] == {"country_id": "us"}
+        assert first_run["country_package_version"] == "us-1.0.0"
+        assert first_run["report_cache_version"] == "r123"
+        assert second_run["run_sequence"] == 2
+        assert second_run["trigger_type"] == "rerun"
+
+    def test_lists_report_runs_in_sequence_order(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_3",
+            population_type="household",
+            policy_id=3,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="initial"
+        )
+        report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="rerun"
+        )
+
+        runs = report_run_service.list_report_output_runs(report_output["id"])
+
+        assert [run["run_sequence"] for run in runs] == [1, 2]
+
+
+class TestSelectDisplayReportRun:
+    def test_prefers_active_run(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4",
+            population_type="household",
+            policy_id=4,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        latest_successful_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="initial"
+        )
+        active_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET active_run_id = ?, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            (active_run["id"], latest_successful_run["id"], report_output["id"]),
+        )
+        updated_report_output = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+
+        selected_run = report_run_service.select_display_run(updated_report_output)
+
+        assert selected_run["id"] == active_run["id"]
+
+    def test_falls_back_to_latest_successful_run(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_5",
+            population_type="household",
+            policy_id=5,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        successful_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="initial"
+        )
+        report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET active_run_id = NULL, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            (successful_run["id"], report_output["id"]),
+        )
+        updated_report_output = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+
+        selected_run = report_run_service.select_display_run(updated_report_output)
+
+        assert selected_run["id"] == successful_run["id"]
+
+    def test_falls_back_to_newest_run_when_no_pointers_exist(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_6",
+            population_type="household",
+            policy_id=6,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        first_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="initial"
+        )
+        newest_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET active_run_id = NULL, latest_successful_run_id = NULL
+            WHERE id = ?
+            """,
+            (report_output["id"],),
+        )
+        updated_report_output = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+
+        selected_run = report_run_service.select_display_run(updated_report_output)
+
+        assert first_run["run_sequence"] == 1
+        assert selected_run["id"] == newest_run["id"]

--- a/tests/unit/services/test_report_run_service.py
+++ b/tests/unit/services/test_report_run_service.py
@@ -70,7 +70,7 @@ class TestCreateReportOutputRun:
 
         assert [run["run_sequence"] for run in runs] == [1, 2]
 
-    def test_retries_run_sequence_after_conflict(self, test_db, monkeypatch):
+    def test_allocates_run_sequence_transactionally(self, test_db):
         simulation = simulation_service.create_simulation(
             country_id="us",
             population_id="household_7",
@@ -83,29 +83,16 @@ class TestCreateReportOutputRun:
             simulation_2_id=None,
             year="2025",
         )
-        report_run_service.create_report_output_run(
+
+        first_run = report_run_service.create_report_output_run(
             report_output["id"], trigger_type="initial"
         )
-        original_next_run_sequence = report_run_service._next_run_sequence
-        attempts = iter([1, 2])
-
-        def conflicting_then_fresh_sequence(report_output_id: int) -> int:
-            try:
-                return next(attempts)
-            except StopIteration:
-                return original_next_run_sequence(report_output_id)
-
-        monkeypatch.setattr(
-            report_run_service,
-            "_next_run_sequence",
-            conflicting_then_fresh_sequence,
-        )
-
-        run = report_run_service.create_report_output_run(
+        second_run = report_run_service.create_report_output_run(
             report_output["id"], trigger_type="rerun"
         )
 
-        assert run["run_sequence"] == 2
+        assert first_run["run_sequence"] == 1
+        assert second_run["run_sequence"] == 2
 
     def test_raises_when_parent_report_output_is_missing(self, test_db):
         with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/services/test_report_run_service.py
+++ b/tests/unit/services/test_report_run_service.py
@@ -1,3 +1,5 @@
+import pytest
+
 from policyengine_api.services.report_output_service import ReportOutputService
 from policyengine_api.services.report_run_service import ReportRunService
 from policyengine_api.services.simulation_service import SimulationService
@@ -67,6 +69,49 @@ class TestCreateReportOutputRun:
         runs = report_run_service.list_report_output_runs(report_output["id"])
 
         assert [run["run_sequence"] for run in runs] == [1, 2]
+
+    def test_retries_run_sequence_after_conflict(self, test_db, monkeypatch):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_7",
+            population_type="household",
+            policy_id=7,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="initial"
+        )
+        original_next_run_sequence = report_run_service._next_run_sequence
+        attempts = iter([1, 2])
+
+        def conflicting_then_fresh_sequence(report_output_id: int) -> int:
+            try:
+                return next(attempts)
+            except StopIteration:
+                return original_next_run_sequence(report_output_id)
+
+        monkeypatch.setattr(
+            report_run_service,
+            "_next_run_sequence",
+            conflicting_then_fresh_sequence,
+        )
+
+        run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="rerun"
+        )
+
+        assert run["run_sequence"] == 2
+
+    def test_raises_when_parent_report_output_is_missing(self, test_db):
+        with pytest.raises(ValueError) as exc_info:
+            report_run_service.create_report_output_run(999999, trigger_type="initial")
+
+        assert "Report output #999999 not found" in str(exc_info.value)
 
 
 class TestSelectDisplayReportRun:
@@ -142,6 +187,39 @@ class TestSelectDisplayReportRun:
 
         assert selected_run["id"] == successful_run["id"]
 
+    def test_falls_back_when_active_run_pointer_is_stale(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_5a",
+            population_type="household",
+            policy_id=5,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        successful_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="initial"
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET active_run_id = ?, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            ("missing-run", successful_run["id"], report_output["id"]),
+        )
+        updated_report_output = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+
+        selected_run = report_run_service.select_display_run(updated_report_output)
+
+        assert selected_run["id"] == successful_run["id"]
+
     def test_falls_back_to_newest_run_when_no_pointers_exist(self, test_db):
         simulation = simulation_service.create_simulation(
             country_id="us",
@@ -177,4 +255,39 @@ class TestSelectDisplayReportRun:
         selected_run = report_run_service.select_display_run(updated_report_output)
 
         assert first_run["run_sequence"] == 1
+        assert selected_run["id"] == newest_run["id"]
+
+    def test_falls_back_to_newest_run_when_latest_successful_pointer_is_stale(
+        self, test_db
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_6a",
+            population_type="household",
+            policy_id=6,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        newest_run = report_run_service.create_report_output_run(
+            report_output["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET active_run_id = NULL, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            ("missing-run", report_output["id"]),
+        )
+        updated_report_output = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+
+        selected_run = report_run_service.select_display_run(updated_report_output)
+
         assert selected_run["id"] == newest_run["id"]

--- a/tests/unit/services/test_report_spec_service.py
+++ b/tests/unit/services/test_report_spec_service.py
@@ -102,6 +102,81 @@ class TestBuildReportSpec:
 
         assert "population types must match" in str(exc_info.value)
 
+    def test_raises_for_mismatched_household_ids(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_2",
+            population_type="household",
+            policy_id=2,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.build_report_spec(
+                report_output, simulation_1, simulation_2
+            )
+
+        assert "matching household IDs" in str(exc_info.value)
+
+    def test_raises_for_mismatched_geography_ids(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ny",
+            population_type="geography",
+            policy_id=11,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
+            year="2027",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.build_report_spec(
+                report_output, simulation_1, simulation_2
+            )
+
+        assert "matching geography IDs" in str(exc_info.value)
+
+    def test_raises_for_country_mismatch_between_report_and_simulation(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="uk",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.build_report_spec(report_output, simulation_1)
+
+        assert "Simulation 1 country must match report output country" in str(
+            exc_info.value
+        )
+
 
 class TestPersistReportSpec:
     def test_sets_and_gets_report_spec(self, test_db):
@@ -150,3 +225,73 @@ class TestPersistReportSpec:
         loaded_report_spec = report_spec_service.get_report_spec(report_output["id"])
         assert loaded_report_spec is not None
         assert loaded_report_spec.model_dump() == report_spec.model_dump()
+
+    def test_rejects_unsupported_schema_version_on_write(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2027",
+        )
+        report_spec = EconomyReportSpec.model_validate(
+            {
+                "country_id": "us",
+                "report_kind": "economy_single",
+                "time_period": "2027",
+                "region": "ca",
+                "baseline_policy_id": 10,
+                "reform_policy_id": 10,
+                "dataset": "default",
+                "target": "general",
+                "options": {},
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.set_report_spec(
+                report_output["id"],
+                report_spec,
+                report_spec_status="explicit",
+                schema_version=2,
+            )
+
+        assert "Unsupported report spec schema version" in str(exc_info.value)
+
+    def test_rejects_unsupported_schema_version_on_read(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2027",
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET report_kind = ?, report_spec_json = ?, report_spec_schema_version = ?, report_spec_status = ?
+            WHERE id = ?
+            """,
+            (
+                "economy_single",
+                '{"country_id":"us","report_kind":"economy_single","time_period":"2027","region":"ca","baseline_policy_id":10,"reform_policy_id":10,"dataset":"default","target":"general","options":{}}',
+                2,
+                "explicit",
+                report_output["id"],
+            ),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.get_report_spec(report_output["id"])
+
+        assert "Unsupported report spec schema version" in str(exc_info.value)

--- a/tests/unit/services/test_report_spec_service.py
+++ b/tests/unit/services/test_report_spec_service.py
@@ -1,0 +1,152 @@
+import pytest
+
+from policyengine_api.services.report_output_service import ReportOutputService
+from policyengine_api.services.report_spec_service import (
+    EconomyReportSpec,
+    HouseholdReportSpec,
+    ReportSpecService,
+)
+from policyengine_api.services.simulation_service import SimulationService
+
+report_output_service = ReportOutputService()
+report_spec_service = ReportSpecService()
+simulation_service = SimulationService()
+
+
+class TestBuildReportSpec:
+    def test_builds_household_comparison_report_spec(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=2,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
+            year="2026",
+        )
+
+        report_spec = report_spec_service.build_report_spec(
+            report_output, simulation_1, simulation_2
+        )
+
+        assert isinstance(report_spec, HouseholdReportSpec)
+        assert report_spec.report_kind == "household_comparison"
+        assert report_spec.time_period == "2026"
+        assert report_spec.simulation_1.policy_id == 1
+        assert report_spec.simulation_2.policy_id == 2
+
+    def test_builds_default_economy_report_spec(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=11,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
+            year="2027",
+        )
+
+        report_spec = report_spec_service.build_report_spec(
+            report_output, simulation_1, simulation_2
+        )
+
+        assert isinstance(report_spec, EconomyReportSpec)
+        assert report_spec.report_kind == "economy_comparison"
+        assert report_spec.region == "ca"
+        assert report_spec.dataset == "default"
+        assert report_spec.target == "general"
+        assert report_spec.options == {}
+
+    def test_raises_for_mixed_population_types(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=2,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.build_report_spec(
+                report_output, simulation_1, simulation_2
+            )
+
+        assert "population types must match" in str(exc_info.value)
+
+
+class TestPersistReportSpec:
+    def test_sets_and_gets_report_spec(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2027",
+        )
+        report_spec = EconomyReportSpec.model_validate(
+            {
+                "country_id": "us",
+                "report_kind": "economy_single",
+                "time_period": "2027",
+                "region": "ca",
+                "baseline_policy_id": 10,
+                "reform_policy_id": 10,
+                "dataset": "default",
+                "target": "general",
+                "options": {},
+            }
+        )
+
+        result = report_spec_service.set_report_spec(
+            report_output["id"], report_spec, report_spec_status="explicit"
+        )
+
+        assert result is True
+        stored_report = test_db.query(
+            """
+            SELECT report_kind, report_spec_json, report_spec_schema_version, report_spec_status
+            FROM report_outputs WHERE id = ?
+            """,
+            (report_output["id"],),
+        ).fetchone()
+        assert stored_report["report_kind"] == "economy_single"
+        assert stored_report["report_spec_schema_version"] == 1
+        assert stored_report["report_spec_status"] == "explicit"
+
+        loaded_report_spec = report_spec_service.get_report_spec(report_output["id"])
+        assert loaded_report_spec is not None
+        assert loaded_report_spec.model_dump() == report_spec.model_dump()

--- a/tests/unit/services/test_report_spec_service.py
+++ b/tests/unit/services/test_report_spec_service.py
@@ -177,6 +177,62 @@ class TestBuildReportSpec:
             exc_info.value
         )
 
+    def test_raises_when_simulation_1_does_not_match_report_output_linkage(
+        self, test_db
+    ):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        other_simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=2,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.build_report_spec(report_output, other_simulation)
+
+        assert "Simulation 1 must match report_output.simulation_1_id" in str(
+            exc_info.value
+        )
+
+    def test_raises_when_report_requires_second_simulation_but_none_is_supplied(
+        self, test_db
+    ):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=2,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
+            year="2025",
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.build_report_spec(report_output, simulation_1)
+
+        assert "requires a second simulation" in str(exc_info.value)
+
 
 class TestPersistReportSpec:
     def test_sets_and_gets_report_spec(self, test_db):
@@ -225,6 +281,109 @@ class TestPersistReportSpec:
         loaded_report_spec = report_spec_service.get_report_spec(report_output["id"])
         assert loaded_report_spec is not None
         assert loaded_report_spec.model_dump() == report_spec.model_dump()
+
+    def test_rejects_report_spec_write_when_region_does_not_match_report(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2027",
+        )
+        report_spec = EconomyReportSpec.model_validate(
+            {
+                "country_id": "us",
+                "report_kind": "economy_single",
+                "time_period": "2027",
+                "region": "ny",
+                "baseline_policy_id": 10,
+                "reform_policy_id": 10,
+                "dataset": "default",
+                "target": "general",
+                "options": {},
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.set_report_spec(
+                report_output["id"], report_spec, report_spec_status="explicit"
+            )
+
+        assert "Report spec region must match linked simulations" in str(exc_info.value)
+
+    def test_rejects_report_spec_write_when_time_period_does_not_match_report(
+        self, test_db
+    ):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2027",
+        )
+        report_spec = EconomyReportSpec.model_validate(
+            {
+                "country_id": "us",
+                "report_kind": "economy_single",
+                "time_period": "2028",
+                "region": "ca",
+                "baseline_policy_id": 10,
+                "reform_policy_id": 10,
+                "dataset": "default",
+                "target": "general",
+                "options": {},
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.set_report_spec(
+                report_output["id"], report_spec, report_spec_status="explicit"
+            )
+
+        assert "time_period must match report output year" in str(exc_info.value)
+
+    def test_rejects_inconsistent_stored_report_spec_on_read(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=10,
+        )
+        report_output = report_output_service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=None,
+            year="2027",
+        )
+        test_db.query(
+            """
+            UPDATE report_outputs
+            SET report_kind = ?, report_spec_json = ?, report_spec_schema_version = ?, report_spec_status = ?
+            WHERE id = ?
+            """,
+            (
+                "economy_single",
+                '{"country_id":"us","report_kind":"economy_single","time_period":"2027","region":"ny","baseline_policy_id":10,"reform_policy_id":10,"dataset":"default","target":"general","options":{}}',
+                1,
+                "explicit",
+                report_output["id"],
+            ),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            report_spec_service.get_report_spec(report_output["id"])
+
+        assert "Report spec region must match linked simulations" in str(exc_info.value)
 
     def test_rejects_unsupported_schema_version_on_write(self, test_db):
         simulation_1 = simulation_service.create_simulation(

--- a/tests/unit/services/test_simulation_run_service.py
+++ b/tests/unit/services/test_simulation_run_service.py
@@ -38,36 +38,23 @@ class TestCreateSimulationRun:
         assert second_run["run_sequence"] == 2
         assert second_run["trigger_type"] == "rerun"
 
-    def test_retries_run_sequence_after_conflict(self, test_db, monkeypatch):
+    def test_allocates_run_sequence_transactionally(self, test_db):
         simulation = simulation_service.create_simulation(
             country_id="us",
             population_id="household_1a",
             population_type="household",
             policy_id=1,
         )
-        simulation_run_service.create_simulation_run(
+
+        first_run = simulation_run_service.create_simulation_run(
             simulation["id"], input_position=1, trigger_type="initial"
         )
-        original_next_run_sequence = simulation_run_service._next_run_sequence
-        attempts = iter([1, 2])
-
-        def conflicting_then_fresh_sequence(simulation_id: int) -> int:
-            try:
-                return next(attempts)
-            except StopIteration:
-                return original_next_run_sequence(simulation_id)
-
-        monkeypatch.setattr(
-            simulation_run_service,
-            "_next_run_sequence",
-            conflicting_then_fresh_sequence,
-        )
-
-        run = simulation_run_service.create_simulation_run(
+        second_run = simulation_run_service.create_simulation_run(
             simulation["id"], input_position=1, trigger_type="rerun"
         )
 
-        assert run["run_sequence"] == 2
+        assert first_run["run_sequence"] == 1
+        assert second_run["run_sequence"] == 2
 
     def test_raises_when_parent_simulation_is_missing(self, test_db):
         with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/services/test_simulation_run_service.py
+++ b/tests/unit/services/test_simulation_run_service.py
@@ -1,0 +1,130 @@
+from policyengine_api.services.simulation_run_service import SimulationRunService
+from policyengine_api.services.simulation_service import SimulationService
+
+simulation_run_service = SimulationRunService()
+simulation_service = SimulationService()
+
+
+class TestCreateSimulationRun:
+    def test_creates_simulation_runs_with_incrementing_sequence(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1",
+            population_type="household",
+            policy_id=1,
+        )
+
+        first_run = simulation_run_service.create_simulation_run(
+            simulation["id"],
+            input_position=1,
+            trigger_type="initial",
+            simulation_spec_snapshot={"population_id": "household_1"},
+            version_manifest={"simulation_cache_version": "s123"},
+        )
+        second_run = simulation_run_service.create_simulation_run(
+            simulation["id"],
+            input_position=1,
+            trigger_type="rerun",
+        )
+
+        assert first_run["run_sequence"] == 1
+        assert first_run["trigger_type"] == "initial"
+        assert first_run["simulation_spec_snapshot_json"] == {
+            "population_id": "household_1"
+        }
+        assert first_run["simulation_cache_version"] == "s123"
+        assert second_run["run_sequence"] == 2
+        assert second_run["trigger_type"] == "rerun"
+
+
+class TestSelectDisplaySimulationRun:
+    def test_prefers_active_run(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_2",
+            population_type="household",
+            policy_id=2,
+        )
+        latest_successful_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="initial"
+        )
+        active_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET active_run_id = ?, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            (active_run["id"], latest_successful_run["id"], simulation["id"]),
+        )
+        updated_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation["id"],),
+        ).fetchone()
+
+        selected_run = simulation_run_service.select_display_run(updated_simulation)
+
+        assert selected_run["id"] == active_run["id"]
+
+    def test_falls_back_to_latest_successful_run(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_3",
+            population_type="household",
+            policy_id=3,
+        )
+        successful_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="initial"
+        )
+        simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET active_run_id = NULL, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            (successful_run["id"], simulation["id"]),
+        )
+        updated_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation["id"],),
+        ).fetchone()
+
+        selected_run = simulation_run_service.select_display_run(updated_simulation)
+
+        assert selected_run["id"] == successful_run["id"]
+
+    def test_falls_back_to_newest_run_when_no_pointers_exist(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4",
+            population_type="household",
+            policy_id=4,
+        )
+        first_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="initial"
+        )
+        newest_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET active_run_id = NULL, latest_successful_run_id = NULL
+            WHERE id = ?
+            """,
+            (simulation["id"],),
+        )
+        updated_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation["id"],),
+        ).fetchone()
+
+        selected_run = simulation_run_service.select_display_run(updated_simulation)
+
+        assert first_run["run_sequence"] == 1
+        assert selected_run["id"] == newest_run["id"]

--- a/tests/unit/services/test_simulation_run_service.py
+++ b/tests/unit/services/test_simulation_run_service.py
@@ -1,3 +1,5 @@
+import pytest
+
 from policyengine_api.services.simulation_run_service import SimulationRunService
 from policyengine_api.services.simulation_service import SimulationService
 
@@ -35,6 +37,45 @@ class TestCreateSimulationRun:
         assert first_run["simulation_cache_version"] == "s123"
         assert second_run["run_sequence"] == 2
         assert second_run["trigger_type"] == "rerun"
+
+    def test_retries_run_sequence_after_conflict(self, test_db, monkeypatch):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_1a",
+            population_type="household",
+            policy_id=1,
+        )
+        simulation_run_service.create_simulation_run(
+            simulation["id"], input_position=1, trigger_type="initial"
+        )
+        original_next_run_sequence = simulation_run_service._next_run_sequence
+        attempts = iter([1, 2])
+
+        def conflicting_then_fresh_sequence(simulation_id: int) -> int:
+            try:
+                return next(attempts)
+            except StopIteration:
+                return original_next_run_sequence(simulation_id)
+
+        monkeypatch.setattr(
+            simulation_run_service,
+            "_next_run_sequence",
+            conflicting_then_fresh_sequence,
+        )
+
+        run = simulation_run_service.create_simulation_run(
+            simulation["id"], input_position=1, trigger_type="rerun"
+        )
+
+        assert run["run_sequence"] == 2
+
+    def test_raises_when_parent_simulation_is_missing(self, test_db):
+        with pytest.raises(ValueError) as exc_info:
+            simulation_run_service.create_simulation_run(
+                999999, input_position=1, trigger_type="initial"
+            )
+
+        assert "Simulation #999999 not found" in str(exc_info.value)
 
 
 class TestSelectDisplaySimulationRun:
@@ -98,6 +139,33 @@ class TestSelectDisplaySimulationRun:
 
         assert selected_run["id"] == successful_run["id"]
 
+    def test_falls_back_when_active_run_pointer_is_stale(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_3a",
+            population_type="household",
+            policy_id=3,
+        )
+        successful_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="initial"
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET active_run_id = ?, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            ("missing-run", successful_run["id"], simulation["id"]),
+        )
+        updated_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation["id"],),
+        ).fetchone()
+
+        selected_run = simulation_run_service.select_display_run(updated_simulation)
+
+        assert selected_run["id"] == successful_run["id"]
+
     def test_falls_back_to_newest_run_when_no_pointers_exist(self, test_db):
         simulation = simulation_service.create_simulation(
             country_id="us",
@@ -127,4 +195,33 @@ class TestSelectDisplaySimulationRun:
         selected_run = simulation_run_service.select_display_run(updated_simulation)
 
         assert first_run["run_sequence"] == 1
+        assert selected_run["id"] == newest_run["id"]
+
+    def test_falls_back_to_newest_run_when_latest_successful_pointer_is_stale(
+        self, test_db
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_4a",
+            population_type="household",
+            policy_id=4,
+        )
+        newest_run = simulation_run_service.create_simulation_run(
+            simulation["id"], trigger_type="rerun"
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET active_run_id = NULL, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            ("missing-run", simulation["id"]),
+        )
+        updated_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation["id"],),
+        ).fetchone()
+
+        selected_run = simulation_run_service.select_display_run(updated_simulation)
+
         assert selected_run["id"] == newest_run["id"]

--- a/tests/unit/services/test_simulation_spec_service.py
+++ b/tests/unit/services/test_simulation_spec_service.py
@@ -1,3 +1,5 @@
+import pytest
+
 from policyengine_api.services.simulation_service import SimulationService
 from policyengine_api.services.simulation_spec_service import (
     SimulationSpec,
@@ -59,3 +61,53 @@ class TestSimulationSpecService:
         )
         assert loaded_simulation_spec is not None
         assert loaded_simulation_spec.model_dump() == simulation_spec.model_dump()
+
+    def test_rejects_unsupported_schema_version_on_write(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=3,
+        )
+        simulation_spec = SimulationSpec.model_validate(
+            {
+                "country_id": "us",
+                "population_id": "ca",
+                "population_type": "geography",
+                "policy_id": 3,
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            simulation_spec_service.set_simulation_spec(
+                simulation["id"],
+                simulation_spec,
+                schema_version=2,
+            )
+
+        assert "Unsupported simulation spec schema version" in str(exc_info.value)
+
+    def test_rejects_unsupported_schema_version_on_read(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=3,
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET simulation_spec_json = ?, simulation_spec_schema_version = ?
+            WHERE id = ?
+            """,
+            (
+                '{"country_id":"us","population_id":"ca","population_type":"geography","policy_id":3}',
+                2,
+                simulation["id"],
+            ),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            simulation_spec_service.get_simulation_spec(simulation["id"])
+
+        assert "Unsupported simulation spec schema version" in str(exc_info.value)

--- a/tests/unit/services/test_simulation_spec_service.py
+++ b/tests/unit/services/test_simulation_spec_service.py
@@ -1,0 +1,61 @@
+from policyengine_api.services.simulation_service import SimulationService
+from policyengine_api.services.simulation_spec_service import (
+    SimulationSpec,
+    SimulationSpecService,
+)
+
+simulation_service = SimulationService()
+simulation_spec_service = SimulationSpecService()
+
+
+class TestSimulationSpecService:
+    def test_builds_simulation_spec_from_row(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="uk",
+            population_id="household_42",
+            population_type="household",
+            policy_id=7,
+        )
+
+        simulation_spec = simulation_spec_service.build_simulation_spec(simulation)
+
+        assert isinstance(simulation_spec, SimulationSpec)
+        assert simulation_spec.country_id == "uk"
+        assert simulation_spec.population_id == "household_42"
+        assert simulation_spec.policy_id == 7
+
+    def test_sets_and_gets_simulation_spec(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=3,
+        )
+        simulation_spec = SimulationSpec.model_validate(
+            {
+                "country_id": "us",
+                "population_id": "ca",
+                "population_type": "geography",
+                "policy_id": 3,
+            }
+        )
+
+        result = simulation_spec_service.set_simulation_spec(
+            simulation["id"], simulation_spec
+        )
+
+        assert result is True
+        stored_simulation = test_db.query(
+            """
+            SELECT simulation_spec_json, simulation_spec_schema_version
+            FROM simulations WHERE id = ?
+            """,
+            (simulation["id"],),
+        ).fetchone()
+        assert stored_simulation["simulation_spec_schema_version"] == 1
+
+        loaded_simulation_spec = simulation_spec_service.get_simulation_spec(
+            simulation["id"]
+        )
+        assert loaded_simulation_spec is not None
+        assert loaded_simulation_spec.model_dump() == simulation_spec.model_dump()

--- a/tests/unit/services/test_simulation_spec_service.py
+++ b/tests/unit/services/test_simulation_spec_service.py
@@ -111,3 +111,55 @@ class TestSimulationSpecService:
             simulation_spec_service.get_simulation_spec(simulation["id"])
 
         assert "Unsupported simulation spec schema version" in str(exc_info.value)
+
+    def test_rejects_simulation_spec_write_when_fields_do_not_match_row(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=3,
+        )
+        simulation_spec = SimulationSpec.model_validate(
+            {
+                "country_id": "us",
+                "population_id": "ny",
+                "population_type": "geography",
+                "policy_id": 3,
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            simulation_spec_service.set_simulation_spec(
+                simulation["id"], simulation_spec
+            )
+
+        assert "Simulation spec must match the linked simulation row" in str(
+            exc_info.value
+        )
+
+    def test_rejects_inconsistent_stored_simulation_spec_on_read(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="ca",
+            population_type="geography",
+            policy_id=3,
+        )
+        test_db.query(
+            """
+            UPDATE simulations
+            SET simulation_spec_json = ?, simulation_spec_schema_version = ?
+            WHERE id = ?
+            """,
+            (
+                '{"country_id":"us","population_id":"ny","population_type":"geography","policy_id":3}',
+                1,
+                simulation["id"],
+            ),
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            simulation_spec_service.get_simulation_spec(simulation["id"])
+
+        assert "Simulation spec must match the linked simulation row" in str(
+            exc_info.value
+        )


### PR DESCRIPTION
Fixes #3427

## Summary

This PR implements stage 2 of the report-output run migration plan.

It adds internal services and tests for:

- typed report specs
- typed simulation specs
- explicit legacy report alias resolution
- report run creation and selection
- simulation run creation and selection

## What changes for consumers

Nothing yet.

This is an internal service-layer PR only. Routes, response shapes, and runtime behavior stay the same.

## What does not change

- no endpoint contract changes
- no route integration yet
- no backfill
- no dual-write
- no rerun behavior change

## Safety

- isolated internal service layer
- no production behavior changes
- focused unit coverage for every new service

## Verification

```bash
FLASK_DEBUG=1 uv run pytest --confcutdir=tests/unit \
  tests/unit/services/test_report_spec_service.py \
  tests/unit/services/test_simulation_spec_service.py \
  tests/unit/services/test_report_output_alias_service.py \
  tests/unit/services/test_report_run_service.py \
  tests/unit/services/test_simulation_run_service.py
```
