### PR TITLE
Serialize date metadata values

### DIFF
--- a/changelog.d/fix-metadata-date-json.fixed.md
+++ b/changelog.d/fix-metadata-date-json.fixed.md
@@ -1,0 +1,1 @@
+Serialize date values in country metadata responses.

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -17,6 +17,7 @@ from policyengine_core.periods import instant
 import dpath
 import math
 import pandas as pd
+from datetime import date, datetime
 from pathlib import Path
 from policyengine_api.data.congressional_districts import (
     build_congressional_district_metadata,
@@ -62,6 +63,8 @@ class PolicyEngineCountry:
     def _json_safe(self, value):
         if isinstance(value, Path):
             return str(value)
+        if isinstance(value, (date, datetime)):
+            return value.isoformat()
         if isinstance(value, dict):
             return {
                 key: self._json_safe(nested_value)

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -1,9 +1,27 @@
 import pytest
 import pandas as pd
+from datetime import date, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
 from policyengine_api.country import COUNTRIES, PolicyEngineCountry
+
+
+class TestCountryJsonSafety:
+    def test__json_safe_serializes_dates(self):
+        country = PolicyEngineCountry.__new__(PolicyEngineCountry)
+
+        result = country._json_safe(
+            {
+                "release_date": date(2026, 5, 12),
+                "nested": [datetime(2026, 5, 12, 8, 30, 45)],
+            }
+        )
+
+        assert result == {
+            "release_date": "2026-05-12",
+            "nested": ["2026-05-12T08:30:45"],
+        }
 
 
 class TestUKCountryMetadata:


### PR DESCRIPTION
## Summary
- Convert date and datetime values in country metadata to ISO strings before serving metadata JSON
- Add a unit test for date serialization in PolicyEngineCountry._json_safe

## Tests
- env -u UV_FROZEN uv run ruff format --check policyengine_api/country.py tests/unit/test_country.py
- env -u UV_FROZEN uv run python -m py_compile policyengine_api/country.py tests/unit/test_country.py
- env -u UV_FROZEN uv run pytest -q tests/unit/test_country.py::TestCountryJsonSafety (blocked locally: POLICYENGINE_DB_PASSWORD is required when policyengine_api.data initializes)