### PR TITLE
Increase live calculate integration timeout

### DIFF
--- a/changelog.d/3553.fixed.md
+++ b/changelog.d/3553.fixed.md
@@ -1,0 +1,1 @@
+Raised the live integration HTTP timeout so staging `/us/calculate` smoke tests can complete during slower responses.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ def api_base_url() -> str:
 def api_client(api_base_url: str):
     with httpx.Client(
         base_url=api_base_url,
-        timeout=30.0,
+        timeout=90.0,
         follow_redirects=True,
     ) as client:
         yield client


### PR DESCRIPTION
Fixes #3553

## Summary

- Raise the shared live integration `httpx.Client` timeout from 30 seconds to 90 seconds.
- This gives the synchronous `/us/calculate` smoke tests enough room for staging latency and cold-start behavior observed in the deploy rerun.

## Testing

- `python -m pytest tests/integration/test_live_calculate.py --collect-only -q`