### PR TITLE
Stage 5: Dual-write live updates into run tables

### DIFF
--- a/changelog.d/3440.changed.md
+++ b/changelog.d/3440.changed.md
@@ -1,0 +1,1 @@
+Dual-write live simulation and report create/update traffic into the new run tables, keep parent run pointers in sync, and harden report mutations to remain country-scoped and transactionally consistent.

--- a/policyengine_api/routes/report_output_routes.py
+++ b/policyengine_api/routes/report_output_routes.py
@@ -54,6 +54,11 @@ def create_report_output(country_id: str) -> Response:
         )
 
         if existing_report:
+            existing_report = (
+                report_output_service.ensure_report_output_dual_write_state(
+                    existing_report["id"]
+                )
+            )
             # Report already exists, return it with 200 status
             response_body = dict(
                 status="ok",

--- a/policyengine_api/routes/report_output_routes.py
+++ b/policyengine_api/routes/report_output_routes.py
@@ -56,7 +56,8 @@ def create_report_output(country_id: str) -> Response:
         if existing_report:
             existing_report = (
                 report_output_service.ensure_report_output_dual_write_state(
-                    existing_report["id"]
+                    existing_report["id"],
+                    country_id=country_id,
                 )
             )
             # Report already exists, return it with 200 status
@@ -109,7 +110,9 @@ def get_report_output(country_id: str, report_id: int) -> Response:
     """
     print(f"Getting report output {report_id} for country {country_id}")
 
-    report_output: dict | None = report_output_service.get_report_output(report_id)
+    report_output: dict | None = report_output_service.get_report_output(
+        country_id, report_id
+    )
 
     if report_output is None:
         raise NotFound(f"Report #{report_id} not found.")
@@ -165,7 +168,9 @@ def update_report_output(country_id: str) -> Response:
 
     try:
         # First check if the report output exists
-        existing_report = report_output_service.get_stored_report_output(report_id)
+        existing_report = report_output_service.get_stored_report_output(
+            country_id, report_id
+        )
         if existing_report is None:
             raise NotFound(f"Report #{report_id} not found.")
 
@@ -183,7 +188,9 @@ def update_report_output(country_id: str) -> Response:
 
         # Get the updated stored record so stale-runtime jobs do not appear to
         # complete the current runtime lineage in the PATCH response.
-        updated_report = report_output_service.get_stored_report_output(report_id)
+        updated_report = report_output_service.get_stored_report_output(
+            country_id, report_id
+        )
 
         response_body = dict(
             status="ok",

--- a/policyengine_api/routes/simulation_routes.py
+++ b/policyengine_api/routes/simulation_routes.py
@@ -4,7 +4,6 @@ import json
 
 from policyengine_api.services.simulation_service import SimulationService
 from policyengine_api.utils.payload_validators import validate_country
-from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 
 simulation_bp = Blueprint("simulation", __name__)
 simulation_service = SimulationService()
@@ -57,6 +56,9 @@ def create_simulation(country_id: str) -> Response:
         )
 
         if existing_simulation:
+            existing_simulation = simulation_service.ensure_simulation_dual_write_state(
+                existing_simulation["id"]
+            )
             # Simulation already exists, return it with 200 status
             response_body = dict(
                 status="ok",

--- a/policyengine_api/routes/simulation_routes.py
+++ b/policyengine_api/routes/simulation_routes.py
@@ -57,7 +57,8 @@ def create_simulation(country_id: str) -> Response:
 
         if existing_simulation:
             existing_simulation = simulation_service.ensure_simulation_dual_write_state(
-                existing_simulation["id"]
+                existing_simulation["id"],
+                country_id=country_id,
             )
             # Simulation already exists, return it with 200 status
             response_body = dict(

--- a/policyengine_api/services/report_output_service.py
+++ b/policyengine_api/services/report_output_service.py
@@ -93,6 +93,24 @@ class ReportOutputService:
 
         return simulation_1, simulation_2
 
+    def _require_simulation_exists(
+        self,
+        tx,
+        *,
+        country_id: str,
+        simulation_id: int,
+    ) -> dict:
+        simulation = self.simulation_service._get_simulation_row(
+            simulation_id,
+            queryer=tx,
+            country_id=country_id,
+        )
+        if simulation is None:
+            raise ValueError(
+                f"Report output references missing simulation #{simulation_id}"
+            )
+        return simulation
+
     def _list_report_runs_descending(
         self, report_output_id: int, *, queryer=None
     ) -> list[dict]:
@@ -584,6 +602,18 @@ class ReportOutputService:
                         tx,
                         existing_report["id"],
                         country_id=country_id,
+                    )
+
+                self._require_simulation_exists(
+                    tx,
+                    country_id=country_id,
+                    simulation_id=simulation_1_id,
+                )
+                if simulation_2_id is not None:
+                    self._require_simulation_exists(
+                        tx,
+                        country_id=country_id,
+                        simulation_id=simulation_2_id,
                     )
 
                 if simulation_2_id is not None:

--- a/policyengine_api/services/report_output_service.py
+++ b/policyengine_api/services/report_output_service.py
@@ -2,15 +2,318 @@ from sqlalchemy.engine.row import Row
 
 from policyengine_api.data import database
 from policyengine_api.constants import get_report_output_cache_version
+from policyengine_api.services.report_run_service import ReportRunService
+from policyengine_api.services.report_spec_service import (
+    ECONOMY_REPORT_KINDS,
+    ReportSpec,
+    ReportSpecService,
+)
+from policyengine_api.services.run_sync_utils import (
+    determine_parent_pointers,
+    serialize_json_field,
+)
 
 
 class ReportOutputService:
+    def __init__(self):
+        self.report_spec_service = ReportSpecService()
+        self.report_run_service = ReportRunService()
+
     def _get_report_output_row(self, report_output_id: int) -> dict | None:
         row: Row | None = database.query(
             "SELECT * FROM report_outputs WHERE id = ?",
             (report_output_id,),
         ).fetchone()
         return dict(row) if row is not None else None
+
+    def _get_simulation_row(self, simulation_id: int) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def _get_linked_simulations(self, report_output: dict) -> tuple[dict, dict | None]:
+        simulation_1 = self._get_simulation_row(report_output["simulation_1_id"])
+        if simulation_1 is None:
+            raise ValueError(
+                "Report output references missing simulation "
+                f"#{report_output['simulation_1_id']}"
+            )
+
+        simulation_2 = None
+        if report_output["simulation_2_id"] is not None:
+            simulation_2 = self._get_simulation_row(report_output["simulation_2_id"])
+            if simulation_2 is None:
+                raise ValueError(
+                    "Report output references missing simulation "
+                    f"#{report_output['simulation_2_id']}"
+                )
+
+        return simulation_1, simulation_2
+
+    def _get_runs_descending(self, report_output_id: int) -> list[dict]:
+        return sorted(
+            self.report_run_service.list_report_output_runs(report_output_id),
+            key=lambda run: run["run_sequence"],
+            reverse=True,
+        )
+
+    def _select_mutable_run(
+        self, report_output: dict, runs_descending: list[dict]
+    ) -> dict | None:
+        active_run_id = report_output.get("active_run_id")
+        if active_run_id:
+            active_run = self.report_run_service.get_report_output_run(active_run_id)
+            if active_run is not None:
+                return active_run
+        return runs_descending[0] if runs_descending else None
+
+    def _derive_report_country_package_version(
+        self,
+        simulation_1: dict,
+        simulation_2: dict | None = None,
+    ) -> str | None:
+        versions = [
+            simulation["api_version"]
+            for simulation in (simulation_1, simulation_2)
+            if simulation is not None and simulation.get("api_version") is not None
+        ]
+        if not versions:
+            return None
+        if len(set(versions)) == 1:
+            return versions[0]
+        return None
+
+    def _build_version_manifest(
+        self,
+        report_output: dict,
+        report_spec: ReportSpec | None,
+        simulation_1: dict | None = None,
+        simulation_2: dict | None = None,
+    ) -> dict[str, str | None]:
+        resolved_dataset = None
+        if report_spec is not None and report_spec.report_kind in ECONOMY_REPORT_KINDS:
+            resolved_dataset = report_spec.dataset
+
+        return {
+            "country_package_version": (
+                self._derive_report_country_package_version(simulation_1, simulation_2)
+                if simulation_1 is not None
+                else None
+            ),
+            "policyengine_version": None,
+            "data_version": None,
+            "runtime_app_name": None,
+            "report_cache_version": report_output.get("api_version"),
+            "simulation_cache_version": None,
+            "requested_version_override": None,
+            "resolved_dataset": resolved_dataset,
+            "resolved_options_hash": None,
+        }
+
+    def _get_report_spec_status(self, report_spec: ReportSpec) -> str:
+        if report_spec.report_kind in ECONOMY_REPORT_KINDS:
+            return "backfilled_assumed"
+        return "explicit"
+
+    def _upsert_report_spec(
+        self, report_output: dict
+    ) -> tuple[ReportSpec | None, dict | None, dict | None]:
+        try:
+            simulation_1, simulation_2 = self._get_linked_simulations(report_output)
+        except ValueError as exc:
+            print(
+                "Skipping report spec sync for report output "
+                f"#{report_output['id']}. Details: {str(exc)}"
+            )
+            return None, None, None
+
+        try:
+            report_spec = self.report_spec_service.build_report_spec(
+                report_output=report_output,
+                simulation_1=simulation_1,
+                simulation_2=simulation_2,
+            )
+        except ValueError as exc:
+            print(
+                "Skipping report spec sync for report output "
+                f"#{report_output['id']}. Details: {str(exc)}"
+            )
+            return None, simulation_1, simulation_2
+
+        report_spec_status = self._get_report_spec_status(report_spec)
+        existing_spec = None
+        try:
+            existing_spec = self.report_spec_service.get_report_spec(
+                report_output["id"]
+            )
+        except ValueError:
+            existing_spec = None
+
+        if (
+            existing_spec is None
+            or existing_spec.model_dump() != report_spec.model_dump()
+            or report_output.get("report_spec_status") != report_spec_status
+        ):
+            self.report_spec_service.set_report_spec(
+                report_output_id=report_output["id"],
+                report_spec=report_spec,
+                report_spec_status=report_spec_status,
+            )
+
+        return report_spec, simulation_1, simulation_2
+
+    def _run_matches_parent(
+        self,
+        run: dict,
+        report_output: dict,
+        report_spec: ReportSpec | None,
+        version_manifest: dict[str, str | None],
+    ) -> bool:
+        expected_snapshot = (
+            report_spec.model_dump() if report_spec is not None else None
+        )
+        return (
+            run["status"] == report_output["status"]
+            and run.get("output") == report_output.get("output")
+            and run.get("error_message") == report_output.get("error_message")
+            and run.get("report_spec_snapshot_json") == expected_snapshot
+            and run.get("country_package_version")
+            == version_manifest["country_package_version"]
+            and run.get("policyengine_version")
+            == version_manifest["policyengine_version"]
+            and run.get("data_version") == version_manifest["data_version"]
+            and run.get("runtime_app_name") == version_manifest["runtime_app_name"]
+            and run.get("report_cache_version")
+            == version_manifest["report_cache_version"]
+            and run.get("simulation_cache_version")
+            == version_manifest["simulation_cache_version"]
+            and run.get("requested_version_override")
+            == version_manifest["requested_version_override"]
+            and run.get("resolved_dataset") == version_manifest["resolved_dataset"]
+            and run.get("resolved_options_hash")
+            == version_manifest["resolved_options_hash"]
+        )
+
+    def _update_report_run(
+        self,
+        run_id: str,
+        report_output: dict,
+        report_spec: ReportSpec | None,
+        version_manifest: dict[str, str | None],
+    ) -> None:
+        report_spec_snapshot = (
+            report_spec.model_dump_json() if report_spec is not None else None
+        )
+        database.query(
+            """
+            UPDATE report_output_runs
+            SET status = ?, output = ?, error_message = ?,
+                report_spec_snapshot_json = ?, country_package_version = ?,
+                policyengine_version = ?, data_version = ?, runtime_app_name = ?,
+                report_cache_version = ?, simulation_cache_version = ?,
+                requested_version_override = ?, resolved_dataset = ?,
+                resolved_options_hash = ?
+            WHERE id = ?
+            """,
+            (
+                report_output["status"],
+                serialize_json_field(report_output.get("output")),
+                report_output.get("error_message"),
+                report_spec_snapshot,
+                version_manifest["country_package_version"],
+                version_manifest["policyengine_version"],
+                version_manifest["data_version"],
+                version_manifest["runtime_app_name"],
+                version_manifest["report_cache_version"],
+                version_manifest["simulation_cache_version"],
+                version_manifest["requested_version_override"],
+                version_manifest["resolved_dataset"],
+                version_manifest["resolved_options_hash"],
+                run_id,
+            ),
+        )
+
+    def _sync_parent_pointers(
+        self, report_output: dict, runs_descending: list[dict]
+    ) -> None:
+        desired_active_run_id, desired_latest_successful_run_id = (
+            determine_parent_pointers(report_output["status"], runs_descending)
+        )
+        if (
+            report_output.get("active_run_id") == desired_active_run_id
+            and report_output.get("latest_successful_run_id")
+            == desired_latest_successful_run_id
+        ):
+            return
+
+        database.query(
+            """
+            UPDATE report_outputs
+            SET active_run_id = ?, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            (
+                desired_active_run_id,
+                desired_latest_successful_run_id,
+                report_output["id"],
+            ),
+        )
+
+    def ensure_report_output_dual_write_state(self, report_output_id: int) -> dict:
+        report_output = self._get_report_output_row(report_output_id)
+        if report_output is None:
+            raise ValueError(f"Report output #{report_output_id} not found")
+
+        report_spec, simulation_1, simulation_2 = self._upsert_report_spec(
+            report_output
+        )
+        report_output = self._get_report_output_row(report_output_id)
+        if report_output is None:
+            raise ValueError(f"Report output #{report_output_id} not found after sync")
+
+        version_manifest = self._build_version_manifest(
+            report_output,
+            report_spec=report_spec,
+            simulation_1=simulation_1,
+            simulation_2=simulation_2,
+        )
+        runs_descending = self._get_runs_descending(report_output_id)
+        if not runs_descending:
+            self.report_run_service.create_report_output_run(
+                report_output_id=report_output_id,
+                status=report_output["status"],
+                trigger_type="initial",
+                output=report_output.get("output"),
+                error_message=report_output.get("error_message"),
+                report_spec_snapshot=(
+                    report_spec.model_dump() if report_spec is not None else None
+                ),
+                version_manifest=version_manifest,
+            )
+            runs_descending = self._get_runs_descending(report_output_id)
+        else:
+            mutable_run = self._select_mutable_run(report_output, runs_descending)
+            if mutable_run is not None and not self._run_matches_parent(
+                mutable_run,
+                report_output,
+                report_spec,
+                version_manifest,
+            ):
+                self._update_report_run(
+                    run_id=mutable_run["id"],
+                    report_output=report_output,
+                    report_spec=report_spec,
+                    version_manifest=version_manifest,
+                )
+                runs_descending = self._get_runs_descending(report_output_id)
+
+        self._sync_parent_pointers(report_output, runs_descending)
+        refreshed_report_output = self._get_report_output_row(report_output_id)
+        if refreshed_report_output is None:
+            raise ValueError(f"Report output #{report_output_id} not found after sync")
+        return refreshed_report_output
 
     def get_stored_report_output(self, report_output_id: int) -> dict | None:
         """
@@ -125,7 +428,7 @@ class ReportOutputService:
                 print(
                     f"Reusing existing report output with ID: {existing_report['id']}"
                 )
-                return existing_report
+                return self.ensure_report_output_dual_write_state(existing_report["id"])
 
             # Insert with default status 'pending'
             if simulation_2_id is not None:
@@ -161,7 +464,7 @@ class ReportOutputService:
                 raise Exception("Failed to retrieve created report output")
 
             print(f"Created report output with ID: {created_report['id']}")
-            return created_report
+            return self.ensure_report_output_dual_write_state(created_report["id"])
 
         except Exception as e:
             print(f"Error creating report output. Details: {str(e)}")
@@ -255,6 +558,7 @@ class ReportOutputService:
             query = f"UPDATE report_outputs SET {', '.join(update_fields)} WHERE id = ?"
 
             database.query(query, tuple(update_values))
+            self.ensure_report_output_dual_write_state(requested_report["id"])
 
             print(f"Successfully updated report output #{report_id}")
             return True

--- a/policyengine_api/services/report_output_service.py
+++ b/policyengine_api/services/report_output_service.py
@@ -1,8 +1,9 @@
+import uuid
+
 from sqlalchemy.engine.row import Row
 
-from policyengine_api.data import database
 from policyengine_api.constants import get_report_output_cache_version
-from policyengine_api.services.report_run_service import ReportRunService
+from policyengine_api.data import database
 from policyengine_api.services.report_spec_service import (
     ECONOMY_REPORT_KINDS,
     ReportSpec,
@@ -10,31 +11,60 @@ from policyengine_api.services.report_spec_service import (
 )
 from policyengine_api.services.run_sync_utils import (
     determine_parent_pointers,
+    parse_json_field,
     serialize_json_field,
 )
+from policyengine_api.services.simulation_service import SimulationService
 
 
 class ReportOutputService:
     def __init__(self):
         self.report_spec_service = ReportSpecService()
-        self.report_run_service = ReportRunService()
+        self.simulation_service = SimulationService()
 
-    def _get_report_output_row(self, report_output_id: int) -> dict | None:
-        row: Row | None = database.query(
-            "SELECT * FROM report_outputs WHERE id = ?",
-            (report_output_id,),
-        ).fetchone()
+    def _lock_clause(self) -> str:
+        return "" if database.local else " FOR UPDATE"
+
+    def _get_report_output_row(
+        self,
+        report_output_id: int,
+        *,
+        queryer=None,
+        country_id: str | None = None,
+        for_update: bool = False,
+    ) -> dict | None:
+        queryer = queryer or database
+        query = "SELECT * FROM report_outputs WHERE id = ?"
+        params: list[int | str] = [report_output_id]
+        if country_id is not None:
+            query += " AND country_id = ?"
+            params.append(country_id)
+        if for_update:
+            query += self._lock_clause()
+
+        row: Row | None = queryer.query(query, tuple(params)).fetchone()
         return dict(row) if row is not None else None
 
-    def _get_simulation_row(self, simulation_id: int) -> dict | None:
-        row: Row | None = database.query(
-            "SELECT * FROM simulations WHERE id = ?",
-            (simulation_id,),
-        ).fetchone()
-        return dict(row) if row is not None else None
-
-    def _get_linked_simulations(self, report_output: dict) -> tuple[dict, dict | None]:
-        simulation_1 = self._get_simulation_row(report_output["simulation_1_id"])
+    def _get_linked_simulations(
+        self,
+        report_output: dict,
+        *,
+        queryer=None,
+        bootstrap_dual_write_state: bool = False,
+    ) -> tuple[dict, dict | None]:
+        queryer = queryer or database
+        if bootstrap_dual_write_state:
+            simulation_1 = self.simulation_service._ensure_simulation_dual_write_state_in_transaction(
+                queryer,
+                report_output["simulation_1_id"],
+                country_id=report_output["country_id"],
+            )
+        else:
+            simulation_1 = self.simulation_service._get_simulation_row(
+                report_output["simulation_1_id"],
+                queryer=queryer,
+                country_id=report_output["country_id"],
+            )
         if simulation_1 is None:
             raise ValueError(
                 "Report output references missing simulation "
@@ -43,7 +73,18 @@ class ReportOutputService:
 
         simulation_2 = None
         if report_output["simulation_2_id"] is not None:
-            simulation_2 = self._get_simulation_row(report_output["simulation_2_id"])
+            if bootstrap_dual_write_state:
+                simulation_2 = self.simulation_service._ensure_simulation_dual_write_state_in_transaction(
+                    queryer,
+                    report_output["simulation_2_id"],
+                    country_id=report_output["country_id"],
+                )
+            else:
+                simulation_2 = self.simulation_service._get_simulation_row(
+                    report_output["simulation_2_id"],
+                    queryer=queryer,
+                    country_id=report_output["country_id"],
+                )
             if simulation_2 is None:
                 raise ValueError(
                     "Report output references missing simulation "
@@ -52,26 +93,41 @@ class ReportOutputService:
 
         return simulation_1, simulation_2
 
-    def _get_runs_descending(self, report_output_id: int) -> list[dict]:
-        return sorted(
-            self.report_run_service.list_report_output_runs(report_output_id),
-            key=lambda run: run["run_sequence"],
-            reverse=True,
-        )
+    def _list_report_runs_descending(
+        self, report_output_id: int, *, queryer=None
+    ) -> list[dict]:
+        queryer = queryer or database
+        rows = queryer.query(
+            """
+            SELECT * FROM report_output_runs
+            WHERE report_output_id = ?
+            ORDER BY run_sequence DESC
+            """,
+            (report_output_id,),
+        ).fetchall()
+
+        runs = []
+        for row in rows:
+            run = dict(row)
+            run["report_spec_snapshot_json"] = parse_json_field(
+                run.get("report_spec_snapshot_json")
+            )
+            runs.append(run)
+        return runs
 
     def _select_mutable_run(
         self, report_output: dict, runs_descending: list[dict]
     ) -> dict | None:
         active_run_id = report_output.get("active_run_id")
-        if active_run_id:
-            active_run = self.report_run_service.get_report_output_run(active_run_id)
-            if active_run is not None:
-                return active_run
+        if active_run_id is not None:
+            for run in runs_descending:
+                if run["id"] == active_run_id:
+                    return run
         return runs_descending[0] if runs_descending else None
 
     def _derive_report_country_package_version(
         self,
-        simulation_1: dict,
+        simulation_1: dict | None,
         simulation_2: dict | None = None,
     ) -> str | None:
         versions = [
@@ -97,10 +153,8 @@ class ReportOutputService:
             resolved_dataset = report_spec.dataset
 
         return {
-            "country_package_version": (
-                self._derive_report_country_package_version(simulation_1, simulation_2)
-                if simulation_1 is not None
-                else None
+            "country_package_version": self._derive_report_country_package_version(
+                simulation_1, simulation_2
             ),
             "policyengine_version": None,
             "data_version": None,
@@ -117,17 +171,15 @@ class ReportOutputService:
             return "backfilled_assumed"
         return "explicit"
 
-    def _upsert_report_spec(
-        self, report_output: dict
-    ) -> tuple[ReportSpec | None, dict | None, dict | None]:
-        try:
-            simulation_1, simulation_2 = self._get_linked_simulations(report_output)
-        except ValueError as exc:
-            print(
-                "Skipping report spec sync for report output "
-                f"#{report_output['id']}. Details: {str(exc)}"
-            )
-            return None, None, None
+    def _upsert_report_spec_in_transaction(
+        self,
+        tx,
+        report_output: dict,
+        simulation_1: dict | None,
+        simulation_2: dict | None,
+    ) -> ReportSpec | None:
+        if simulation_1 is None:
+            return None
 
         try:
             report_spec = self.report_spec_service.build_report_spec(
@@ -140,29 +192,37 @@ class ReportOutputService:
                 "Skipping report spec sync for report output "
                 f"#{report_output['id']}. Details: {str(exc)}"
             )
-            return None, simulation_1, simulation_2
+            return None
 
         report_spec_status = self._get_report_spec_status(report_spec)
-        existing_spec = None
-        try:
-            existing_spec = self.report_spec_service.get_report_spec(
-                report_output["id"]
-            )
-        except ValueError:
-            existing_spec = None
-
+        existing_spec = parse_json_field(report_output.get("report_spec_json"))
         if (
-            existing_spec is None
-            or existing_spec.model_dump() != report_spec.model_dump()
+            existing_spec != report_spec.model_dump()
+            or report_output.get("report_kind") != report_spec.report_kind
+            or report_output.get("report_spec_schema_version") != 1
             or report_output.get("report_spec_status") != report_spec_status
         ):
-            self.report_spec_service.set_report_spec(
-                report_output_id=report_output["id"],
-                report_spec=report_spec,
-                report_spec_status=report_spec_status,
+            tx.query(
+                """
+                UPDATE report_outputs
+                SET report_kind = ?, report_spec_json = ?,
+                    report_spec_schema_version = ?, report_spec_status = ?
+                WHERE id = ?
+                """,
+                (
+                    report_spec.report_kind,
+                    report_spec.model_dump_json(),
+                    1,
+                    report_spec_status,
+                    report_output["id"],
+                ),
             )
+            report_output["report_kind"] = report_spec.report_kind
+            report_output["report_spec_json"] = report_spec.model_dump()
+            report_output["report_spec_schema_version"] = 1
+            report_output["report_spec_status"] = report_spec_status
 
-        return report_spec, simulation_1, simulation_2
+        return report_spec
 
     def _run_matches_parent(
         self,
@@ -196,17 +256,58 @@ class ReportOutputService:
             == version_manifest["resolved_options_hash"]
         )
 
-    def _update_report_run(
+    def _insert_bootstrap_report_run(
         self,
+        tx,
+        report_output: dict,
+        report_spec: ReportSpec | None,
+        version_manifest: dict[str, str | None],
+    ) -> None:
+        tx.query(
+            """
+            INSERT INTO report_output_runs (
+                id, report_output_id, run_sequence, status, output, error_message,
+                trigger_type, requested_at, started_at, finished_at, source_run_id,
+                report_spec_snapshot_json, country_package_version, policyengine_version,
+                data_version, runtime_app_name, report_cache_version,
+                simulation_cache_version, requested_version_override, resolved_dataset,
+                resolved_options_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid.uuid4()),
+                report_output["id"],
+                1,
+                report_output["status"],
+                serialize_json_field(report_output.get("output")),
+                report_output.get("error_message"),
+                "initial",
+                None,
+                None,
+                None,
+                None,
+                (report_spec.model_dump_json() if report_spec is not None else None),
+                version_manifest["country_package_version"],
+                version_manifest["policyengine_version"],
+                version_manifest["data_version"],
+                version_manifest["runtime_app_name"],
+                version_manifest["report_cache_version"],
+                version_manifest["simulation_cache_version"],
+                version_manifest["requested_version_override"],
+                version_manifest["resolved_dataset"],
+                version_manifest["resolved_options_hash"],
+            ),
+        )
+
+    def _update_report_run_in_transaction(
+        self,
+        tx,
         run_id: str,
         report_output: dict,
         report_spec: ReportSpec | None,
         version_manifest: dict[str, str | None],
     ) -> None:
