### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - name: Install ruff
         run: pip install ruff>=0.9.0
       - name: Format check with ruff
@@ -107,7 +109,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: PolicyEngine/policyengine-api

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
       - name: Install ruff
         run: pip install ruff>=0.9.0
       - name: Format check with ruff
@@ -22,7 +22,7 @@ jobs:
     name: Check changelog fragment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for changelog fragment
         run: |
           FRAGMENTS=$(find changelog.d -type f ! -name '.gitkeep' | wc -l)
@@ -40,9 +40,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -54,13 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Wait until policyengine_us version is available on PyPI
@@ -79,9 +79,9 @@ jobs:
     needs: test_env_vars
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install system dependencies
@@ -89,11 +89,11 @@ jobs:
       - name: Start Redis
         run: sudo systemctl start redis-server
       - name: Auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: policyengine-api
       - name: Install dependencies

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - name: Install ruff
         run: pip install ruff>=0.9.0
       - name: Format check with ruff

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,9 +19,9 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine API')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
       - name: Install ruff
         run: pip install ruff>=0.9.0
       - name: Format check with ruff
@@ -36,9 +36,9 @@ jobs:
     environment: staging
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies (required for finding API model versions)
@@ -61,16 +61,16 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build changelog
@@ -81,7 +81,7 @@ jobs:
       - name: Preview changelog update
         run: ".github/get-changelog-diff.sh"
       - name: Update changelog
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           add: "."
           committer_name: Github Actions[bot]
@@ -97,9 +97,9 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine API')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Publish Git Tag
@@ -120,9 +120,9 @@ jobs:
       url: ${{ steps.version_url.outputs.url }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Compute staging version name
@@ -130,11 +130,11 @@ jobs:
         run: |
           echo "version=staging-${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: GCP authentication
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
       - name: Set up GCloud
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@v3"
       - name: Validate App Engine deployment configuration
         run: bash .github/scripts/validate_app_engine_deploy_env.sh
         env:
@@ -178,9 +178,9 @@ jobs:
       && (github.event.head_commit.message == 'Update PolicyEngine API')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install staging test dependencies
@@ -201,9 +201,9 @@ jobs:
     environment: production
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies (required for finding API model versions)
@@ -227,9 +227,9 @@ jobs:
     environment: production
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Compute production version name
@@ -237,11 +237,11 @@ jobs:
         run: |
           echo "version=prod-${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: GCP authentication
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GCP_SA_KEY }}"
       - name: Set up GCloud
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: "google-github-actions/setup-gcloud@v3"
       - name: Validate App Engine deployment configuration
         run: bash .github/scripts/validate_app_engine_deploy_env.sh
         env:
@@ -292,9 +292,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/update-country-packages.yaml
+++ b/.github/workflows/update-country-packages.yaml
@@ -17,19 +17,19 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: master
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/changelog.d/update-actions-node24.changed.md
+++ b/changelog.d/update-actions-node24.changed.md
@@ -1,0 +1,1 @@
+Updated GitHub Actions workflows for Node 24-compatible action runtimes.


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.