### PR TITLE
Ignore deprecated medical expense input

### DIFF
--- a/changelog.d/deprecated-medical-input.fixed.md
+++ b/changelog.d/deprecated-medical-input.fixed.md
@@ -1,0 +1,1 @@
+Ignore deprecated `medical_out_of_pocket_expenses` inputs in household calculations and return a warning instead of failing.

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -5,6 +5,7 @@ from policyengine_api.constants import COUNTRY_PACKAGE_VERSIONS
 import logging
 from datetime import date
 from policyengine_api.utils.payload_validators import validate_country
+from policyengine_api.utils.deprecated_inputs import drop_deprecated_inputs
 
 
 def get_countries():
@@ -130,6 +131,8 @@ def get_household_under_policy(country_id: str, household_id: str, policy_id: st
     household["household_json"] = add_yearly_variables(
         household["household_json"], country_id
     )
+    deprecated_inputs = drop_deprecated_inputs(household["household_json"])
+    household["household_json"] = deprecated_inputs.household
 
     # Retrieve from the policy table
 
@@ -193,11 +196,15 @@ def get_household_under_policy(country_id: str, household_id: str, policy_id: st
             (json.dumps(result), country_id, household_id, policy_id),
         )
 
-    return dict(
+    response_body = dict(
         status="ok",
         message=None,
         result=result,
     )
+    warning_messages = [warning.message for warning in deprecated_inputs.warnings]
+    if warning_messages:
+        response_body["warnings"] = warning_messages
+    return response_body
 
 
 @validate_country
@@ -216,6 +223,9 @@ def get_calculate(country_id: str, add_missing: bool = False) -> dict:
         # Add in any missing yearly variables to household_json
         household_json = add_yearly_variables(household_json, country_id)
 
+    deprecated_inputs = drop_deprecated_inputs(household_json)
+    household_json = deprecated_inputs.household
+
     country = get_countries().get(country_id)
 
     try:
@@ -232,8 +242,12 @@ def get_calculate(country_id: str, add_missing: bool = False) -> dict:
             mimetype="application/json",
         )
 
-    return dict(
+    response_body = dict(
         status="ok",
         message=None,
         result=result,
     )
+    warning_messages = [warning.message for warning in deprecated_inputs.warnings]
+    if warning_messages:
+        response_body["warnings"] = warning_messages
+    return response_body

--- a/policyengine_api/utils/deprecated_inputs.py
+++ b/policyengine_api/utils/deprecated_inputs.py
@@ -1,0 +1,138 @@
+"""Drop deprecated household inputs before they reach the engine."""
+
+import copy
+from dataclasses import dataclass
+
+
+DEPRECATED_VARIABLES: dict[str, str] = {
+    "medical_out_of_pocket_expenses": (
+        "Removed in policyengine-us 1.673.0. Migrate non-premium spending "
+        "to `other_medical_expenses` and premium spending to "
+        "`health_insurance_premiums`."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class DeprecatedVariableWarning:
+    """A removed/renamed variable was supplied and ignored."""
+
+    variable: str
+    entity_plural: str
+    entity_id: str
+    hint: str
+
+    @property
+    def message(self) -> str:
+        location = f"`{self.entity_plural}/{self.entity_id}`"
+        if self.entity_plural == "axes":
+            location = f"`axes[{self.entity_id}].name`"
+        return (
+            f"Input `{self.variable}` on {location} is deprecated and was "
+            f"ignored for this calculation. {self.hint}"
+        )
+
+
+@dataclass(frozen=True)
+class DeprecatedInputsResult:
+    """A household copy with deprecated inputs removed plus warnings."""
+
+    household: dict
+    warnings: list[DeprecatedVariableWarning]
+
+
+def drop_deprecated_inputs(household: dict) -> DeprecatedInputsResult:
+    """Return a household copy with deprecated input keys stripped."""
+
+    warnings: list[DeprecatedVariableWarning] = []
+
+    if not isinstance(household, dict):
+        return DeprecatedInputsResult(household=household, warnings=warnings)
+
+    cleaned_household = copy.deepcopy(household)
+
+    for entity_plural, entity_group in cleaned_household.items():
+        if entity_plural == "axes" or not isinstance(entity_group, dict):
+            continue
+        for entity_id, variables in entity_group.items():
+            if not isinstance(variables, dict):
+                continue
+            for variable_name in list(variables.keys()):
+                hint = DEPRECATED_VARIABLES.get(variable_name)
+                if hint is None:
+                    continue
+                warnings.append(
+                    DeprecatedVariableWarning(
+                        variable=variable_name,
+                        entity_plural=entity_plural,
+                        entity_id=entity_id,
+                        hint=hint,
+                    )
+                )
+                del variables[variable_name]
+
+    _drop_deprecated_axes(cleaned_household, warnings)
+
+    return DeprecatedInputsResult(
+        household=cleaned_household,
+        warnings=warnings,
+    )
+
+
+def _drop_deprecated_axes(
+    household: dict, warnings: list[DeprecatedVariableWarning]
+) -> None:
+    axes = household.get("axes")
+    if not isinstance(axes, list):
+        return
+
+    changed = False
+    retained_entries = []
+
+    for entry_index, entry in enumerate(axes):
+        if isinstance(entry, list):
+            retained_axes = []
+            for axis_index, axis in enumerate(entry):
+                location = f"{entry_index}][{axis_index}"
+                if _is_deprecated_axis(axis, location, warnings):
+                    changed = True
+                    continue
+                retained_axes.append(axis)
+            if retained_axes:
+                retained_entries.append(retained_axes)
+            continue
+
+        location = str(entry_index)
+        if _is_deprecated_axis(entry, location, warnings):
+            changed = True
+            continue
+        retained_entries.append(entry)
+
+    if not changed:
+        return
+    if retained_entries:
+        household["axes"] = retained_entries
+    else:
+        del household["axes"]
+
+
+def _is_deprecated_axis(
+    axis, location: str, warnings: list[DeprecatedVariableWarning]
+) -> bool:
+    if not isinstance(axis, dict):
+        return False
+
+    variable_name = axis.get("name")
+    hint = DEPRECATED_VARIABLES.get(variable_name)
+    if hint is None:
+        return False
+
+    warnings.append(
+        DeprecatedVariableWarning(
+            variable=variable_name,
+            entity_plural="axes",
+            entity_id=location,
+            hint=hint,
+        )
+    )
+    return True

--- a/tests/test_deprecated_inputs.py
+++ b/tests/test_deprecated_inputs.py
@@ -1,0 +1,47 @@
+from policyengine_api.utils.deprecated_inputs import drop_deprecated_inputs
+
+
+def test_drop_deprecated_inputs_removes_medical_out_of_pocket_expenses():
+    household = {
+        "people": {
+            "you": {
+                "age": {"2025": 30},
+                "medical_out_of_pocket_expenses": {"2025": 100},
+                "employment_income": {"2025": 10_000},
+                "medicaid": {"2025": None},
+            }
+        }
+    }
+
+    result = drop_deprecated_inputs(household)
+
+    cleaned_person = result.household["people"]["you"]
+    assert "medical_out_of_pocket_expenses" not in cleaned_person
+    assert cleaned_person["medicaid"] == {"2025": None}
+    assert household["people"]["you"]["medical_out_of_pocket_expenses"] == {
+        "2025": 100
+    }
+    assert len(result.warnings) == 1
+    assert result.warnings[0].variable == "medical_out_of_pocket_expenses"
+    assert "other_medical_expenses" in result.warnings[0].message
+
+
+def test_drop_deprecated_inputs_removes_axes_for_removed_variables():
+    household = {
+        "people": {"you": {"age": {"2025": 30}, "medicaid": {"2025": None}}},
+        "axes": [
+            [
+                {"name": "medical_out_of_pocket_expenses", "min": 0, "max": 100},
+                {"name": "employment_income", "min": 0, "max": 1_000},
+            ]
+        ],
+    }
+
+    result = drop_deprecated_inputs(household)
+
+    assert result.household["axes"] == [
+        [{"name": "employment_income", "min": 0, "max": 1_000}]
+    ]
+    assert len(result.warnings) == 1
+    assert result.warnings[0].entity_plural == "axes"
+    assert "axes[0][0].name" in result.warnings[0].message

--- a/tests/test_deprecated_inputs.py
+++ b/tests/test_deprecated_inputs.py
@@ -18,9 +18,7 @@ def test_drop_deprecated_inputs_removes_medical_out_of_pocket_expenses():
     cleaned_person = result.household["people"]["you"]
     assert "medical_out_of_pocket_expenses" not in cleaned_person
     assert cleaned_person["medicaid"] == {"2025": None}
-    assert household["people"]["you"]["medical_out_of_pocket_expenses"] == {
-        "2025": 100
-    }
+    assert household["people"]["you"]["medical_out_of_pocket_expenses"] == {"2025": 100}
     assert len(result.warnings) == 1
     assert result.warnings[0].variable == "medical_out_of_pocket_expenses"
     assert "other_medical_expenses" in result.warnings[0].message


### PR DESCRIPTION
## Summary
- Add a standard API deprecated-input scrubber for `medical_out_of_pocket_expenses`.
- Strip that removed variable before household calculations reach the engine.
- Return warning strings on successful responses when deprecated inputs are ignored.

## Context
MFB falls back from `household.api.policyengine.org/us/calculate` to `api.policyengine.org/us/calculate` when household API requests time out. Household API already ignores `medical_out_of_pocket_expenses` and returns a warning, but the standard API fallback still returns a fast HTTP 500 for payloads containing the removed field.

This applies the same graceful behavior to standard API household calculations so MFB fallback requests can keep computing while they migrate to `other_medical_expenses` and `health_insurance_premiums`.

## Testing
- `uv run pytest tests/test_deprecated_inputs.py -q`
- `uv run ruff check policyengine_api/endpoints/household.py policyengine_api/utils/deprecated_inputs.py tests/test_deprecated_inputs.py`