-        report_spec_snapshot = (
-            report_spec.model_dump_json() if report_spec is not None else None
-        )
-        database.query(
+        tx.query(
             """
             UPDATE report_output_runs
             SET status = ?, output = ?, error_message = ?,
@@ -221,7 +322,7 @@ class ReportOutputService:
                 report_output["status"],
                 serialize_json_field(report_output.get("output")),
                 report_output.get("error_message"),
-                report_spec_snapshot,
+                (report_spec.model_dump_json() if report_spec is not None else None),
                 version_manifest["country_package_version"],
                 version_manifest["policyengine_version"],
                 version_manifest["data_version"],
@@ -235,8 +336,11 @@ class ReportOutputService:
             ),
         )
 
-    def _sync_parent_pointers(
-        self, report_output: dict, runs_descending: list[dict]
+    def _sync_parent_pointers_in_transaction(
+        self,
+        tx,
+        report_output: dict,
+        runs_descending: list[dict],
     ) -> None:
         desired_active_run_id, desired_latest_successful_run_id = (
             determine_parent_pointers(report_output["status"], runs_descending)
@@ -248,7 +352,7 @@ class ReportOutputService:
         ):
             return
 
-        database.query(
+        tx.query(
             """
             UPDATE report_outputs
             SET active_run_id = ?, latest_successful_run_id = ?
@@ -260,39 +364,63 @@ class ReportOutputService:
                 report_output["id"],
             ),
         )
+        report_output["active_run_id"] = desired_active_run_id
+        report_output["latest_successful_run_id"] = desired_latest_successful_run_id
 
-    def ensure_report_output_dual_write_state(self, report_output_id: int) -> dict:
-        report_output = self._get_report_output_row(report_output_id)
+    def _ensure_report_output_dual_write_state_in_transaction(
+        self,
+        tx,
+        report_output_id: int,
+        *,
+        country_id: str | None = None,
+    ) -> dict:
+        report_output = self._get_report_output_row(
+            report_output_id,
+            queryer=tx,
+            country_id=country_id,
+            for_update=True,
+        )
         if report_output is None:
             raise ValueError(f"Report output #{report_output_id} not found")
 
-        report_spec, simulation_1, simulation_2 = self._upsert_report_spec(
-            report_output
-        )
-        report_output = self._get_report_output_row(report_output_id)
-        if report_output is None:
-            raise ValueError(f"Report output #{report_output_id} not found after sync")
+        try:
+            simulation_1, simulation_2 = self._get_linked_simulations(
+                report_output,
+                queryer=tx,
+                bootstrap_dual_write_state=True,
+            )
+        except ValueError as exc:
+            print(
+                "Skipping linked simulation sync for report output "
+                f"#{report_output_id}. Details: {str(exc)}"
+            )
+            simulation_1, simulation_2 = None, None
 
