### PR TITLE
Separate App Engine deploy image build from push-time tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Path to the Google_Application_Credentials file
-# Required to run the simulation API
-GOOGLE_APPLICATION_CREDENTIALS=/path/to/policyengine_gcp_credentials.json
+# For local development only, uncomment this if you need to point ADC at a
+# specific credential file. The deployed App Engine service uses its attached
+# service account instead.
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/policyengine_gcp_credentials.json
 
 # Password for connecting to the PolicyEngine database
 POLICYENGINE_DB_PASSWORD=policyengine_db_password

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# For local development only, uncomment this if you need to point ADC at a
-# specific credential file. The deployed App Engine service uses its attached
-# service account instead.
+# Left commented on purpose so `make setup-env` does not poison ADC with a fake
+# path in CI, Docker builds, or local shells. Uncomment only if your local
+# machine needs to point ADC at a real credential file. The deployed App Engine
+# service uses its attached service account instead.
 # GOOGLE_APPLICATION_CREDENTIALS=/path/to/policyengine_gcp_credentials.json
 
 # Password for connecting to the PolicyEngine database

--- a/.github/scripts/build_app_engine_image.sh
+++ b/.github/scripts/build_app_engine_image.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+APP_ENGINE_IMAGE_TAG="${APP_ENGINE_IMAGE_TAG:-policyengine-api-app-engine:test}"
+
+cleanup() {
+  rm -f app.yaml Dockerfile start.sh .dbpw
+}
+
+trap cleanup EXIT
+
+bash .github/scripts/prepare_app_engine_bundle.sh
+
+docker build -t "${APP_ENGINE_IMAGE_TAG}" .

--- a/.github/scripts/deploy_app_engine_version.sh
+++ b/.github/scripts/deploy_app_engine_version.sh
@@ -8,15 +8,12 @@ APP_ENGINE_PROMOTE="${APP_ENGINE_PROMOTE:-0}"
 APP_ENGINE_SERVICE_ACCOUNT="${APP_ENGINE_SERVICE_ACCOUNT:-github-deployment@policyengine-api.iam.gserviceaccount.com}"
 
 cleanup() {
-  rm -f app.yaml Dockerfile start.sh .gac.json .dbpw
+  rm -f app.yaml Dockerfile start.sh .dbpw
 }
 
 trap cleanup EXIT
 
-python gcp/export.py
-cp gcp/policyengine_api/app.yaml .
-cp gcp/policyengine_api/Dockerfile .
-cp gcp/policyengine_api/start.sh .
+bash .github/scripts/prepare_app_engine_bundle.sh
 
 gcloud config set app/cloud_build_timeout 2400
 

--- a/.github/scripts/prepare_app_engine_bundle.sh
+++ b/.github/scripts/prepare_app_engine_bundle.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+python gcp/export.py
+cp gcp/policyengine_api/app.yaml .
+cp gcp/policyengine_api/Dockerfile .
+cp gcp/policyengine_api/start.sh .

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -128,6 +128,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y redis-server
+      - name: Start Redis
+        run: sudo systemctl start redis-server
       - name: Compute staging version name
         id: version
         run: |
@@ -139,9 +143,33 @@ jobs:
           service_account: "${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}"
       - name: Set up GCloud
         uses: "google-github-actions/setup-gcloud@v2"
+      - name: Install dependencies
+        run: make install
+      - name: Run push-time tests
+        run: make test
+        env:
+          POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
+          POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
       - name: Validate App Engine deployment configuration
         run: bash .github/scripts/validate_app_engine_deploy_env.sh
         env:
+          SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
+          GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
+          GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
+          GATEWAY_AUTH_CLIENT_ID: ${{ secrets.GATEWAY_AUTH_CLIENT_ID }}
+          GATEWAY_AUTH_CLIENT_SECRET_RESOURCE: ${{ secrets.GATEWAY_AUTH_CLIENT_SECRET_RESOURCE }}
+      - name: Build staging deploy image
+        run: bash .github/scripts/build_app_engine_image.sh
+        env:
+          APP_ENGINE_IMAGE_TAG: policyengine-api:staging-${{ steps.version.outputs.version }}
+          POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
+          POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
           SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
           GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
           GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -156,6 +156,9 @@ jobs:
       - name: Validate App Engine deployment configuration
         run: bash .github/scripts/validate_app_engine_deploy_env.sh
         env:
+          # Transitional: these values are still passed into the deploy bundle
+          # by gcp/export.py. Long-term target is a generic image plus runtime
+          # config / Secret Manager lookups instead of image bake-in.
           SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
           GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
           GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
@@ -164,6 +167,9 @@ jobs:
       - name: Build staging deploy image
         run: bash .github/scripts/build_app_engine_image.sh
         env:
