### PR TITLE
Temporarily pin policyengine-core below 3.24.0

### DIFF
--- a/changelog.d/3494.changed.md
+++ b/changelog.d/3494.changed.md
@@ -1,0 +1,1 @@
+Temporarily pin `policyengine_core` below 3.24.0 to restore API v1 deployability while the simulation API auth rollout is completed and production has not yet picked up a fixed `policyengine_us` release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "policyengine-il==0.1.0",
     "policyengine_uk==2.78.0",
     "policyengine_us==1.634.9",
-    "policyengine_core>=3.16.6",
+    "policyengine_core>=3.23.5,<3.24.0",
     "policyengine>0.12.0,<1",
     "pydantic",
     "pymysql",


### PR DESCRIPTION
Fixes #3494

Temporary bridge pin to restore API v1 deployability while the simulation API auth rollout is completed and production has not yet picked up a fixed `policyengine_us` release.