+        report_spec = self._upsert_report_spec_in_transaction(
+            tx,
+            report_output,
+            simulation_1,
+            simulation_2,
+        )
         version_manifest = self._build_version_manifest(
             report_output,
             report_spec=report_spec,
             simulation_1=simulation_1,
             simulation_2=simulation_2,
         )
-        runs_descending = self._get_runs_descending(report_output_id)
+        runs_descending = self._list_report_runs_descending(
+            report_output_id, queryer=tx
+        )
         if not runs_descending:
-            self.report_run_service.create_report_output_run(
-                report_output_id=report_output_id,
-                status=report_output["status"],
-                trigger_type="initial",
-                output=report_output.get("output"),
-                error_message=report_output.get("error_message"),
-                report_spec_snapshot=(
-                    report_spec.model_dump() if report_spec is not None else None
-                ),
-                version_manifest=version_manifest,
+            self._insert_bootstrap_report_run(
+                tx,
+                report_output,
+                report_spec,
+                version_manifest,
             )
-            runs_descending = self._get_runs_descending(report_output_id)
+            runs_descending = self._list_report_runs_descending(
+                report_output_id, queryer=tx
+            )
         else:
             mutable_run = self._select_mutable_run(report_output, runs_descending)
             if mutable_run is not None and not self._run_matches_parent(
@@ -301,32 +429,80 @@ class ReportOutputService:
                 report_spec,
                 version_manifest,
             ):
-                self._update_report_run(
+                self._update_report_run_in_transaction(
+                    tx,
                     run_id=mutable_run["id"],
                     report_output=report_output,
                     report_spec=report_spec,
                     version_manifest=version_manifest,
                 )
-                runs_descending = self._get_runs_descending(report_output_id)
+                runs_descending = self._list_report_runs_descending(
+                    report_output_id, queryer=tx
+                )
 
-        self._sync_parent_pointers(report_output, runs_descending)
-        refreshed_report_output = self._get_report_output_row(report_output_id)
+        self._sync_parent_pointers_in_transaction(tx, report_output, runs_descending)
+        refreshed_report_output = self._get_report_output_row(
+            report_output_id,
+            queryer=tx,
+            country_id=country_id,
+        )
         if refreshed_report_output is None:
             raise ValueError(f"Report output #{report_output_id} not found after sync")
         return refreshed_report_output
 
-    def get_stored_report_output(self, report_output_id: int) -> dict | None:
+    def ensure_report_output_dual_write_state(
+        self,
+        report_output_id: int,
+        country_id: str | None = None,
+    ) -> dict:
+        return database.transaction(
+            lambda tx: self._ensure_report_output_dual_write_state_in_transaction(
+                tx,
+                report_output_id,
+                country_id=country_id,
+            )
+        )
+
+    def get_stored_report_output(
+        self, country_id: str, report_output_id: int
+    ) -> dict | None:
         """
         Get the raw stored report output row by ID without aliasing to the
         current runtime lineage. This is useful for mutation paths, which must
         update the originally addressed row rather than a resolved alias.
         """
-        return self._get_report_output_row(report_output_id)
+        return self._get_report_output_row(report_output_id, country_id=country_id)
 
     def _is_current_report_output(self, report_output: dict) -> bool:
         return report_output.get("api_version") == get_report_output_cache_version(
             report_output["country_id"]
         )
+
+    def _find_existing_report_output_row(
+        self,
+        *,
+        country_id: str,
+        simulation_1_id: int,
+        simulation_2_id: int | None,
+        year: str,
+        queryer=None,
+    ) -> dict | None:
+        queryer = queryer or database
+        api_version = get_report_output_cache_version(country_id)
+        query = """
+            SELECT * FROM report_outputs
+            WHERE country_id = ? AND simulation_1_id = ? AND year = ? AND api_version = ?
+        """
+        params: list[int | str] = [country_id, simulation_1_id, year, api_version]
+        if simulation_2_id is not None:
+            query += " AND simulation_2_id = ?"
+            params.append(simulation_2_id)
+        else:
+            query += " AND simulation_2_id IS NULL"
+        query += " ORDER BY id DESC"
+
+        row = queryer.query(query, tuple(params)).fetchone()
+        return dict(row) if row is not None else None
 
     def _get_or_create_current_report_output(self, report_output: dict) -> dict:
         current_report = self.find_existing_report_output(
@@ -359,39 +535,18 @@ class ReportOutputService:
     ) -> dict | None:
         """
         Find an existing report output with the same simulation IDs and year.
-
-        Args:
-            country_id (str): The country ID.
-            simulation_1_id (int): The first simulation ID (required).
-            simulation_2_id (int | None): The second simulation ID (optional, for comparisons).
-            year (str): The year for the report (defaults to "2025").
-
-        Returns:
-            dict | None: The existing report output data or None if not found.
         """
         print("Checking for existing report output")
-        api_version = get_report_output_cache_version(country_id)
 
         try:
-            query = "SELECT * FROM report_outputs WHERE country_id = ? AND simulation_1_id = ? AND year = ? AND api_version = ?"
-            params = [country_id, simulation_1_id, year, api_version]
-
-            if simulation_2_id is not None:
-                query += " AND simulation_2_id = ?"
-                params.append(simulation_2_id)
-            else:
-                query += " AND simulation_2_id IS NULL"
-
-            query += " ORDER BY id DESC"
-
-            row = database.query(query, tuple(params)).fetchone()
-
-            existing_report = None
-            if row is not None:
-                existing_report = dict(row)
+            existing_report = self._find_existing_report_output_row(
+                country_id=country_id,
+                simulation_1_id=simulation_1_id,
+                simulation_2_id=simulation_2_id,
+                year=year,
+            )
+            if existing_report is not None:
                 print(f"Found existing report output with ID: {existing_report['id']}")
-                # Keep output as JSON string - frontend expects string format
-
             return existing_report
 
         except Exception as e:
@@ -407,78 +562,88 @@ class ReportOutputService:
     ) -> dict:
         """
         Create a new report output record with pending status.
-
-        Args:
-            country_id (str): The country ID.
-            simulation_1_id (int): The first simulation ID (required).
-            simulation_2_id (int | None): The second simulation ID (optional, for comparisons).
-            year (str): The year for the report (defaults to "2025").
-
-        Returns:
-            dict: The created report output record.
         """
         print("Creating new report output")
         api_version = get_report_output_cache_version(country_id)
 
         try:
-            existing_report = self.find_existing_report_output(
-                country_id, simulation_1_id, simulation_2_id, year
-            )
-            if existing_report is not None:
-                print(
-                    f"Reusing existing report output with ID: {existing_report['id']}"
+
+            def tx_callback(tx):
+                existing_report = self._find_existing_report_output_row(
+                    country_id=country_id,
+                    simulation_1_id=simulation_1_id,
+                    simulation_2_id=simulation_2_id,
+                    year=year,
+                    queryer=tx,
                 )
-                return self.ensure_report_output_dual_write_state(existing_report["id"])
+                if existing_report is not None:
+                    print(
+                        f"Reusing existing report output with ID: {existing_report['id']}"
+                    )
+                    return self._ensure_report_output_dual_write_state_in_transaction(
+                        tx,
+                        existing_report["id"],
+                        country_id=country_id,
+                    )
 
-            # Insert with default status 'pending'
-            if simulation_2_id is not None:
-                database.query(
-                    "INSERT INTO report_outputs (country_id, simulation_1_id, simulation_2_id, api_version, status, year) VALUES (?, ?, ?, ?, ?, ?)",
-                    (
-                        country_id,
-                        simulation_1_id,
-                        simulation_2_id,
-                        api_version,
-                        "pending",
-                        year,
-                    ),
+                if simulation_2_id is not None:
+                    tx.query(
+                        """
+                        INSERT INTO report_outputs (
+                            country_id, simulation_1_id, simulation_2_id, api_version, status, year
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            country_id,
+                            simulation_1_id,
+                            simulation_2_id,
+                            api_version,
+                            "pending",
+                            year,
+                        ),
+                    )
+                else:
+                    tx.query(
+                        """
+                        INSERT INTO report_outputs (
+                            country_id, simulation_1_id, api_version, status, year
+                        ) VALUES (?, ?, ?, ?, ?)
+                        """,
+                        (
+                            country_id,
+                            simulation_1_id,
+                            api_version,
+                            "pending",
+                            year,
+                        ),
+                    )
+
+                created_report = self._find_existing_report_output_row(
+                    country_id=country_id,
+                    simulation_1_id=simulation_1_id,
+                    simulation_2_id=simulation_2_id,
+                    year=year,
+                    queryer=tx,
                 )
-            else:
-                database.query(
-                    "INSERT INTO report_outputs (country_id, simulation_1_id, api_version, status, year) VALUES (?, ?, ?, ?, ?)",
-                    (
-                        country_id,
-                        simulation_1_id,
-                        api_version,
-                        "pending",
-                        year,
-                    ),
+                if created_report is None:
+                    raise Exception("Failed to retrieve created report output")
+
+                print(f"Created report output with ID: {created_report['id']}")
+                return self._ensure_report_output_dual_write_state_in_transaction(
+                    tx,
+                    created_report["id"],
+                    country_id=country_id,
                 )
 
-            # Safely retrieve the created report output record
-            created_report = self.find_existing_report_output(
-                country_id, simulation_1_id, simulation_2_id, year
-            )
-
-            if created_report is None:
-                raise Exception("Failed to retrieve created report output")
-
-            print(f"Created report output with ID: {created_report['id']}")
-            return self.ensure_report_output_dual_write_state(created_report["id"])
+            return database.transaction(tx_callback)
 
         except Exception as e:
             print(f"Error creating report output. Details: {str(e)}")
             raise e
 
-    def get_report_output(self, report_output_id: int) -> dict | None:
+    def get_report_output(self, country_id: str, report_output_id: int) -> dict | None:
         """
         Get a report output record by ID.
-
-        Args:
-            report_output_id (int): The report output ID.
-
-        Returns:
-            dict | None: The report output data or None if not found.
         """
         print(f"Getting report output {report_output_id}")
 
@@ -488,7 +653,10 @@ class ReportOutputService:
                     f"Invalid report output ID: {report_output_id}. Must be a positive integer."
                 )
 
-            report_output = self._get_report_output_row(report_output_id)
+            report_output = self._get_report_output_row(
+                report_output_id,
+                country_id=country_id,
+            )
             if report_output is None:
                 return None
 
@@ -514,24 +682,10 @@ class ReportOutputService:
     ) -> bool:
         """
         Update a report output record with results or error.
-
-        Args:
-            report_id (int): The report output ID.
-            status (str | None): The new status ('complete' or 'error').
-            output (str | None): The result output as JSON string (for complete status).
-            error_message (str | None): The error message (for error status).
-
-        Returns:
-            bool: True if update was successful.
         """
         print(f"Updating report output {report_id}")
 
         try:
-            requested_report = self._get_report_output_row(report_id)
-            if requested_report is None:
-                raise Exception(f"Report output #{report_id} not found")
-
-            # Build the update query dynamically based on provided fields
             update_fields = []
             update_values = []
 
@@ -541,7 +695,6 @@ class ReportOutputService:
 
             if output is not None:
                 update_fields.append("output = ?")
-                # Output is already a JSON string from frontend
                 update_values.append(output)
 
             if error_message is not None:
@@ -552,13 +705,27 @@ class ReportOutputService:
                 print("No fields to update")
                 return False
 
-            # Add report_id to the end of values for WHERE clause
-            update_values.append(requested_report["id"])
+            def tx_callback(tx):
+                requested_report = self._get_report_output_row(
+                    report_id,
+                    queryer=tx,
+                    country_id=country_id,
+                    for_update=True,
+                )
+                if requested_report is None:
+                    raise ValueError(f"Report output #{report_id} not found")
 
-            query = f"UPDATE report_outputs SET {', '.join(update_fields)} WHERE id = ?"
+                tx.query(
+                    f"UPDATE report_outputs SET {', '.join(update_fields)} WHERE id = ? AND country_id = ?",
+                    (*update_values, report_id, country_id),
+                )
+                self._ensure_report_output_dual_write_state_in_transaction(
+                    tx,
+                    report_id,
+                    country_id=country_id,
+                )
 
-            database.query(query, tuple(update_values))
-            self.ensure_report_output_dual_write_state(requested_report["id"])
+            database.transaction(tx_callback)
 
             print(f"Successfully updated report output #{report_id}")
             return True

--- a/policyengine_api/services/run_sync_utils.py
+++ b/policyengine_api/services/run_sync_utils.py
@@ -2,6 +2,12 @@ import json
 from typing import Any
 
 
+def parse_json_field(value: dict[str, Any] | list[Any] | str | None) -> Any:
+    if value is None or isinstance(value, (dict, list)):
+        return value
+    return json.loads(value)
+
+
 def serialize_json_field(value: dict[str, Any] | list[Any] | str | None) -> str | None:
     if value is None or isinstance(value, str):
         return value

--- a/policyengine_api/services/run_sync_utils.py
+++ b/policyengine_api/services/run_sync_utils.py
@@ -1,0 +1,32 @@
+import json
+from typing import Any
+
+
+def serialize_json_field(value: dict[str, Any] | list[Any] | str | None) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+def get_latest_successful_run_id(runs: list[dict]) -> str | None:
+    for run in runs:
+        if run["status"] == "complete":
+            return run["id"]
+    return None
+
+
+def determine_parent_pointers(
+    status: str, runs_descending: list[dict]
+) -> tuple[str | None, str | None]:
+    newest_run = runs_descending[0] if runs_descending else None
+    latest_successful_run_id = get_latest_successful_run_id(runs_descending)
+
+    if status in {"pending", "running"} and newest_run is not None:
+        return newest_run["id"], latest_successful_run_id
+
+    if status == "complete":
+        return None, latest_successful_run_id or (
+            newest_run["id"] if newest_run is not None else None
+        )
+
+    return None, latest_successful_run_id

--- a/policyengine_api/services/simulation_service.py
+++ b/policyengine_api/services/simulation_service.py
@@ -1,27 +1,64 @@
+import uuid
+
 from sqlalchemy.engine.row import Row
 
-from policyengine_api.data import database
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
+from policyengine_api.data import database
+from policyengine_api.services.run_sync_utils import (
+    determine_parent_pointers,
+    parse_json_field,
+    serialize_json_field,
+)
 from policyengine_api.services.simulation_spec_service import (
     SimulationSpec,
     SimulationSpecService,
-)
-from policyengine_api.services.simulation_run_service import SimulationRunService
-from policyengine_api.services.run_sync_utils import (
-    determine_parent_pointers,
-    serialize_json_field,
 )
 
 
 class SimulationService:
     def __init__(self):
         self.simulation_spec_service = SimulationSpecService()
-        self.simulation_run_service = SimulationRunService()
 
-    def _get_simulation_row(self, simulation_id: int) -> dict | None:
-        row: Row | None = database.query(
-            "SELECT * FROM simulations WHERE id = ?",
-            (simulation_id,),
+    def _lock_clause(self) -> str:
+        return "" if database.local else " FOR UPDATE"
+
+    def _get_simulation_row(
+        self,
+        simulation_id: int,
+        *,
+        queryer=None,
+        country_id: str | None = None,
+        for_update: bool = False,
+    ) -> dict | None:
+        queryer = queryer or database
+        query = "SELECT * FROM simulations WHERE id = ?"
+        params: list[int | str] = [simulation_id]
+        if country_id is not None:
+            query += " AND country_id = ?"
+            params.append(country_id)
+        if for_update:
+            query += self._lock_clause()
+
+        row: Row | None = queryer.query(query, tuple(params)).fetchone()
+        return dict(row) if row is not None else None
+
+    def _find_existing_simulation_row(
+        self,
+        *,
+        country_id: str,
+        population_id: str,
+        population_type: str,
+        policy_id: int,
+        queryer=None,
+    ) -> dict | None:
+        queryer = queryer or database
+        row: Row | None = queryer.query(
+            """
+            SELECT * FROM simulations
+            WHERE country_id = ? AND population_id = ? AND population_type = ? AND policy_id = ?
+            ORDER BY id DESC
+            """,
+            (country_id, population_id, population_type, policy_id),
         ).fetchone()
         return dict(row) if row is not None else None
 
@@ -34,42 +71,61 @@ class SimulationService:
             "simulation_cache_version": None,
         }
 
-    def _get_runs_descending(self, simulation_id: int) -> list[dict]:
-        return sorted(
-            self.simulation_run_service.list_simulation_runs(simulation_id),
-            key=lambda run: run["run_sequence"],
-            reverse=True,
-        )
+    def _list_simulation_runs_descending(
+        self, simulation_id: int, *, queryer=None
+    ) -> list[dict]:
+        queryer = queryer or database
+        rows = queryer.query(
+            """
+            SELECT * FROM simulation_runs
+            WHERE simulation_id = ?
+            ORDER BY run_sequence DESC
+            """,
+            (simulation_id,),
+        ).fetchall()
+
+        runs = []
+        for row in rows:
+            run = dict(row)
+            run["simulation_spec_snapshot_json"] = parse_json_field(
+                run.get("simulation_spec_snapshot_json")
+            )
+            runs.append(run)
+        return runs
 
     def _select_mutable_run(
         self, simulation: dict, runs_descending: list[dict]
     ) -> dict | None:
         active_run_id = simulation.get("active_run_id")
-        if active_run_id:
-            active_run = self.simulation_run_service.get_simulation_run(active_run_id)
-            if active_run is not None:
-                return active_run
+        if active_run_id is not None:
+            for run in runs_descending:
+                if run["id"] == active_run_id:
+                    return run
         return runs_descending[0] if runs_descending else None
 
-    def _upsert_simulation_spec(self, simulation: dict) -> SimulationSpec:
+    def _upsert_simulation_spec_in_transaction(
+        self, tx, simulation: dict
+    ) -> SimulationSpec:
         expected_spec = self.simulation_spec_service.build_simulation_spec(simulation)
-        existing_spec = None
-
-        try:
-            existing_spec = self.simulation_spec_service.get_simulation_spec(
-                simulation["id"]
-            )
-        except ValueError:
-            existing_spec = None
-
+        existing_spec = parse_json_field(simulation.get("simulation_spec_json"))
         if (
-            existing_spec is None
-            or existing_spec.model_dump() != expected_spec.model_dump()
+            existing_spec != expected_spec.model_dump()
+            or simulation.get("simulation_spec_schema_version") != 1
         ):
-            self.simulation_spec_service.set_simulation_spec(
-                simulation_id=simulation["id"],
-                simulation_spec=expected_spec,
+            tx.query(
+                """
+                UPDATE simulations
+                SET simulation_spec_json = ?, simulation_spec_schema_version = ?
+                WHERE id = ?
+                """,
+                (
+                    expected_spec.model_dump_json(),
+                    1,
+                    simulation["id"],
+                ),
             )
+            simulation["simulation_spec_json"] = expected_spec.model_dump()
+            simulation["simulation_spec_schema_version"] = 1
 
         return expected_spec
 
@@ -95,14 +151,52 @@ class SimulationService:
             == version_manifest["simulation_cache_version"]
         )
 
-    def _update_simulation_run(
+    def _insert_bootstrap_run(
+        self, tx, simulation: dict, simulation_spec: SimulationSpec
+    ) -> None:
+        version_manifest = self._build_version_manifest(simulation)
+        tx.query(
+            """
+            INSERT INTO simulation_runs (
+                id, simulation_id, report_output_run_id, input_position, run_sequence,
+                status, output, error_message, trigger_type, requested_at, started_at,
+                finished_at, source_run_id, simulation_spec_snapshot_json,
+                country_package_version, policyengine_version, data_version,
+                runtime_app_name, simulation_cache_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(uuid.uuid4()),
+                simulation["id"],
+                None,
+                None,
+                1,
+                simulation["status"],
+                serialize_json_field(simulation.get("output")),
+                simulation.get("error_message"),
+                "initial",
+                None,
+                None,
+                None,
+                None,
+                simulation_spec.model_dump_json(),
+                version_manifest["country_package_version"],
+                version_manifest["policyengine_version"],
+                version_manifest["data_version"],
+                version_manifest["runtime_app_name"],
+                version_manifest["simulation_cache_version"],
+            ),
+        )
+
+    def _update_simulation_run_in_transaction(
         self,
+        tx,
         run_id: str,
         simulation: dict,
         simulation_spec: SimulationSpec,
     ) -> None:
         version_manifest = self._build_version_manifest(simulation)
-        database.query(
+        tx.query(
             """
             UPDATE simulation_runs
             SET status = ?, output = ?, error_message = ?,
@@ -125,8 +219,8 @@ class SimulationService:
             ),
         )
 
-    def _sync_parent_pointers(
-        self, simulation: dict, runs_descending: list[dict]
+    def _sync_parent_pointers_in_transaction(
+        self, tx, simulation: dict, runs_descending: list[dict]
     ) -> None:
         desired_active_run_id, desired_latest_successful_run_id = (
             determine_parent_pointers(simulation["status"], runs_descending)
@@ -138,7 +232,7 @@ class SimulationService:
         ):
             return
 
-        database.query(
+        tx.query(
             """
             UPDATE simulations
             SET active_run_id = ?, latest_successful_run_id = ?
@@ -150,25 +244,34 @@ class SimulationService:
                 simulation["id"],
             ),
         )
+        simulation["active_run_id"] = desired_active_run_id
+        simulation["latest_successful_run_id"] = desired_latest_successful_run_id
 
-    def ensure_simulation_dual_write_state(self, simulation_id: int) -> dict:
-        simulation = self._get_simulation_row(simulation_id)
+    def _ensure_simulation_dual_write_state_in_transaction(
+        self,
+        tx,
+        simulation_id: int,
+        *,
+        country_id: str | None = None,
+    ) -> dict:
+        simulation = self._get_simulation_row(
+            simulation_id,
+            queryer=tx,
+            country_id=country_id,
+            for_update=True,
+        )
         if simulation is None:
             raise ValueError(f"Simulation #{simulation_id} not found")
 
-        simulation_spec = self._upsert_simulation_spec(simulation)
-        runs_descending = self._get_runs_descending(simulation_id)
+        simulation_spec = self._upsert_simulation_spec_in_transaction(tx, simulation)
+        runs_descending = self._list_simulation_runs_descending(
+            simulation_id, queryer=tx
+        )
         if not runs_descending:
-            self.simulation_run_service.create_simulation_run(
-                simulation_id=simulation_id,
-                status=simulation["status"],
-                trigger_type="initial",
-                output=simulation.get("output"),
-                error_message=simulation.get("error_message"),
-                simulation_spec_snapshot=simulation_spec.model_dump(),
-                version_manifest=self._build_version_manifest(simulation),
+            self._insert_bootstrap_run(tx, simulation, simulation_spec)
+            runs_descending = self._list_simulation_runs_descending(
+                simulation_id, queryer=tx
             )
-            runs_descending = self._get_runs_descending(simulation_id)
         else:
             mutable_run = self._select_mutable_run(simulation, runs_descending)
             if mutable_run is not None and not self._run_matches_parent(
@@ -176,22 +279,36 @@ class SimulationService:
                 simulation,
                 simulation_spec,
             ):
-                self._update_simulation_run(
+                self._update_simulation_run_in_transaction(
+                    tx,
                     run_id=mutable_run["id"],
                     simulation=simulation,
                     simulation_spec=simulation_spec,
                 )
-                runs_descending = self._get_runs_descending(simulation_id)
+                runs_descending = self._list_simulation_runs_descending(
+                    simulation_id, queryer=tx
+                )
 
-        refreshed_simulation = self._get_simulation_row(simulation_id)
-        if refreshed_simulation is None:
-            raise ValueError(f"Simulation #{simulation_id} not found after sync")
-
-        self._sync_parent_pointers(refreshed_simulation, runs_descending)
-        refreshed_simulation = self._get_simulation_row(simulation_id)
+        self._sync_parent_pointers_in_transaction(tx, simulation, runs_descending)
+        refreshed_simulation = self._get_simulation_row(
+            simulation_id,
+            queryer=tx,
+            country_id=country_id,
+        )
         if refreshed_simulation is None:
             raise ValueError(f"Simulation #{simulation_id} not found after sync")
         return refreshed_simulation
+
+    def ensure_simulation_dual_write_state(
+        self, simulation_id: int, country_id: str | None = None
+    ) -> dict:
+        return database.transaction(
+            lambda tx: self._ensure_simulation_dual_write_state_in_transaction(
+                tx,
+                simulation_id,
+                country_id=country_id,
+            )
+        )
 
     def find_existing_simulation(
         self,
@@ -215,17 +332,14 @@ class SimulationService:
         print("Checking for existing simulation")
 
         try:
-            # Check for existing record with same parameters (excluding api_version)
-            query = "SELECT * FROM simulations WHERE country_id = ? AND population_id = ? AND population_type = ? AND policy_id = ?"
-            params = (country_id, population_id, population_type, policy_id)
-
-            row = database.query(query, params).fetchone()
-
-            existing_simulation = None
-            if row is not None:
-                existing_simulation = dict(row)
+            existing_simulation = self._find_existing_simulation_row(
+                country_id=country_id,
+                population_id=population_id,
+                population_type=population_type,
+                policy_id=policy_id,
+            )
+            if existing_simulation is not None:
                 print(f"Found existing simulation with ID: {existing_simulation['id']}")
-
             return existing_simulation
 
         except Exception as e:
@@ -255,39 +369,59 @@ class SimulationService:
         api_version: str = COUNTRY_PACKAGE_VERSIONS.get(country_id)
 
         try:
-            existing_simulation = self.find_existing_simulation(
-                country_id, population_id, population_type, policy_id
-            )
-            if existing_simulation is not None:
-                print(
-                    f"Reusing existing simulation with ID: {existing_simulation['id']}"
+
+            def tx_callback(tx):
+                existing_simulation = self._find_existing_simulation_row(
+                    country_id=country_id,
+                    population_id=population_id,
+                    population_type=population_type,
+                    policy_id=policy_id,
+                    queryer=tx,
                 )
-                return self.ensure_simulation_dual_write_state(
-                    existing_simulation["id"]
+                if existing_simulation is not None:
+                    print(
+                        f"Reusing existing simulation with ID: {existing_simulation['id']}"
+                    )
+                    return self._ensure_simulation_dual_write_state_in_transaction(
+                        tx,
+                        existing_simulation["id"],
+                        country_id=country_id,
+                    )
+
+                tx.query(
+                    """
+                    INSERT INTO simulations (
+                        country_id, api_version, population_id, population_type, policy_id, status
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        country_id,
+                        api_version,
+                        population_id,
+                        population_type,
+                        policy_id,
+                        "pending",
+                    ),
                 )
 
-            database.query(
-                "INSERT INTO simulations (country_id, api_version, population_id, population_type, policy_id, status) VALUES (?, ?, ?, ?, ?, ?)",
-                (
-                    country_id,
-                    api_version,
-                    population_id,
-                    population_type,
-                    policy_id,
-                    "pending",
-                ),
-            )
+                created_simulation = self._find_existing_simulation_row(
+                    country_id=country_id,
+                    population_id=population_id,
+                    population_type=population_type,
+                    policy_id=policy_id,
+                    queryer=tx,
+                )
+                if created_simulation is None:
+                    raise Exception("Failed to retrieve created simulation")
 
-            # Safely retrieve the created simulation record
-            created_simulation = self.find_existing_simulation(
-                country_id, population_id, population_type, policy_id
-            )
+                print(f"Created simulation with ID: {created_simulation['id']}")
+                return self._ensure_simulation_dual_write_state_in_transaction(
+                    tx,
+                    created_simulation["id"],
+                    country_id=country_id,
+                )
 
-            if created_simulation is None:
-                raise Exception("Failed to retrieve created simulation")
-
-            print(f"Created simulation with ID: {created_simulation['id']}")
-            return self.ensure_simulation_dual_write_state(created_simulation["id"])
+            return database.transaction(tx_callback)
 
         except Exception as e:
             print(f"Error creating simulation. Details: {str(e)}")
@@ -312,16 +446,7 @@ class SimulationService:
                     f"Invalid simulation ID: {simulation_id}. Must be a positive integer."
                 )
 
-            row: Row | None = database.query(
-                "SELECT * FROM simulations WHERE id = ? AND country_id = ?",
-                (simulation_id, country_id),
-            ).fetchone()
-
-            simulation = None
-            if row is not None:
-                simulation = dict(row)
-
-            return simulation
+            return self._get_simulation_row(simulation_id, country_id=country_id)
 
         except Exception as e:
             print(f"Error fetching simulation #{simulation_id}. Details: {str(e)}")
@@ -349,11 +474,9 @@ class SimulationService:
             bool: True if update was successful.
         """
         print(f"Updating simulation {simulation_id}")
-        # Automatically update api_version on every update to latest
         api_version: str = COUNTRY_PACKAGE_VERSIONS.get(country_id)
 
         try:
-            # Build the update query dynamically based on provided fields
             update_fields = []
             update_values = []
 
@@ -363,14 +486,12 @@ class SimulationService:
 
             if output is not None:
                 update_fields.append("output = ?")
-                # Output is already a JSON string from frontend
                 update_values.append(output)
 
             if error_message is not None:
                 update_fields.append("error_message = ?")
                 update_values.append(error_message)
 
-            # Always update API version
             update_fields.append("api_version = ?")
             update_values.append(api_version)
 
@@ -378,13 +499,27 @@ class SimulationService:
                 print("No fields to update")
                 return False
 
-            # Add simulation_id to the end of values for WHERE clause
-            update_values.append(simulation_id)
+            def tx_callback(tx):
+                simulation = self._get_simulation_row(
+                    simulation_id,
+                    queryer=tx,
+                    country_id=country_id,
+                    for_update=True,
+                )
+                if simulation is None:
+                    raise ValueError(f"Simulation #{simulation_id} not found")
 
-            query = f"UPDATE simulations SET {', '.join(update_fields)} WHERE id = ?"
+                tx.query(
+                    f"UPDATE simulations SET {', '.join(update_fields)} WHERE id = ? AND country_id = ?",
+                    (*update_values, simulation_id, country_id),
+                )
+                self._ensure_simulation_dual_write_state_in_transaction(
+                    tx,
+                    simulation_id,
+                    country_id=country_id,
+                )
 
-            database.query(query, tuple(update_values))
-            self.ensure_simulation_dual_write_state(simulation_id)
+            database.transaction(tx_callback)
 
             print(f"Successfully updated simulation #{simulation_id}")
             return True

--- a/policyengine_api/services/simulation_service.py
+++ b/policyengine_api/services/simulation_service.py
@@ -1,11 +1,198 @@
-import json
 from sqlalchemy.engine.row import Row
 
 from policyengine_api.data import database
 from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
+from policyengine_api.services.simulation_spec_service import (
+    SimulationSpec,
+    SimulationSpecService,
+)
+from policyengine_api.services.simulation_run_service import SimulationRunService
+from policyengine_api.services.run_sync_utils import (
+    determine_parent_pointers,
+    serialize_json_field,
+)
 
 
 class SimulationService:
+    def __init__(self):
+        self.simulation_spec_service = SimulationSpecService()
+        self.simulation_run_service = SimulationRunService()
+
+    def _get_simulation_row(self, simulation_id: int) -> dict | None:
+        row: Row | None = database.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    def _build_version_manifest(self, simulation: dict) -> dict[str, str | None]:
+        return {
+            "country_package_version": simulation.get("api_version"),
+            "policyengine_version": None,
+            "data_version": None,
+            "runtime_app_name": None,
+            "simulation_cache_version": None,
+        }
+
+    def _get_runs_descending(self, simulation_id: int) -> list[dict]:
+        return sorted(
+            self.simulation_run_service.list_simulation_runs(simulation_id),
+            key=lambda run: run["run_sequence"],
+            reverse=True,
+        )
+
+    def _select_mutable_run(
+        self, simulation: dict, runs_descending: list[dict]
+    ) -> dict | None:
+        active_run_id = simulation.get("active_run_id")
+        if active_run_id:
+            active_run = self.simulation_run_service.get_simulation_run(active_run_id)
+            if active_run is not None:
+                return active_run
+        return runs_descending[0] if runs_descending else None
+
+    def _upsert_simulation_spec(self, simulation: dict) -> SimulationSpec:
+        expected_spec = self.simulation_spec_service.build_simulation_spec(simulation)
+        existing_spec = None
+
+        try:
+            existing_spec = self.simulation_spec_service.get_simulation_spec(
+                simulation["id"]
+            )
+        except ValueError:
+            existing_spec = None
+
+        if (
+            existing_spec is None
+            or existing_spec.model_dump() != expected_spec.model_dump()
+        ):
+            self.simulation_spec_service.set_simulation_spec(
+                simulation_id=simulation["id"],
+                simulation_spec=expected_spec,
+            )
+
+        return expected_spec
+
+    def _run_matches_parent(
+        self,
+        run: dict,
+        simulation: dict,
+        simulation_spec: SimulationSpec,
+    ) -> bool:
+        version_manifest = self._build_version_manifest(simulation)
+        return (
+            run["status"] == simulation["status"]
+            and run.get("output") == simulation.get("output")
+            and run.get("error_message") == simulation.get("error_message")
+            and run.get("simulation_spec_snapshot_json") == simulation_spec.model_dump()
+            and run.get("country_package_version")
+            == version_manifest["country_package_version"]
+            and run.get("policyengine_version")
+            == version_manifest["policyengine_version"]
+            and run.get("data_version") == version_manifest["data_version"]
+            and run.get("runtime_app_name") == version_manifest["runtime_app_name"]
+            and run.get("simulation_cache_version")
+            == version_manifest["simulation_cache_version"]
+        )
+
+    def _update_simulation_run(
+        self,
+        run_id: str,
+        simulation: dict,
+        simulation_spec: SimulationSpec,
+    ) -> None:
+        version_manifest = self._build_version_manifest(simulation)
+        database.query(
+            """
+            UPDATE simulation_runs
+            SET status = ?, output = ?, error_message = ?,
+                simulation_spec_snapshot_json = ?, country_package_version = ?,
+                policyengine_version = ?, data_version = ?, runtime_app_name = ?,
+                simulation_cache_version = ?
+            WHERE id = ?
+            """,
+            (
+                simulation["status"],
+                serialize_json_field(simulation.get("output")),
+                simulation.get("error_message"),
+                simulation_spec.model_dump_json(),
+                version_manifest["country_package_version"],
+                version_manifest["policyengine_version"],
+                version_manifest["data_version"],
+                version_manifest["runtime_app_name"],
+                version_manifest["simulation_cache_version"],
+                run_id,
+            ),
+        )
+
+    def _sync_parent_pointers(
+        self, simulation: dict, runs_descending: list[dict]
+    ) -> None:
+        desired_active_run_id, desired_latest_successful_run_id = (
+            determine_parent_pointers(simulation["status"], runs_descending)
+        )
+        if (
+            simulation.get("active_run_id") == desired_active_run_id
+            and simulation.get("latest_successful_run_id")
+            == desired_latest_successful_run_id
+        ):
+            return
+
+        database.query(
+            """
+            UPDATE simulations
+            SET active_run_id = ?, latest_successful_run_id = ?
+            WHERE id = ?
+            """,
+            (
+                desired_active_run_id,
+                desired_latest_successful_run_id,
+                simulation["id"],
+            ),
+        )
+
+    def ensure_simulation_dual_write_state(self, simulation_id: int) -> dict:
+        simulation = self._get_simulation_row(simulation_id)
+        if simulation is None:
+            raise ValueError(f"Simulation #{simulation_id} not found")
+
+        simulation_spec = self._upsert_simulation_spec(simulation)
+        runs_descending = self._get_runs_descending(simulation_id)
+        if not runs_descending:
+            self.simulation_run_service.create_simulation_run(
+                simulation_id=simulation_id,
+                status=simulation["status"],
+                trigger_type="initial",
+                output=simulation.get("output"),
+                error_message=simulation.get("error_message"),
+                simulation_spec_snapshot=simulation_spec.model_dump(),
+                version_manifest=self._build_version_manifest(simulation),
+            )
+            runs_descending = self._get_runs_descending(simulation_id)
+        else:
+            mutable_run = self._select_mutable_run(simulation, runs_descending)
+            if mutable_run is not None and not self._run_matches_parent(
+                mutable_run,
+                simulation,
+                simulation_spec,
+            ):
+                self._update_simulation_run(
+                    run_id=mutable_run["id"],
+                    simulation=simulation,
+                    simulation_spec=simulation_spec,
+                )
+                runs_descending = self._get_runs_descending(simulation_id)
+
+        refreshed_simulation = self._get_simulation_row(simulation_id)
+        if refreshed_simulation is None:
+            raise ValueError(f"Simulation #{simulation_id} not found after sync")
+
+        self._sync_parent_pointers(refreshed_simulation, runs_descending)
+        refreshed_simulation = self._get_simulation_row(simulation_id)
+        if refreshed_simulation is None:
+            raise ValueError(f"Simulation #{simulation_id} not found after sync")
+        return refreshed_simulation
+
     def find_existing_simulation(
         self,
         country_id: str,
@@ -68,6 +255,17 @@ class SimulationService:
         api_version: str = COUNTRY_PACKAGE_VERSIONS.get(country_id)
 
         try:
+            existing_simulation = self.find_existing_simulation(
+                country_id, population_id, population_type, policy_id
+            )
+            if existing_simulation is not None:
+                print(
+                    f"Reusing existing simulation with ID: {existing_simulation['id']}"
+                )
+                return self.ensure_simulation_dual_write_state(
+                    existing_simulation["id"]
+                )
+
             database.query(
                 "INSERT INTO simulations (country_id, api_version, population_id, population_type, policy_id, status) VALUES (?, ?, ?, ?, ?, ?)",
                 (
@@ -89,7 +287,7 @@ class SimulationService:
                 raise Exception("Failed to retrieve created simulation")
 
             print(f"Created simulation with ID: {created_simulation['id']}")
-            return created_simulation
+            return self.ensure_simulation_dual_write_state(created_simulation["id"])
 
         except Exception as e:
             print(f"Error creating simulation. Details: {str(e)}")
@@ -186,6 +384,7 @@ class SimulationService:
             query = f"UPDATE simulations SET {', '.join(update_fields)} WHERE id = ?"
 
             database.query(query, tuple(update_values))
+            self.ensure_simulation_dual_write_state(simulation_id)
 
             print(f"Successfully updated simulation #{simulation_id}")
             return True

--- a/tests/unit/services/test_report_output_service.py
+++ b/tests/unit/services/test_report_output_service.py
@@ -143,11 +143,17 @@ class TestCreateReportOutput:
     def test_create_report_output_single_simulation(self, test_db):
         """Test creating a report output with a single simulation."""
         # GIVEN an empty database
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_single_create",
+            population_type="household",
+            policy_id=1,
+        )
 
         # WHEN we create a report output with one simulation
         created_report = service.create_report_output(
             country_id="us",
-            simulation_1_id=1,
+            simulation_1_id=simulation["id"],
             simulation_2_id=None,
             year="2025",
         )
@@ -156,7 +162,7 @@ class TestCreateReportOutput:
         assert created_report is not None
         assert isinstance(created_report, dict)
         assert created_report["id"] > 0
-        assert created_report["simulation_1_id"] == 1
+        assert created_report["simulation_1_id"] == simulation["id"]
         assert created_report["simulation_2_id"] is None
         assert created_report["status"] == "pending"
         assert created_report["year"] == "2025"
@@ -167,7 +173,7 @@ class TestCreateReportOutput:
             (created_report["id"],),
         ).fetchone()
         assert result is not None
-        assert result["simulation_1_id"] == 1
+        assert result["simulation_1_id"] == simulation["id"]
         assert result["simulation_2_id"] is None
         assert result["status"] == "pending"
         assert result["year"] == "2025"
@@ -175,19 +181,31 @@ class TestCreateReportOutput:
     def test_create_report_output_comparison(self, test_db):
         """Test creating a report output comparing two simulations."""
         # GIVEN an empty database
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_comparison",
+            population_type="household",
+            policy_id=2,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_comparison",
+            population_type="household",
+            policy_id=3,
+        )
 
         # WHEN we create a report output with two simulations
         created_report = service.create_report_output(
             country_id="us",
-            simulation_1_id=1,
-            simulation_2_id=2,
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
             year="2025",
         )
 
         # THEN a valid report record should be returned
         assert created_report is not None
-        assert created_report["simulation_1_id"] == 1
-        assert created_report["simulation_2_id"] == 2
+        assert created_report["simulation_1_id"] == simulation_1["id"]
+        assert created_report["simulation_2_id"] == simulation_2["id"]
         assert created_report["status"] == "pending"
         assert created_report["year"] == "2025"
 
@@ -196,8 +214,8 @@ class TestCreateReportOutput:
             "SELECT * FROM report_outputs WHERE id = ?",
             (created_report["id"],),
         ).fetchone()
-        assert result["simulation_1_id"] == 1
-        assert result["simulation_2_id"] == 2
+        assert result["simulation_1_id"] == simulation_1["id"]
+        assert result["simulation_2_id"] == simulation_2["id"]
         assert result["status"] == "pending"
         assert result["year"] == "2025"
 
@@ -207,14 +225,35 @@ class TestCreateReportOutput:
 
         # WHEN we create reports with different parameters
         created_reports = []
+        simulation_ids = []
         for i in range(3):
+            simulation_1 = simulation_service.create_simulation(
+                country_id="us",
+                population_id=f"household_report_id_{i}",
+                population_type="household",
+                policy_id=100 + i,
+            )
+            simulation_2 = None
+            if i % 2 != 0:
+                simulation_2 = simulation_service.create_simulation(
+                    country_id="us",
+                    population_id=f"household_report_id_{i}",
+                    population_type="household",
+                    policy_id=200 + i,
+                )
             report = service.create_report_output(
                 country_id="us",
-                simulation_1_id=i + 1,
-                simulation_2_id=None if i % 2 == 0 else i + 10,
+                simulation_1_id=simulation_1["id"],
+                simulation_2_id=None if simulation_2 is None else simulation_2["id"],
                 year="2025",
             )
             created_reports.append(report)
+            simulation_ids.append(
+                (
+                    simulation_1["id"],
+                    None if simulation_2 is None else simulation_2["id"],
+                )
+            )
 
         # THEN all IDs should be unique
         ids = [report["id"] for report in created_reports]
@@ -225,19 +264,25 @@ class TestCreateReportOutput:
             result = test_db.query(
                 "SELECT * FROM report_outputs WHERE id = ?", (report["id"],)
             ).fetchone()
-            assert result["simulation_1_id"] == i + 1
-            expected_sim2 = None if i % 2 == 0 else i + 10
+            expected_sim1, expected_sim2 = simulation_ids[i]
+            assert result["simulation_1_id"] == expected_sim1
             assert result["simulation_2_id"] == expected_sim2
             assert result["year"] == "2025"
 
     def test_create_report_output_with_different_year(self, test_db):
         """Test creating a report output with a different year."""
         # GIVEN an empty database
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_other_year",
+            population_type="household",
+            policy_id=4,
+        )
 
         # WHEN we create a report output with year 2024
         created_report = service.create_report_output(
             country_id="us",
-            simulation_1_id=200,
+            simulation_1_id=simulation["id"],
             simulation_2_id=None,
             year="2024",
         )
@@ -245,7 +290,7 @@ class TestCreateReportOutput:
         # THEN a valid report record should be returned
         assert created_report is not None
         assert created_report["year"] == "2024"
-        assert created_report["simulation_1_id"] == 200
+        assert created_report["simulation_1_id"] == simulation["id"]
 
         # AND the report should be in the database
         result = test_db.query(
@@ -253,7 +298,7 @@ class TestCreateReportOutput:
             (created_report["id"],),
         ).fetchone()
         assert result["year"] == "2024"
-        assert result["simulation_1_id"] == 200
+        assert result["simulation_1_id"] == simulation["id"]
 
     def test_create_report_output_populates_dual_write_state(self, test_db):
         simulation = simulation_service.create_simulation(
@@ -518,12 +563,18 @@ class TestGetReportOutput:
     def test_get_report_output_creates_current_runtime_row_for_stale_id(self, test_db):
         stale_version = "r0stale1"
         current_version = get_report_output_cache_version("us")
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_stale_runtime_create",
+            population_type="household",
+            policy_id=5,
+        )
 
         test_db.query(
             """INSERT INTO report_outputs
             (country_id, simulation_1_id, simulation_2_id, status, api_version, year)
             VALUES (?, ?, ?, ?, ?, ?)""",
-            ("us", 3, None, "complete", stale_version, "2025"),
+            ("us", simulation["id"], None, "complete", stale_version, "2025"),
         )
 
         stale_record = test_db.query(
@@ -542,7 +593,7 @@ class TestGetReportOutput:
 
         current_rows = test_db.query(
             "SELECT * FROM report_outputs WHERE country_id = ? AND simulation_1_id = ? AND year = ? ORDER BY id ASC",
-            ("us", 3, "2025"),
+            ("us", simulation["id"], "2025"),
         ).fetchall()
         assert len(current_rows) == 2
         assert current_rows[0]["api_version"] == stale_version
@@ -579,18 +630,30 @@ class TestUniqueConstraint:
     def test_duplicate_report_returns_existing(self, test_db):
         """Test that creating duplicate reports returns the existing record."""
         # GIVEN we create a report
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_duplicate_report",
+            population_type="household",
+            policy_id=50,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_duplicate_report",
+            population_type="household",
+            policy_id=60,
+        )
         first_report = service.create_report_output(
             country_id="us",
-            simulation_1_id=50,
-            simulation_2_id=60,
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
             year="2025",
         )
 
         # WHEN we try to create an identical report
         second_report = service.create_report_output(
             country_id="us",
-            simulation_1_id=50,
-            simulation_2_id=60,
+            simulation_1_id=simulation_1["id"],
+            simulation_2_id=simulation_2["id"],
             year="2025",
         )
 

--- a/tests/unit/services/test_report_output_service.py
+++ b/tests/unit/services/test_report_output_service.py
@@ -3,12 +3,14 @@ import json
 
 from policyengine_api.constants import get_report_output_cache_version
 from policyengine_api.services.report_output_service import ReportOutputService
+from policyengine_api.services.simulation_service import SimulationService
 
-from tests.fixtures.services.report_output_fixtures import (
-    existing_report_record,
-)
+from tests.fixtures.services import report_output_fixtures
+
+pytest_plugins = ("tests.fixtures.services.report_output_fixtures",)
 
 service = ReportOutputService()
+simulation_service = SimulationService()
 
 
 class TestFindExistingReportOutput:
@@ -28,6 +30,10 @@ class TestFindExistingReportOutput:
         # THEN the result should contain the existing report
         assert result is not None
         assert result["id"] == existing_report_record["id"]
+        assert (
+            result["country_id"]
+            == report_output_fixtures.valid_report_data["country_id"]
+        )
         assert result["simulation_1_id"] == existing_report_record["simulation_1_id"]
         assert result["status"] == existing_report_record["status"]
 
@@ -248,6 +254,142 @@ class TestCreateReportOutput:
         ).fetchone()
         assert result["year"] == "2024"
         assert result["simulation_1_id"] == 200
+
+    def test_create_report_output_populates_dual_write_state(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_dual_write",
+            population_type="household",
+            policy_id=21,
+        )
+
+        created_report = service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        stored_report = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert stored_report["report_kind"] == "household_single"
+        assert stored_report["report_spec_json"] is not None
+        assert stored_report["report_spec_schema_version"] == 1
+        assert stored_report["report_spec_status"] == "explicit"
+        assert stored_report["active_run_id"] is not None
+        assert stored_report["latest_successful_run_id"] is None
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "pending"
+        assert run["trigger_type"] == "initial"
+        snapshot = run["report_spec_snapshot_json"]
+        if isinstance(snapshot, str):
+            snapshot = json.loads(snapshot)
+        assert snapshot["report_kind"] == "household_single"
+
+    def test_create_report_output_reuses_existing_row_and_bootstraps_dual_write(
+        self, test_db
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_existing_report",
+            population_type="household",
+            policy_id=22,
+        )
+
+        test_db.query(
+            """
+            INSERT INTO report_outputs (
+                country_id, simulation_1_id, simulation_2_id, api_version, status, year
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                simulation["id"],
+                None,
+                get_report_output_cache_version("us"),
+                "pending",
+                "2025",
+            ),
+        )
+
+        created_report = service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        rows = test_db.query(
+            """
+            SELECT * FROM report_outputs
+            WHERE country_id = ? AND simulation_1_id = ? AND simulation_2_id IS NULL AND year = ?
+            """,
+            ("us", simulation["id"], "2025"),
+        ).fetchall()
+        assert len(rows) == 1
+        assert created_report["id"] == rows[0]["id"]
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert run is not None
+
+    def test_create_report_output_populates_economy_comparison_report_spec(
+        self, test_db
+    ):
+        baseline_simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="state/ca",
+            population_type="geography",
+            policy_id=30,
+        )
+        reform_simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="state/ca",
+            population_type="geography",
+            policy_id=31,
+        )
+
+        created_report = service.create_report_output(
+            country_id="us",
+            simulation_1_id=baseline_simulation["id"],
+            simulation_2_id=reform_simulation["id"],
+            year="2025",
+        )
+
+        stored_report = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert stored_report["report_kind"] == "economy_comparison"
+        assert stored_report["report_spec_status"] == "backfilled_assumed"
+
+        report_spec = stored_report["report_spec_json"]
+        if isinstance(report_spec, str):
+            report_spec = json.loads(report_spec)
+        assert report_spec["region"] == "state/ca"
+        assert report_spec["baseline_policy_id"] == 30
+        assert report_spec["reform_policy_id"] == 31
+        assert report_spec["dataset"] == "default"
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert run is not None
+        snapshot = run["report_spec_snapshot_json"]
+        if isinstance(snapshot, str):
+            snapshot = json.loads(snapshot)
+        assert snapshot["report_kind"] == "economy_comparison"
+        assert snapshot["region"] == "state/ca"
 
 
 class TestGetReportOutput:
@@ -516,6 +658,254 @@ class TestUpdateReportOutput:
         ).fetchone()
         assert result["status"] == "complete"
         assert result["output"] is None  # Should remain unchanged
+
+    def test_update_report_output_updates_dual_write_state(self, test_db):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_update",
+            population_type="household",
+            policy_id=23,
+        )
+        created_report = service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+        output_json = json.dumps({"distribution": [1, 2, 3]})
+
+        success = service.update_report_output(
+            country_id="us",
+            report_id=created_report["id"],
+            status="complete",
+            output=output_json,
+        )
+
+        assert success is True
+
+        stored_report = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert stored_report["active_run_id"] is None
+        assert stored_report["latest_successful_run_id"] is not None
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert run["status"] == "complete"
+        assert run["output"] == output_json
+        assert run["id"] == stored_report["latest_successful_run_id"]
+
+    def test_update_report_output_bootstraps_missing_run_state(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_legacy_report",
+            population_type="household",
+            policy_id=24,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_legacy_report",
+            population_type="household",
+            policy_id=25,
+        )
+        test_db.query(
+            """
+            INSERT INTO report_outputs (
+                country_id, simulation_1_id, simulation_2_id, api_version, status, year
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                simulation_1["id"],
+                simulation_2["id"],
+                get_report_output_cache_version("us"),
+                "pending",
+                "2025",
+            ),
+        )
+        report_output = test_db.query(
+            "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        success = service.update_report_output(
+            country_id="us",
+            report_id=report_output["id"],
+            status="error",
+            error_message="legacy report failure",
+        )
+
+        assert success is True
+
+        stored_report = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+        assert stored_report["report_spec_json"] is not None
+        assert stored_report["active_run_id"] is None
+        assert stored_report["latest_successful_run_id"] is None
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (report_output["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "error"
+        assert run["error_message"] == "legacy report failure"
+
+    def test_update_report_output_keeps_invalid_legacy_linkage_working(self, test_db):
+        simulation_1 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="us",
+            population_type="geography",
+            policy_id=26,
+        )
+        simulation_2 = simulation_service.create_simulation(
+            country_id="us",
+            population_id="state/ca",
+            population_type="geography",
+            policy_id=27,
+        )
+        test_db.query(
+            """
+            INSERT INTO report_outputs (
+                country_id, simulation_1_id, simulation_2_id, api_version, status, year
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                simulation_1["id"],
+                simulation_2["id"],
+                get_report_output_cache_version("us"),
+                "pending",
+                "2025",
+            ),
+        )
+        report_output = test_db.query(
+            "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        success = service.update_report_output(
+            country_id="us",
+            report_id=report_output["id"],
+            status="complete",
+            output=json.dumps({"budget": {"budgetary_impact": 1}}),
+        )
+
+        assert success is True
+
+        stored_report = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (report_output["id"],),
+        ).fetchone()
+        assert stored_report["report_spec_json"] is None
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (report_output["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["report_spec_snapshot_json"] is None
+
+    def test_update_report_output_stale_id_updates_only_stale_lineage_run(
+        self, test_db
+    ):
+        stale_version = "r0stale1"
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_stale_lineage",
+            population_type="household",
+            policy_id=32,
+        )
+        test_db.query(
+            """
+            INSERT INTO report_outputs
+            (country_id, simulation_1_id, simulation_2_id, status, api_version, year)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("us", simulation["id"], None, "pending", stale_version, "2025"),
+        )
+        stale_report = test_db.query(
+            "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        success = service.update_report_output(
+            country_id="us",
+            report_id=stale_report["id"],
+            status="complete",
+            output=json.dumps({"result": "stale"}),
+        )
+
+        assert success is True
+
+        rows = test_db.query(
+            """
+            SELECT * FROM report_outputs
+            WHERE country_id = ? AND simulation_1_id = ? AND year = ?
+            ORDER BY id ASC
+            """,
+            ("us", simulation["id"], "2025"),
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["id"] == stale_report["id"]
+        assert rows[0]["status"] == "complete"
+
+        runs = test_db.query(
+            """
+            SELECT * FROM report_output_runs
+            WHERE report_output_id = ?
+            ORDER BY run_sequence ASC
+            """,
+            (stale_report["id"],),
+        ).fetchall()
+        assert len(runs) == 1
+        assert runs[0]["status"] == "complete"
+        assert runs[0]["output"] == json.dumps({"result": "stale"})
+
+    def test_update_report_output_does_not_append_extra_run_for_legacy_patch_traffic(
+        self, test_db
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_single_run",
+            population_type="household",
+            policy_id=33,
+        )
+        created_report = service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        first_run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert first_run is not None
+
+        success = service.update_report_output(
+            country_id="us",
+            report_id=created_report["id"],
+            status="complete",
+            output=json.dumps({"distribution": [4, 5, 6]}),
+        )
+
+        assert success is True
+
+        runs = test_db.query(
+            """
+            SELECT * FROM report_output_runs
+            WHERE report_output_id = ?
+            ORDER BY run_sequence ASC
+            """,
+            (created_report["id"],),
+        ).fetchall()
+        assert len(runs) == 1
+        assert runs[0]["id"] == first_run["id"]
+        assert runs[0]["status"] == "complete"
 
     def test_update_report_output_no_fields_returns_false(
         self, test_db, existing_report_record

--- a/tests/unit/services/test_report_output_service.py
+++ b/tests/unit/services/test_report_output_service.py
@@ -401,7 +401,8 @@ class TestGetReportOutput:
 
         # WHEN we retrieve the report
         result = service.get_report_output(
-            report_output_id=existing_report_record["id"]
+            country_id=existing_report_record["country_id"],
+            report_output_id=existing_report_record["id"],
         )
 
         # THEN the correct report should be returned
@@ -415,7 +416,7 @@ class TestGetReportOutput:
         # GIVEN an empty database
 
         # WHEN we try to retrieve a non-existent report
-        result = service.get_report_output(report_output_id=999)
+        result = service.get_report_output(country_id="us", report_output_id=999)
 
         # THEN None should be returned
         assert result is None
@@ -445,7 +446,9 @@ class TestGetReportOutput:
         ).fetchone()
 
         # WHEN we retrieve the report
-        result = service.get_report_output(report_output_id=record["id"])
+        result = service.get_report_output(
+            country_id="us", report_output_id=record["id"]
+        )
 
         # THEN the output should be returned as JSON string (not parsed)
         assert result["output"] == json.dumps(test_output)
@@ -504,7 +507,9 @@ class TestGetReportOutput:
             "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
         ).fetchone()
 
-        result = service.get_report_output(report_output_id=stale_record["id"])
+        result = service.get_report_output(
+            country_id="us", report_output_id=stale_record["id"]
+        )
         assert result is not None
         assert result["id"] == stale_record["id"]
         assert result["api_version"] == current_record["api_version"]
@@ -525,7 +530,9 @@ class TestGetReportOutput:
             "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
         ).fetchone()
 
-        result = service.get_report_output(report_output_id=stale_record["id"])
+        result = service.get_report_output(
+            country_id="us", report_output_id=stale_record["id"]
+        )
 
         assert result is not None
         assert result["id"] == stale_record["id"]
@@ -548,12 +555,22 @@ class TestGetReportOutput:
         # WHEN we call get_report_output with invalid ID types
         # THEN an exception should be raised
         with pytest.raises(Exception) as exc_info:
-            service.get_report_output(report_output_id=-1)
+            service.get_report_output(country_id="us", report_output_id=-1)
         assert "Invalid report output ID" in str(exc_info.value)
 
         with pytest.raises(Exception) as exc_info:
-            service.get_report_output(report_output_id="not_an_int")
+            service.get_report_output(country_id="us", report_output_id="not_an_int")
         assert "Invalid report output ID" in str(exc_info.value)
+
+    def test_get_report_output_wrong_country_returns_none(
+        self, test_db, existing_report_record
+    ):
+        result = service.get_report_output(
+            country_id="uk",
+            report_output_id=existing_report_record["id"],
+        )
+
+        assert result is None
 
 
 class TestUniqueConstraint:
@@ -953,3 +970,178 @@ class TestUpdateReportOutput:
         assert rows[0]["api_version"] == stale_version
         assert rows[0]["status"] == "complete"
         assert rows[0]["output"] == output_json
+
+    def test_create_report_output_rolls_back_parent_insert_on_dual_write_failure(
+        self, test_db, monkeypatch
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_create_rollback",
+            population_type="household",
+            policy_id=34,
+        )
+
+        def fail_dual_write(tx, report_output_id, *, country_id=None):
+            raise RuntimeError("dual write sync failed")
+
+        monkeypatch.setattr(
+            service,
+            "_ensure_report_output_dual_write_state_in_transaction",
+            fail_dual_write,
+        )
+
+        with pytest.raises(RuntimeError, match="dual write sync failed"):
+            service.create_report_output(
+                country_id="us",
+                simulation_1_id=simulation["id"],
+                simulation_2_id=None,
+                year="2025",
+            )
+
+        rows = test_db.query(
+            """
+            SELECT * FROM report_outputs
+            WHERE country_id = ? AND simulation_1_id = ? AND simulation_2_id IS NULL AND year = ?
+            """,
+            ("us", simulation["id"], "2025"),
+        ).fetchall()
+        assert rows == []
+
+    def test_update_report_output_rolls_back_parent_update_on_dual_write_failure(
+        self, test_db, monkeypatch
+    ):
+        simulation = simulation_service.create_simulation(
+            country_id="us",
+            population_id="household_report_update_rollback",
+            population_type="household",
+            policy_id=35,
+        )
+        created_report = service.create_report_output(
+            country_id="us",
+            simulation_1_id=simulation["id"],
+            simulation_2_id=None,
+            year="2025",
+        )
+
+        def fail_dual_write(tx, report_output_id, *, country_id=None):
+            raise RuntimeError("dual write sync failed")
+
+        monkeypatch.setattr(
+            service,
+            "_ensure_report_output_dual_write_state_in_transaction",
+            fail_dual_write,
+        )
+
+        with pytest.raises(RuntimeError, match="dual write sync failed"):
+            service.update_report_output(
+                country_id="us",
+                report_id=created_report["id"],
+                status="complete",
+                output=json.dumps({"rolled_back": True}),
+            )
+
+        stored_report = test_db.query(
+            "SELECT * FROM report_outputs WHERE id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert stored_report["status"] == "pending"
+        assert stored_report["output"] is None
+
+        run = test_db.query(
+            "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+            (created_report["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "pending"
+        assert run["output"] is None
+
+    def test_ensure_report_output_dual_write_state_bootstraps_linked_simulations(
+        self, test_db
+    ):
+        test_db.query(
+            """
+            INSERT INTO simulations (
+                country_id, api_version, population_id, population_type, policy_id, status
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                "us-system-1.0.0",
+                "household_stage5_linked",
+                "household",
+                36,
+                "pending",
+            ),
+        )
+        simulation_1 = test_db.query(
+            "SELECT * FROM simulations ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        test_db.query(
+            """
+            INSERT INTO simulations (
+                country_id, api_version, population_id, population_type, policy_id, status
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                "us-system-1.0.0",
+                "household_stage5_linked",
+                "household",
+                37,
+                "pending",
+            ),
+        )
+        simulation_2 = test_db.query(
+            "SELECT * FROM simulations ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        test_db.query(
+            """
+            INSERT INTO report_outputs (
+                country_id, simulation_1_id, simulation_2_id, api_version, status, year
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                simulation_1["id"],
+                simulation_2["id"],
+                get_report_output_cache_version("us"),
+                "pending",
+                "2025",
+            ),
+        )
+        report_output = test_db.query(
+            "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        synced_report = service.ensure_report_output_dual_write_state(
+            report_output["id"],
+            country_id="us",
+        )
+
+        assert synced_report["active_run_id"] is not None
+
+        stored_simulation_1 = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation_1["id"],),
+        ).fetchone()
+        stored_simulation_2 = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation_2["id"],),
+        ).fetchone()
+        assert stored_simulation_1["simulation_spec_json"] is not None
+        assert stored_simulation_1["active_run_id"] is not None
+        assert stored_simulation_2["simulation_spec_json"] is not None
+        assert stored_simulation_2["active_run_id"] is not None
+
+        simulation_1_run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (simulation_1["id"],),
+        ).fetchone()
+        simulation_2_run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (simulation_2["id"],),
+        ).fetchone()
+        assert simulation_1_run is not None
+        assert simulation_2_run is not None

--- a/tests/unit/services/test_report_run_service.py
+++ b/tests/unit/services/test_report_run_service.py
@@ -38,12 +38,12 @@ class TestCreateReportOutputRun:
             trigger_type="rerun",
         )
 
-        assert first_run["run_sequence"] == 1
+        assert first_run["run_sequence"] == 2
         assert first_run["trigger_type"] == "initial"
         assert first_run["report_spec_snapshot_json"] == {"country_id": "us"}
         assert first_run["country_package_version"] == "us-1.0.0"
         assert first_run["report_cache_version"] == "r123"
-        assert second_run["run_sequence"] == 2
+        assert second_run["run_sequence"] == 3
         assert second_run["trigger_type"] == "rerun"
 
     def test_lists_report_runs_in_sequence_order(self, test_db):
@@ -68,7 +68,7 @@ class TestCreateReportOutputRun:
 
         runs = report_run_service.list_report_output_runs(report_output["id"])
 
-        assert [run["run_sequence"] for run in runs] == [1, 2]
+        assert [run["run_sequence"] for run in runs] == [1, 2, 3]
 
     def test_allocates_run_sequence_transactionally(self, test_db):
         simulation = simulation_service.create_simulation(
@@ -91,8 +91,8 @@ class TestCreateReportOutputRun:
             report_output["id"], trigger_type="rerun"
         )
 
-        assert first_run["run_sequence"] == 1
-        assert second_run["run_sequence"] == 2
+        assert first_run["run_sequence"] == 2
+        assert second_run["run_sequence"] == 3
 
     def test_raises_when_parent_report_output_is_missing(self, test_db):
         with pytest.raises(ValueError) as exc_info:
@@ -241,7 +241,7 @@ class TestSelectDisplayReportRun:
 
         selected_run = report_run_service.select_display_run(updated_report_output)
 
-        assert first_run["run_sequence"] == 1
+        assert first_run["run_sequence"] == 2
         assert selected_run["id"] == newest_run["id"]
 
     def test_falls_back_to_newest_run_when_latest_successful_pointer_is_stale(

--- a/tests/unit/services/test_report_spec_service.py
+++ b/tests/unit/services/test_report_spec_service.py
@@ -1,5 +1,6 @@
 import pytest
 
+from policyengine_api.constants import get_report_output_cache_version
 from policyengine_api.services.report_output_service import ReportOutputService
 from policyengine_api.services.report_spec_service import (
     EconomyReportSpec,
@@ -163,12 +164,24 @@ class TestBuildReportSpec:
             population_type="household",
             policy_id=1,
         )
-        report_output = report_output_service.create_report_output(
-            country_id="us",
-            simulation_1_id=simulation_1["id"],
-            simulation_2_id=None,
-            year="2025",
+        test_db.query(
+            """
+            INSERT INTO report_outputs (
+                country_id, simulation_1_id, simulation_2_id, api_version, status, year
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "us",
+                simulation_1["id"],
+                None,
+                get_report_output_cache_version("us"),
+                "pending",
+                "2025",
+            ),
         )
+        report_output = test_db.query(
+            "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+        ).fetchone()
 
         with pytest.raises(ValueError) as exc_info:
             report_spec_service.build_report_spec(report_output, simulation_1)

--- a/tests/unit/services/test_simulation_run_service.py
+++ b/tests/unit/services/test_simulation_run_service.py
@@ -29,13 +29,13 @@ class TestCreateSimulationRun:
             trigger_type="rerun",
         )
 
-        assert first_run["run_sequence"] == 1
+        assert first_run["run_sequence"] == 2
         assert first_run["trigger_type"] == "initial"
         assert first_run["simulation_spec_snapshot_json"] == {
             "population_id": "household_1"
         }
         assert first_run["simulation_cache_version"] == "s123"
-        assert second_run["run_sequence"] == 2
+        assert second_run["run_sequence"] == 3
         assert second_run["trigger_type"] == "rerun"
 
     def test_allocates_run_sequence_transactionally(self, test_db):
@@ -53,8 +53,8 @@ class TestCreateSimulationRun:
             simulation["id"], input_position=1, trigger_type="rerun"
         )
 
-        assert first_run["run_sequence"] == 1
-        assert second_run["run_sequence"] == 2
+        assert first_run["run_sequence"] == 2
+        assert second_run["run_sequence"] == 3
 
     def test_raises_when_parent_simulation_is_missing(self, test_db):
         with pytest.raises(ValueError) as exc_info:
@@ -181,7 +181,7 @@ class TestSelectDisplaySimulationRun:
 
         selected_run = simulation_run_service.select_display_run(updated_simulation)
 
-        assert first_run["run_sequence"] == 1
+        assert first_run["run_sequence"] == 2
         assert selected_run["id"] == newest_run["id"]
 
     def test_falls_back_to_newest_run_when_latest_successful_pointer_is_stale(

--- a/tests/unit/services/test_simulation_service.py
+++ b/tests/unit/services/test_simulation_service.py
@@ -224,6 +224,35 @@ class TestCreateSimulation:
         ).fetchone()
         assert run is not None
 
+    def test_create_simulation_rolls_back_parent_insert_on_dual_write_failure(
+        self, test_db, monkeypatch
+    ):
+        def fail_dual_write(tx, simulation_id, *, country_id=None):
+            raise RuntimeError("dual write sync failed")
+
+        monkeypatch.setattr(
+            service,
+            "_ensure_simulation_dual_write_state_in_transaction",
+            fail_dual_write,
+        )
+
+        with pytest.raises(RuntimeError, match="dual write sync failed"):
+            service.create_simulation(
+                country_id="us",
+                population_id="household_create_rollback",
+                population_type="household",
+                policy_id=8,
+            )
+
+        rows = test_db.query(
+            """
+            SELECT * FROM simulations
+            WHERE country_id = ? AND population_id = ? AND population_type = ? AND policy_id = ?
+            """,
+            ("us", "household_create_rollback", "household", 8),
+        ).fetchall()
+        assert rows == []
+
 
 class TestGetSimulation:
     """Test retrieving simulations from the database."""
@@ -414,3 +443,45 @@ class TestUpdateSimulation:
         assert len(runs) == 1
         assert runs[0]["id"] == first_run["id"]
         assert runs[0]["status"] == "complete"
+
+    def test_update_simulation_rolls_back_parent_update_on_dual_write_failure(
+        self, test_db, monkeypatch
+    ):
+        created_simulation = service.create_simulation(
+            country_id="us",
+            population_id="household_update_rollback",
+            population_type="household",
+            policy_id=15,
+        )
+
+        def fail_dual_write(tx, simulation_id, *, country_id=None):
+            raise RuntimeError("dual write sync failed")
+
+        monkeypatch.setattr(
+            service,
+            "_ensure_simulation_dual_write_state_in_transaction",
+            fail_dual_write,
+        )
+
+        with pytest.raises(RuntimeError, match="dual write sync failed"):
+            service.update_simulation(
+                country_id="us",
+                simulation_id=created_simulation["id"],
+                status="complete",
+                output=json.dumps({"rolled_back": True}),
+            )
+
+        stored_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert stored_simulation["status"] == "pending"
+        assert stored_simulation["output"] is None
+
+        run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "pending"
+        assert run["output"] is None

--- a/tests/unit/services/test_simulation_service.py
+++ b/tests/unit/services/test_simulation_service.py
@@ -1,11 +1,11 @@
 import pytest
+import json
 
 from policyengine_api.services.simulation_service import SimulationService
 
-from tests.fixtures.services.simulation_fixtures import (
-    valid_simulation_data,
-    existing_simulation_record,
-)
+from tests.fixtures.services import simulation_fixtures
+
+pytest_plugins = ("tests.fixtures.services.simulation_fixtures",)
 
 service = SimulationService()
 
@@ -21,18 +21,29 @@ class TestFindExistingSimulation:
 
         # WHEN we search for a simulation with matching parameters
         result = service.find_existing_simulation(
-            country_id=valid_simulation_data["country_id"],
-            population_id=valid_simulation_data["population_id"],
-            population_type=valid_simulation_data["population_type"],
-            policy_id=valid_simulation_data["policy_id"],
+            country_id=simulation_fixtures.valid_simulation_data["country_id"],
+            population_id=simulation_fixtures.valid_simulation_data["population_id"],
+            population_type=simulation_fixtures.valid_simulation_data[
+                "population_type"
+            ],
+            policy_id=simulation_fixtures.valid_simulation_data["policy_id"],
         )
 
         # THEN the result should contain the existing simulation
         assert result is not None
         assert result["id"] == existing_simulation_record["id"]
-        assert result["country_id"] == valid_simulation_data["country_id"]
-        assert result["population_id"] == valid_simulation_data["population_id"]
-        assert result["policy_id"] == valid_simulation_data["policy_id"]
+        assert (
+            result["country_id"]
+            == simulation_fixtures.valid_simulation_data["country_id"]
+        )
+        assert (
+            result["population_id"]
+            == simulation_fixtures.valid_simulation_data["population_id"]
+        )
+        assert (
+            result["policy_id"]
+            == simulation_fixtures.valid_simulation_data["policy_id"]
+        )
 
     def test_find_existing_simulation_given_no_match(self, test_db):
         """Test that find_existing_simulation returns None when no match exists."""
@@ -57,10 +68,12 @@ class TestFindExistingSimulation:
 
         # WHEN we search for the same simulation (API version is ignored)
         result = service.find_existing_simulation(
-            country_id=valid_simulation_data["country_id"],
-            population_id=valid_simulation_data["population_id"],
-            population_type=valid_simulation_data["population_type"],
-            policy_id=valid_simulation_data["policy_id"],
+            country_id=simulation_fixtures.valid_simulation_data["country_id"],
+            population_id=simulation_fixtures.valid_simulation_data["population_id"],
+            population_type=simulation_fixtures.valid_simulation_data[
+                "population_type"
+            ],
+            policy_id=simulation_fixtures.valid_simulation_data["policy_id"],
         )
 
         # THEN the existing record should be found (API version ignored)
@@ -148,6 +161,69 @@ class TestCreateSimulation:
             assert result["population_id"] == f"household_{i}"
             assert result["policy_id"] == i
 
+    def test_create_simulation_populates_dual_write_state(self, test_db):
+        created_simulation = service.create_simulation(
+            country_id="us",
+            population_id="household_dual_write",
+            population_type="household",
+            policy_id=3,
+        )
+
+        stored_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert stored_simulation["simulation_spec_json"] is not None
+        assert stored_simulation["simulation_spec_schema_version"] == 1
+        assert stored_simulation["active_run_id"] is not None
+        assert stored_simulation["latest_successful_run_id"] is None
+
+        run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "pending"
+        assert run["trigger_type"] == "initial"
+        snapshot = run["simulation_spec_snapshot_json"]
+        if isinstance(snapshot, str):
+            snapshot = json.loads(snapshot)
+        assert snapshot["population_id"] == "household_dual_write"
+        assert snapshot["policy_id"] == 3
+
+    def test_create_simulation_reuses_existing_row_and_bootstraps_dual_write(
+        self, test_db
+    ):
+        test_db.query(
+            """INSERT INTO simulations
+            (country_id, api_version, population_id, population_type, policy_id, status)
+            VALUES (?, ?, ?, ?, ?, ?)""",
+            ("us", "us-system-1.0.0", "household_bootstrap", "household", 7, "pending"),
+        )
+
+        created_simulation = service.create_simulation(
+            country_id="us",
+            population_id="household_bootstrap",
+            population_type="household",
+            policy_id=7,
+        )
+
+        rows = test_db.query(
+            """
+            SELECT * FROM simulations
+            WHERE country_id = ? AND population_id = ? AND population_type = ? AND policy_id = ?
+            """,
+            ("us", "household_bootstrap", "household", 7),
+        ).fetchall()
+        assert len(rows) == 1
+        assert created_simulation["id"] == rows[0]["id"]
+
+        run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert run is not None
+
 
 class TestGetSimulation:
     """Test retrieving simulations from the database."""
@@ -158,14 +234,17 @@ class TestGetSimulation:
 
         # WHEN we retrieve the simulation
         result = service.get_simulation(
-            country_id=valid_simulation_data["country_id"],
+            country_id=simulation_fixtures.valid_simulation_data["country_id"],
             simulation_id=existing_simulation_record["id"],
         )
 
         # THEN the correct simulation should be returned
         assert result is not None
         assert result["id"] == existing_simulation_record["id"]
-        assert result["country_id"] == valid_simulation_data["country_id"]
+        assert (
+            result["country_id"]
+            == simulation_fixtures.valid_simulation_data["country_id"]
+        )
 
     def test_get_simulation_nonexistent(self, test_db):
         """Test retrieving a non-existent simulation returns None."""
@@ -231,3 +310,107 @@ class TestUniqueConstraint:
         assert first_simulation["country_id"] == second_simulation["country_id"]
         assert first_simulation["population_id"] == second_simulation["population_id"]
         assert first_simulation["policy_id"] == second_simulation["policy_id"]
+
+
+class TestUpdateSimulation:
+    def test_update_simulation_updates_dual_write_state(self, test_db):
+        created_simulation = service.create_simulation(
+            country_id="us",
+            population_id="household_update",
+            population_type="household",
+            policy_id=11,
+        )
+        output_json = json.dumps({"result": "ok"})
+
+        success = service.update_simulation(
+            country_id="us",
+            simulation_id=created_simulation["id"],
+            status="complete",
+            output=output_json,
+        )
+
+        assert success is True
+
+        stored_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert stored_simulation["active_run_id"] is None
+        assert stored_simulation["latest_successful_run_id"] is not None
+
+        run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert run["status"] == "complete"
+        assert run["output"] == output_json
+        assert run["id"] == stored_simulation["latest_successful_run_id"]
+
+    def test_update_simulation_bootstraps_missing_run_state(self, test_db):
+        test_db.query(
+            """INSERT INTO simulations
+            (country_id, api_version, population_id, population_type, policy_id, status)
+            VALUES (?, ?, ?, ?, ?, ?)""",
+            ("us", "us-system-1.0.0", "household_legacy", "household", 13, "pending"),
+        )
+        simulation = test_db.query(
+            "SELECT * FROM simulations ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+
+        success = service.update_simulation(
+            country_id="us",
+            simulation_id=simulation["id"],
+            status="error",
+            error_message="legacy failure",
+        )
+
+        assert success is True
+
+        stored_simulation = test_db.query(
+            "SELECT * FROM simulations WHERE id = ?",
+            (simulation["id"],),
+        ).fetchone()
+        assert stored_simulation["simulation_spec_json"] is not None
+        assert stored_simulation["active_run_id"] is None
+        assert stored_simulation["latest_successful_run_id"] is None
+
+        run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (simulation["id"],),
+        ).fetchone()
+        assert run is not None
+        assert run["status"] == "error"
+        assert run["error_message"] == "legacy failure"
+
+    def test_update_simulation_does_not_append_extra_run_for_legacy_patch_traffic(
+        self, test_db
+    ):
+        created_simulation = service.create_simulation(
+            country_id="us",
+            population_id="household_single_run",
+            population_type="household",
+            policy_id=14,
+        )
+
+        first_run = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+            (created_simulation["id"],),
+        ).fetchone()
+        assert first_run is not None
+
+        success = service.update_simulation(
+            country_id="us",
+            simulation_id=created_simulation["id"],
+            status="complete",
+            output=json.dumps({"value": 1}),
+        )
+
+        assert success is True
+
+        runs = test_db.query(
+            "SELECT * FROM simulation_runs WHERE simulation_id = ? ORDER BY run_sequence",
+            (created_simulation["id"],),
+        ).fetchall()
+        assert len(runs) == 1
+        assert runs[0]["id"] == first_run["id"]
+        assert runs[0]["status"] == "complete"

--- a/tests/unit/test_stage5_routes.py
+++ b/tests/unit/test_stage5_routes.py
@@ -120,6 +120,97 @@ def test_create_report_output_existing_row_repairs_dual_write_state(test_db):
     assert snapshot["report_kind"] == "household_single"
 
 
+def test_create_report_output_missing_primary_simulation_returns_bad_request(test_db):
+    client = create_test_client()
+    response = client.post(
+        "/us/report",
+        json={
+            "simulation_1_id": 999999,
+            "simulation_2_id": None,
+            "year": "2025",
+        },
+    )
+
+    assert response.status_code == 400
+
+    report_rows = test_db.query("SELECT * FROM report_outputs").fetchall()
+    report_run_rows = test_db.query("SELECT * FROM report_output_runs").fetchall()
+    assert report_rows == []
+    assert report_run_rows == []
+
+
+def test_create_report_output_missing_secondary_simulation_returns_bad_request(test_db):
+    simulation = simulation_service.create_simulation(
+        country_id="us",
+        population_id="household_missing_secondary",
+        population_type="household",
+        policy_id=42,
+    )
+
+    client = create_test_client()
+    response = client.post(
+        "/us/report",
+        json={
+            "simulation_1_id": simulation["id"],
+            "simulation_2_id": simulation["id"] + 999999,
+            "year": "2025",
+        },
+    )
+
+    assert response.status_code == 400
+
+    report_rows = test_db.query(
+        "SELECT * FROM report_outputs WHERE simulation_1_id = ?",
+        (simulation["id"],),
+    ).fetchall()
+    report_run_rows = test_db.query("SELECT * FROM report_output_runs").fetchall()
+    assert report_rows == []
+    assert report_run_rows == []
+
+
+def test_get_simulation_wrong_country_returns_not_found(test_db):
+    simulation = simulation_service.create_simulation(
+        country_id="us",
+        population_id="household_wrong_country_get",
+        population_type="household",
+        policy_id=43,
+    )
+
+    client = create_test_client()
+    response = client.get(f"/uk/simulation/{simulation['id']}")
+
+    assert response.status_code == 404
+
+
+def test_patch_simulation_wrong_country_returns_not_found_and_does_not_mutate(test_db):
+    simulation = simulation_service.create_simulation(
+        country_id="us",
+        population_id="household_wrong_country_patch",
+        population_type="household",
+        policy_id=44,
+    )
+
+    client = create_test_client()
+    response = client.patch(
+        "/uk/simulation",
+        json={
+            "id": simulation["id"],
+            "status": "complete",
+            "output": json.dumps({"should_not": "persist"}),
+        },
+    )
+
+    assert response.status_code == 404
+
+    stored_simulation = test_db.query(
+        "SELECT * FROM simulations WHERE id = ?",
+        (simulation["id"],),
+    ).fetchone()
+    assert stored_simulation["country_id"] == "us"
+    assert stored_simulation["status"] == "pending"
+    assert stored_simulation["output"] is None
+
+
 def test_get_report_output_wrong_country_returns_not_found(test_db):
     test_db.query(
         """

--- a/tests/unit/test_stage5_routes.py
+++ b/tests/unit/test_stage5_routes.py
@@ -118,3 +118,58 @@ def test_create_report_output_existing_row_repairs_dual_write_state(test_db):
     if isinstance(snapshot, str):
         snapshot = json.loads(snapshot)
     assert snapshot["report_kind"] == "household_single"
+
+
+def test_get_report_output_wrong_country_returns_not_found(test_db):
+    test_db.query(
+        """
+        INSERT INTO report_outputs (
+            country_id, simulation_1_id, simulation_2_id, api_version, status, year
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("us", 999, None, get_report_output_cache_version("us"), "pending", "2025"),
+    )
+    report_output = test_db.query(
+        "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+
+    client = create_test_client()
+    response = client.get(f"/uk/report/{report_output['id']}")
+
+    assert response.status_code == 404
+
+
+def test_patch_report_output_wrong_country_returns_not_found_and_does_not_mutate(
+    test_db,
+):
+    test_db.query(
+        """
+        INSERT INTO report_outputs (
+            country_id, simulation_1_id, simulation_2_id, api_version, status, year
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("us", 1000, None, get_report_output_cache_version("us"), "pending", "2025"),
+    )
+    report_output = test_db.query(
+        "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+
+    client = create_test_client()
+    response = client.patch(
+        "/uk/report",
+        json={
+            "id": report_output["id"],
+            "status": "complete",
+            "output": json.dumps({"should_not": "persist"}),
+        },
+    )
+
+    assert response.status_code == 404
+
+    stored_report = test_db.query(
+        "SELECT * FROM report_outputs WHERE id = ?",
+        (report_output["id"],),
+    ).fetchone()
+    assert stored_report["country_id"] == "us"
+    assert stored_report["status"] == "pending"
+    assert stored_report["output"] is None

--- a/tests/unit/test_stage5_routes.py
+++ b/tests/unit/test_stage5_routes.py
@@ -1,0 +1,120 @@
+import json
+
+from flask import Flask
+
+from policyengine_api.constants import get_report_output_cache_version
+from policyengine_api.routes.report_output_routes import report_output_bp
+from policyengine_api.routes.simulation_routes import simulation_bp
+from policyengine_api.services.report_output_service import ReportOutputService
+from policyengine_api.services.simulation_service import SimulationService
+
+
+simulation_service = SimulationService()
+report_output_service = ReportOutputService()
+
+
+def create_test_client() -> Flask:
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(simulation_bp)
+    app.register_blueprint(report_output_bp)
+    return app.test_client()
+
+
+def test_create_simulation_existing_row_repairs_dual_write_state(test_db):
+    test_db.query(
+        """INSERT INTO simulations
+        (country_id, api_version, population_id, population_type, policy_id, status)
+        VALUES (?, ?, ?, ?, ?, ?)""",
+        ("us", "us-system-1.0.0", "household_route_repair", "household", 40, "pending"),
+    )
+    simulation = test_db.query(
+        "SELECT * FROM simulations ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+
+    client = create_test_client()
+    response = client.post(
+        "/us/simulation",
+        json={
+            "population_id": "household_route_repair",
+            "population_type": "household",
+            "policy_id": 40,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["message"] == "Simulation already exists"
+    assert payload["result"]["id"] == simulation["id"]
+
+    stored_simulation = test_db.query(
+        "SELECT * FROM simulations WHERE id = ?",
+        (simulation["id"],),
+    ).fetchone()
+    assert stored_simulation["simulation_spec_json"] is not None
+    assert stored_simulation["active_run_id"] is not None
+
+    run = test_db.query(
+        "SELECT * FROM simulation_runs WHERE simulation_id = ?",
+        (simulation["id"],),
+    ).fetchone()
+    assert run is not None
+
+
+def test_create_report_output_existing_row_repairs_dual_write_state(test_db):
+    simulation = simulation_service.create_simulation(
+        country_id="us",
+        population_id="household_route_report",
+        population_type="household",
+        policy_id=41,
+    )
+    test_db.query(
+        """
+        INSERT INTO report_outputs (
+            country_id, simulation_1_id, simulation_2_id, api_version, status, year
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "us",
+            simulation["id"],
+            None,
+            get_report_output_cache_version("us"),
+            "pending",
+            "2025",
+        ),
+    )
+    report_output = test_db.query(
+        "SELECT * FROM report_outputs ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+
+    client = create_test_client()
+    response = client.post(
+        "/us/report",
+        json={
+            "simulation_1_id": simulation["id"],
+            "simulation_2_id": None,
+            "year": "2025",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["message"] == "Report output already exists"
+    assert payload["result"]["id"] == report_output["id"]
+
+    stored_report = test_db.query(
+        "SELECT * FROM report_outputs WHERE id = ?",
+        (report_output["id"],),
+    ).fetchone()
+    assert stored_report["report_spec_json"] is not None
+    assert stored_report["active_run_id"] is not None
+
+    run = test_db.query(
+        "SELECT * FROM report_output_runs WHERE report_output_id = ?",
+        (report_output["id"],),
+    ).fetchone()
+    assert run is not None
+    snapshot = run["report_spec_snapshot_json"]
+    if isinstance(snapshot, str):
+        snapshot = json.loads(snapshot)
+    assert snapshot["report_kind"] == "household_single"


### PR DESCRIPTION
Fixes #3439

Stage 5 of the report-output migration.

This PR:
- dual-writes live simulation create/update traffic into simulation_runs
- dual-writes live report create/update traffic into report_output_runs
- keeps active_run_id/latest_successful_run_id in sync during legacy traffic
- lazily bootstraps missing run/spec state so stage 5 can operate before stage 4 is fully backfilled
- keeps existing API routes and response shapes stable

Not in scope:
- stage 6 read cutover
- stage 8 rerun rewrite

Verification:
- uv run ruff check policyengine_api/services/run_sync_utils.py policyengine_api/services/simulation_service.py policyengine_api/services/report_output_service.py policyengine_api/routes/simulation_routes.py policyengine_api/routes/report_output_routes.py tests/unit/services/test_simulation_service.py tests/unit/services/test_report_output_service.py tests/unit/test_stage5_routes.py
- FLASK_DEBUG=1 .venv/bin/python -m pytest --confcutdir=tests/unit tests/unit/services/test_simulation_service.py tests/unit/services/test_report_output_service.py tests/unit/test_stage5_routes.py -q