+          # Transitional: these values are still rendered into the App Engine
+          # image today. Long-term target is to stop passing them into the
+          # image build and supply them as runtime config / Secret Manager data.
           APP_ENGINE_IMAGE_TAG: policyengine-api:staging-${{ steps.version.outputs.version }}
           POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
           POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN }}
@@ -178,6 +184,9 @@ jobs:
       - name: Deploy staging version
         run: bash .github/scripts/deploy_app_engine_version.sh
         env:
+          # Transitional: deploy_app_engine_version.sh still prepares a bundle
+          # from these values before App Engine deploy. Long-term target is one
+          # generic image plus runtime config / Secret Manager.
           APP_ENGINE_VERSION: ${{ steps.version.outputs.version }}
           APP_ENGINE_PROMOTE: "0"
           POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
@@ -280,6 +289,9 @@ jobs:
       - name: Validate App Engine deployment configuration
         run: bash .github/scripts/validate_app_engine_deploy_env.sh
         env:
+          # Transitional: these values are still passed into the deploy bundle
+          # by gcp/export.py. Long-term target is a generic image plus runtime
+          # config / Secret Manager lookups instead of image bake-in.
           SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
           GATEWAY_AUTH_ISSUER: ${{ secrets.GATEWAY_AUTH_ISSUER }}
           GATEWAY_AUTH_AUDIENCE: ${{ secrets.GATEWAY_AUTH_AUDIENCE }}
@@ -288,6 +300,9 @@ jobs:
       - name: Deploy production version
         run: bash .github/scripts/deploy_app_engine_version.sh
         env:
+          # Transitional: deploy_app_engine_version.sh still prepares a bundle
+          # from these values before App Engine deploy. Long-term target is one
+          # generic image plus runtime config / Secret Manager.
           APP_ENGINE_VERSION: ${{ steps.version.outputs.version }}
           APP_ENGINE_PROMOTE: "0"
           POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 install:
 	pip install -e ".[dev]"
+
+setup-env:
 	bash .github/setup_env.sh
 
 debug:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To contribute, clone the repository instead of forking it and then request to be
 
 ```
 make install
+make setup-env
 ```
 
 ### 4. Start a server on localhost to see your changes

--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ make install
 make setup-env
 ```
 
+### 3a. Configure environment variables
+
+`make setup-env` creates a local `.env` from `.env.example`. At minimum, local development expects values for:
+
+- `POLICYENGINE_DB_PASSWORD`
+- `POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN`
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `HUGGING_FACE_TOKEN`
+
+If you need a local Google credential file for ADC, uncomment and set:
+
+- `GOOGLE_APPLICATION_CREDENTIALS`
+
+Keep that commented unless you are pointing at a real local credential file. The deployed App Engine service uses its attached service account instead.
+
+If you are running against an auth-protected simulation gateway outside the managed deploy path, you may also need:
+
+- `SIMULATION_API_URL`
+- `GATEWAY_AUTH_REQUIRED`
+- `GATEWAY_AUTH_ISSUER`
+- `GATEWAY_AUTH_AUDIENCE`
+- `GATEWAY_AUTH_CLIENT_ID`
+- one of `GATEWAY_AUTH_CLIENT_SECRET` or `GATEWAY_AUTH_CLIENT_SECRET_RESOURCE`
+
+Managed App Engine deploys currently still render some runtime config into the image bundle. Long-term, we intend to stop doing that and supply environment-specific config at runtime instead.
+
 ### 4. Start a server on localhost to see your changes
 
 Run:

--- a/changelog.d/separate-build-and-push-tests.changed.md
+++ b/changelog.d/separate-build-and-push-tests.changed.md
@@ -1,0 +1,1 @@
+Move push-time API tests out of the App Engine Docker build and run them in sequence within the staging deploy workflow before the actual deploy.

--- a/gcp/policyengine_api/Dockerfile
+++ b/gcp/policyengine_api/Dockerfile
@@ -23,7 +23,7 @@ ADD . /app
 # Make start.sh executable
 RUN chmod +x /app/start.sh
 
-RUN cd /app && make install && make test
+RUN cd /app && make install
 
 # Use full path to start.sh
 CMD ["/bin/sh", "/app/start.sh"]


### PR DESCRIPTION
Fixes #3523

## Summary
- move push-time API tests out of the App Engine Docker build and into ordered staging deploy steps
- make local `.env` setup explicit instead of a side effect of `make install`
- add a staging deploy-image build check before the real App Engine deploy

## Details
- remove `make test` from the App Engine Dockerfile build path
- run `make test` on the GitHub runner inside `deploy-staging` before deploy
- add helper scripts to prepare the App Engine bundle and verify the image builds
- stop `.env.example` from actively setting a fake `GOOGLE_APPLICATION_CREDENTIALS` path

## Validation
- `bash -n .github/scripts/prepare_app_engine_bundle.sh .github/scripts/build_app_engine_image.sh .github/scripts/deploy_app_engine_version.sh .github/setup_env.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/push.yml"); puts "ok"'