### PR TITLE
Fix App Engine deploy and startup script false failures

### DIFF
--- a/.github/scripts/deploy_app_engine_version.sh
+++ b/.github/scripts/deploy_app_engine_version.sh
@@ -34,4 +34,4 @@ if [[ "${APP_ENGINE_PROMOTE}" != "1" ]]; then
   deploy_args+=("--no-promote")
 fi
 
-yes | gcloud app deploy "${deploy_args[@]}"
+gcloud app deploy --quiet "${deploy_args[@]}"

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ brew install redis
 redis-server
 ```
 
-2. Start the API service worker
+2. Start the API
 
 Run the below
 
 ```
-FLASK_DEBUG=1 python policyengine_api/worker.py
+FLASK_DEBUG=1 python -m flask --app policyengine_api.api run
 ```
 
 NOTE: Calculations are not possible in the uk app without access to a specific dataset. Expect an error: "ValueError: Invalid response code 404 for url https://api.github.com/repos/policyengine/non-public-microdata/releases/tags/uk-2024-march-efo."

--- a/changelog.d/app-engine-deploy-quiet.fixed.md
+++ b/changelog.d/app-engine-deploy-quiet.fixed.md
@@ -1,1 +1,1 @@
-Fixed staged App Engine deploy automation to use `gcloud app deploy --quiet` instead of piping `yes`, preventing false CI failures after successful deployments. Also removed stale startup attempts to launch a nonexistent `policyengine_api/worker.py` process in the App Engine container.
+Fixed staged App Engine deploy automation to use `gcloud app deploy --quiet` instead of piping `yes`, preventing false CI failures after successful deployments. Also removed stale runtime, test-fixture, and README references to a nonexistent `policyengine_api/worker.py` process.

--- a/changelog.d/app-engine-deploy-quiet.fixed.md
+++ b/changelog.d/app-engine-deploy-quiet.fixed.md
@@ -1,1 +1,1 @@
-Fixed staged App Engine deploy automation to use `gcloud app deploy --quiet` instead of piping `yes`, preventing false CI failures after successful deployments.
+Fixed staged App Engine deploy automation to use `gcloud app deploy --quiet` instead of piping `yes`, preventing false CI failures after successful deployments. Also removed stale startup attempts to launch a nonexistent `policyengine_api/worker.py` process in the App Engine container.

--- a/changelog.d/app-engine-deploy-quiet.fixed.md
+++ b/changelog.d/app-engine-deploy-quiet.fixed.md
@@ -1,0 +1,1 @@
+Fixed staged App Engine deploy automation to use `gcloud app deploy --quiet` instead of piping `yes`, preventing false CI failures after successful deployments.

--- a/gcp/policyengine_api/start.sh
+++ b/gcp/policyengine_api/start.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Environment variables
 PORT="${PORT:-8080}"
-WORKER_COUNT="${WORKER_COUNT:-3}"
 REDIS_PORT="${REDIS_PORT:-6379}"
 
 # Start the API
@@ -14,15 +13,6 @@ redis-server --protected-mode no \
 
 # Wait for Redis to be ready
 sleep 2
-
-# Start multiple workers using POSIX-compliant loop
-i=1
-while [ $i -le "$WORKER_COUNT" ]
-do
-    echo "Starting worker $i..."
-    python3 policyengine_api/worker.py &
-    i=$((i + 1))
-done
 
 # Keep the script running and handle shutdown gracefully
 trap "pkill -P $$; exit 1" INT TERM

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,5 @@ def client():
     with running(["redis-server"], 3):
         redis_client = redis.Redis()
         redis_client.ping()
-        with running([sys.executable, "policyengine_api/worker.py"], 3):
-            with app.test_client() as test_client:
-                yield test_client
+        with app.test_client() as test_client:
+            yield test_client


### PR DESCRIPTION
Fixes #3514

## Summary
- replace `yes | gcloud app deploy` with `gcloud app deploy --quiet`
- prevent false CI failures after successful App Engine deploys under `set -o pipefail`
- remove stale App Engine startup attempts to launch nonexistent `policyengine_api/worker.py`
- add a changelog fragment for the deploy/startup fixes

## Testing
- `bash -n .github/scripts/deploy_app_engine_version.sh`
- `bash -n gcp/policyengine_api/start.sh`