### PR TITLE
Fix gateway auth unit tests under deploy env

### DIFF
--- a/changelog.d/gateway-auth-test-env.fixed.md
+++ b/changelog.d/gateway-auth-test-env.fixed.md
@@ -1,0 +1,1 @@
+Fixed the staging App Engine deploy build by isolating gateway-auth unit tests from deploy-time auth environment variables.

--- a/tests/unit/libs/test_gateway_auth.py
+++ b/tests/unit/libs/test_gateway_auth.py
@@ -32,6 +32,13 @@ CLIENT_SECRET_RESOURCE = (
 )
 
 
+@pytest.fixture(autouse=True)
+def clear_gateway_auth_env(monkeypatch):
+    """Isolate unit tests from any gateway-auth env baked into the build image."""
+    for key in (*GATEWAY_AUTH_ENV_VARS, GATEWAY_AUTH_REQUIRED_ENV):
+        monkeypatch.delenv(key, raising=False)
+
+
 def _make_token_response(token: str, expires_in: int = 86400) -> MagicMock:
     response = MagicMock()
     response.status_code = 200

--- a/tests/unit/libs/test_simulation_api_modal.py
+++ b/tests/unit/libs/test_simulation_api_modal.py
@@ -49,6 +49,22 @@ from tests.fixtures.libs.simulation_api_modal import (  # noqa: E402
 
 pytest_plugins = ("tests.fixtures.libs.simulation_api_modal",)
 
+GATEWAY_AUTH_TEST_ENV_VARS = (
+    "GATEWAY_AUTH_ISSUER",
+    "GATEWAY_AUTH_AUDIENCE",
+    "GATEWAY_AUTH_CLIENT_ID",
+    "GATEWAY_AUTH_CLIENT_SECRET",
+    "GATEWAY_AUTH_CLIENT_SECRET_RESOURCE",
+    "GATEWAY_AUTH_REQUIRED",
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_gateway_auth_env(monkeypatch):
+    """Isolate unit tests from gateway-auth env injected during Docker builds."""
+    for key in GATEWAY_AUTH_TEST_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+
 
 class TestModalSimulationExecution:
     """Tests for the ModalSimulationExecution dataclass."""


### PR DESCRIPTION
## Summary
- isolate gateway auth unit tests from deploy-time auth environment variables
- clear both raw-secret and Secret Manager auth env vars before each auth test
- add a changelog fragment so PR and push workflows align

## Testing
- uv run pytest --noconftest tests/unit/libs/test_gateway_auth.py tests/unit/libs/test_simulation_api_modal.py
- uv run ruff check tests/unit/libs/test_gateway_auth.py tests/unit/libs/test_simulation_api_modal.py