### PR TITLE
Cast time_period to string before posting to simulation gateway

### DIFF
--- a/changelog.d/fix-cast-time-period-string-for-gateway.fixed.md
+++ b/changelog.d/fix-cast-time-period-string-for-gateway.fixed.md
@@ -1,0 +1,1 @@
+Cast time_period to string before posting to the simulation gateway. The gateway's request schema (policyengine-api-v2 PR #458) requires Optional[str], but the local policyengine package's SimulationOptions.TimePeriodType is int and model_dump re-emits int, which the gateway 422s.

--- a/policyengine_api/services/economy_service.py
+++ b/policyengine_api/services/economy_service.py
@@ -511,6 +511,15 @@ class EconomyService:
         }
         sim_params["_telemetry"] = telemetry
 
+        # The simulation gateway (policyengine-api-v2 PR #458) requires
+        # ``time_period`` as a string, but the upstream ``policyengine``
+        # package (``TimePeriodType = int``) coerces the value to int during
+        # ``model_validate`` and ``model_dump`` re-emits it as int. Cast back
+        # to str at the request boundary so the gateway's strict schema
+        # validates instead of returning 422.
+        if sim_params.get("time_period") is not None:
+            sim_params["time_period"] = str(sim_params["time_period"])
+
         sim_api_execution = simulation_api.run(sim_params)
         execution_id = simulation_api.get_execution_id(sim_api_execution)
         run_id = getattr(sim_api_execution, "run_id", None) or telemetry["run_id"]


### PR DESCRIPTION
## Summary

- One-line fix: stringify `time_period` in the dict produced by `SimulationOptions.model_dump()` right before `simulation_api.run(...)` posts it to the gateway.

## Why

The simulation gateway (`projects/policyengine-api-simulation/src/modal/gateway/models.py` in `policyengine-api-v2`, PR [#458](https://github.com/PolicyEngine/policyengine-api-v2/pull/458) merged 2026-04-17, deployed to prod as v42 on 2026-04-26) tightened its request schema to require:

```python
time_period: Optional[str] = None
```

The locally-installed `policyengine` PyPI package's `SimulationOptions` declares (`policyengine.py` commit `29f2c1a`, 2025-01-28):

```python
TimePeriodType = int
class SimulationOptions(BaseModel):
    time_period: TimePeriodType = Field(...)
```

So `SimulationOptions.model_validate({"time_period": "2027", ...})` coerces "2027" → 2027 (int), and `model_dump()` re-emits it as int. The gateway then returns:

```
422 Unprocessable Entity - {"detail":[{"type":"string_type","loc":["body","time_period"],"msg":"Input should be a valid string"}]}
```

…which surfaces as a 500 to every `/<country_id>/economy/<id>/over/<id>` request currently. All four state dashboards that depend on the live economy endpoint are blocked.

## Approach

Two places to fix:

- **B.1 (this PR):** cast at the call site in `economy_service.py` — minimum surface, ships immediately, doesn't require coordinating a `policyengine` PyPI release.
- B.2 (deferred): add a `@field_serializer` to `SimulationOptions.time_period` upstream in `PolicyEngine/policyengine.py`. Worth doing later as defence-in-depth so any other consumer of `model_dump()` is also covered, but this PR is sufficient to unblock production.

## Test plan

- [ ] Verify `/us/economy/<id>/over/<id>?region=mo&time_period=2027` no longer returns 500/422 from the gateway after this lands.
- [ ] Check NC/UT/SC dashboards (which only read precomputed CSVs) are unaffected — they don't go through this code path.
- [ ] No simulation-side regressions: downstream `SimulationOptions.time_period` is still typed as int internally; we only stringify the JSON body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)