### PR TITLE
Remove Cloud Run deploy bootstrap commands

### DIFF
--- a/.github/scripts/build_cloud_run_image.sh
+++ b/.github/scripts/build_cloud_run_image.sh
@@ -6,24 +6,21 @@ source .github/scripts/cloud_run_env.sh
 cloud_run_set_defaults
 
 if [[ "${CLOUD_RUN_DRY_RUN:-0}" == "1" ]]; then
-  cloud_run_run gcloud services enable run.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com --project "${CLOUD_RUN_PROJECT}"
   cloud_run_run gcloud artifacts repositories describe "${CLOUD_RUN_ARTIFACT_REPOSITORY}" --project "${CLOUD_RUN_PROJECT}" --location "${CLOUD_RUN_REGION}"
-  cloud_run_run gcloud artifacts repositories create "${CLOUD_RUN_ARTIFACT_REPOSITORY}" --repository-format docker --location "${CLOUD_RUN_REGION}" --description "Docker repository for PolicyEngine API Cloud Run"
   cloud_run_run gcloud auth configure-docker "${CLOUD_RUN_REGION}-docker.pkg.dev" --quiet
   cloud_run_run docker build -f gcp/cloud_run/Dockerfile -t "${CLOUD_RUN_IMAGE_URI}" .
   cloud_run_run docker push "${CLOUD_RUN_IMAGE_URI}"
   exit 0
 fi
 
-gcloud services enable run.googleapis.com artifactregistry.googleapis.com cloudbuild.googleapis.com --project "${CLOUD_RUN_PROJECT}"
-
 if ! gcloud artifacts repositories describe "${CLOUD_RUN_ARTIFACT_REPOSITORY}" \
   --project "${CLOUD_RUN_PROJECT}" \
   --location "${CLOUD_RUN_REGION}" >/dev/null 2>&1; then
-  gcloud artifacts repositories create "${CLOUD_RUN_ARTIFACT_REPOSITORY}" \
-    --repository-format docker \
-    --location "${CLOUD_RUN_REGION}" \
-    --description "Docker repository for PolicyEngine API Cloud Run"
+  cat >&2 <<EOF
+Missing Artifact Registry repository '${CLOUD_RUN_ARTIFACT_REPOSITORY}' in ${CLOUD_RUN_PROJECT}/${CLOUD_RUN_REGION}.
+Provision the repository once before running Cloud Run deploys.
+EOF
+  exit 1
 fi
 
 gcloud auth configure-docker "${CLOUD_RUN_REGION}-docker.pkg.dev" --quiet

--- a/changelog.d/remove-cloud-run-api-bootstrap.fixed.md
+++ b/changelog.d/remove-cloud-run-api-bootstrap.fixed.md
@@ -1,0 +1,1 @@
+Removed one-time Cloud Run API enablement and Artifact Registry repository creation from the deploy image build script.


### PR DESCRIPTION
Fixes #3657

## Summary
- Remove `gcloud services enable` from the Cloud Run image build script.
- Remove Artifact Registry repository auto-creation from the deploy path.
- Fail clearly if the expected Artifact Registry repository is missing.

## Verification
- `bash -n .github/scripts/build_cloud_run_image.sh`
- `CLOUD_RUN_DRY_RUN=1 GITHUB_SHA=1234567890abcdef GITHUB_RUN_NUMBER=42 bash .github/scripts/build_cloud_run_image.sh`