### PR TITLE
Import redis lazily for deployed-service integration tests

### DIFF
--- a/changelog.d/lazy-redis-import.fixed.md
+++ b/changelog.d/lazy-redis-import.fixed.md
@@ -1,0 +1,1 @@
+Fixed staging integration test collection by importing `redis` lazily inside the `rest_client` fixture instead of at `tests/conftest.py` module import time.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import time
 from contextlib import contextmanager
 from subprocess import Popen, TimeoutExpired
 import sys
-import redis
 import pytest
 
 # Add the project root directory to PYTHONPATH
@@ -31,6 +30,7 @@ def running(process_arguments, seconds_to_wait_after_launch=0):
 def client():
     """run the app for the tests to run against"""
     from policyengine_api.api import app
+    import redis
 
     app.config["TESTING"] = True
     with running(["redis-server"], 3):


### PR DESCRIPTION
Fixes #3517

## Summary
- move the `redis` import inside the `rest_client` fixture in `tests/conftest.py`
- allow deployed-service integration tests to collect without installing the `redis` Python package
- add a changelog fragment for the test-fixture import fix

## Testing
- `python3 -m py_compile tests/conftest.py`
- `/tmp/policyengine-api-staging-test-venv/bin/python -m pytest tests/integration/test_live_calculate.py tests/integration/test_live_economy.py -v`