### PR TITLE
chore: add changelog fragment to unstick versioning

### DIFF
--- a/changelog.d/unstick-deploy.changed.md
+++ b/changelog.d/unstick-deploy.changed.md
@@ -1,0 +1,1 @@
+No functional change. Adds a changelog fragment so towncrier can build after the #3471 revert, which removed the only pending fragment and left the versioning job failing with "No changelog fragments found".


### PR DESCRIPTION
## Summary

The #3471 revert (#3473) removed the only pending changelog fragment, so towncrier now exits non-zero with "No changelog fragments found" on every push to master — the versioning job fails and Deploy API + Docker jobs stay skipped. Ship a no-op fragment so the next push triggers a clean versioning + deploy cycle.

No functional change. After merge the versioning bot will consume this fragment, bump the version, and restore the normal deploy pipeline.

Unrelated: CI failures on "Test environment variables" are pre-existing (same `gov.contrib.additional_tax_bracket.bracket.rates` metadata error that's also failing on `auto/update-policyengine-us-1.653.*`), not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)