### PR TITLE
Align changelog PR check with push versioning

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,16 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v5
       - name: Check for changelog fragment
-        run: uv run --with "towncrier>=24.8.0" towncrier check --compare-with origin/master
+        run: |
+          FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)
+          if [ "$FRAGMENTS" -eq 0 ]; then
+            echo "::error::No changelog fragment found in changelog.d/"
+            echo "Add one with: echo 'Description.' > changelog.d/\$(git branch --show-current).<type>.md"
+            echo "Types: added, changed, fixed, removed, breaking"
+            exit 1
+          fi
   test_container_builds:
     name: Docker
     runs-on: ubuntu-latest

--- a/changelog.d/changelog-check-align-versioning.changed.md
+++ b/changelog.d/changelog-check-align-versioning.changed.md
@@ -1,0 +1,1 @@
+Require pull request CI to enforce a real changelog fragment so it matches the push-time versioning workflow.


### PR DESCRIPTION
## Summary

The PR changelog gate was using `towncrier check --compare-with origin/master`, which allowed PRs with no new fragment to pass in some branch histories while the push workflow still failed at `bump_version.py` with `No changelog fragments found`.

This switches the PR check to the same effective contract the push workflow enforces: a PR must contain at least one real fragment file in `changelog.d/`.

## Changes

- replace the `towncrier check --compare-with origin/master` PR gate with a direct fragment-presence check
- keep `.gitkeep` excluded
- add a changelog fragment for this workflow fix

## Validation

- verified the new PR check logic sees a fragment in `changelog.d/`
- ran `uv run python .github/bump_version.py` to confirm the fragment is consumable by the push-time versioning script
