### PR TITLE
Update PolicyEngine bundle to 4.18.5

### DIFF
--- a/.github/check-policyengine-bundle-supported.sh
+++ b/.github/check-policyengine-bundle-supported.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CHECK_ONLY_IF_CHANGED=0
+BASE_REF=""
+VERSION_GUARD_SCRIPT="${SIMULATION_VERSION_GUARD_SCRIPT:-.github/request-simulation-model-versions.sh}"
+
+usage() {
+    echo "Usage: $0 [--if-changed-from-base <base_ref>]"
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --if-changed-from-base)
+            CHECK_ONLY_IF_CHANGED=1
+            BASE_REF="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option $1"
+            usage
+            ;;
+    esac
+done
+
+extract_policyengine_version() {
+    sed -n 's/.*policyengine\[models\]==\([0-9.][0-9.]*\).*/\1/p' | head -n 1
+}
+
+current_version="$(extract_policyengine_version < pyproject.toml)"
+if [ -z "$current_version" ]; then
+    echo "ERROR: policyengine[models] pin not found in pyproject.toml"
+    exit 1
+fi
+
+if [ "$CHECK_ONLY_IF_CHANGED" = "1" ]; then
+    if [ -z "$BASE_REF" ]; then
+        echo "ERROR: --if-changed-from-base requires a base ref"
+        exit 1
+    fi
+
+    git fetch --no-tags --depth=1 origin "$BASE_REF"
+    base_version="$(
+        git show "origin/${BASE_REF}:pyproject.toml" \
+            | extract_policyengine_version \
+            || true
+    )"
+
+    if [ "$current_version" = "$base_version" ]; then
+        echo "PolicyEngine .py bundle pin is unchanged; skipping simulation API support check."
+        exit 0
+    fi
+fi
+
+bash "$VERSION_GUARD_SCRIPT" -py "$current_version"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,9 +6,27 @@ env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
+  ensure-policyengine-bundle-supported-by-simulation-api:
+    name: Ensure PolicyEngine bundle is supported by simulation API
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install jq
+        run: sudo apt-get install -y jq
+      - name: Check simulation API supports updated PolicyEngine bundle
+        env:
+          SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
+        run: bash .github/check-policyengine-bundle-supported.sh --if-changed-from-base "${{ github.base_ref }}"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: ensure-policyengine-bundle-supported-by-simulation-api
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -21,6 +39,7 @@ jobs:
   quality-guards:
     name: Quality guards
     runs-on: ubuntu-latest
+    needs: ensure-policyengine-bundle-supported-by-simulation-api
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -33,6 +52,7 @@ jobs:
   check-changelog:
     name: Check changelog fragment
     runs-on: ubuntu-latest
+    needs: ensure-policyengine-bundle-supported-by-simulation-api
     steps:
       - uses: actions/checkout@v4
       - name: Check for changelog fragment
@@ -40,6 +60,7 @@ jobs:
   test_container_builds:
     name: Docker
     runs-on: ubuntu-latest
+    needs: ensure-policyengine-bundle-supported-by-simulation-api
     permissions:
       contents: read
       packages: write
@@ -57,6 +78,7 @@ jobs:
   test_cloud_run_container_builds:
     name: Cloud Run container
     runs-on: ubuntu-latest
+    needs: ensure-policyengine-bundle-supported-by-simulation-api
     permissions:
       contents: read
     steps:
@@ -67,6 +89,7 @@ jobs:
   test_env_vars:
     name: Test environment variables
     runs-on: ubuntu-latest
+    needs: ensure-policyengine-bundle-supported-by-simulation-api
     permissions:
       contents: read
       id-token: write
@@ -95,7 +118,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: test_env_vars
+    needs:
+      - ensure-policyengine-bundle-supported-by-simulation-api
+      - test_env_vars
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,7 +26,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: ensure-policyengine-bundle-supported-by-simulation-api
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -39,7 +38,6 @@ jobs:
   quality-guards:
     name: Quality guards
     runs-on: ubuntu-latest
-    needs: ensure-policyengine-bundle-supported-by-simulation-api
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -52,7 +50,6 @@ jobs:
   check-changelog:
     name: Check changelog fragment
     runs-on: ubuntu-latest
-    needs: ensure-policyengine-bundle-supported-by-simulation-api
     steps:
       - uses: actions/checkout@v4
       - name: Check for changelog fragment

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,20 +37,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies (required for finding API model versions)
-        run: make install
-      - name: Install jq (required only for GitHub Actions)
+      - name: Install jq
         run: sudo apt-get install -y jq
-      - name: Find API model versions and write to environment variable
-        run: python3 .github/find-api-model-versions.py
-      - name: Ensure full API and simulation API model versions are in sync
-        run: ".github/request-simulation-model-versions.sh -py ${{ env.POLICYENGINE_VERSION }} -us ${{ env.US_VERSION }} -uk ${{ env.UK_VERSION }}"
+      - name: Check simulation API supports PolicyEngine bundle
         env:
           SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
+        run: bash .github/check-policyengine-bundle-supported.sh
 
   versioning:
     name: Update versioning
@@ -365,20 +357,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies (required for finding API model versions)
-        run: make install
-      - name: Install jq (required only for GitHub Actions)
+      - name: Install jq
         run: sudo apt-get install -y jq
-      - name: Find API model versions and write to environment variable
-        run: python3 .github/find-api-model-versions.py
-      - name: Ensure full API and simulation API model versions are in sync
-        run: ".github/request-simulation-model-versions.sh -py ${{ env.POLICYENGINE_VERSION }} -us ${{ env.US_VERSION }} -uk ${{ env.UK_VERSION }}"
+      - name: Check simulation API supports PolicyEngine bundle
         env:
           SIMULATION_API_URL: ${{ secrets.SIMULATION_API_URL }}
+        run: bash .github/check-policyengine-bundle-supported.sh
 
   deploy-production-candidate:
     name: Deploy production App Engine candidate

--- a/changelog.d/update-policyengine-bundle-4.18.5.changed.md
+++ b/changelog.d/update-policyengine-bundle-4.18.5.changed.md
@@ -1,0 +1,1 @@
+Update the PolicyEngine bundle to 4.18.5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "policyengine_canada==0.96.3",
     "policyengine-ng==0.5.1",
     "policyengine-il==0.1.0",
-    "policyengine[models]==4.18.3",
+    "policyengine[models]==4.18.5",
     "pydantic",
     "pymysql",
     "python-dotenv",

--- a/tests/unit/test_cloud_run_deploy_scripts.py
+++ b/tests/unit/test_cloud_run_deploy_scripts.py
@@ -7,7 +7,6 @@ import shlex
 import subprocess
 from pathlib import Path
 
-
 REPO = Path(__file__).resolve().parents[2]
 PRODUCTION_CLOUD_SQL_INSTANCE = "policyengine-api:us-central1:policyengine-api-data"
 DEDICATED_CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT = (
@@ -180,6 +179,57 @@ def test_simulation_version_guard_accepts_bundle_and_compatible_country_routes()
 
     assert result.returncode == 0, result.stderr
     assert "SUCCESS: PolicyEngine bundle route is deployed and ready" in result.stdout
+
+
+def test_simulation_version_guard_accepts_policyengine_bundle_route_only():
+    result = _run_simulation_version_guard(
+        {
+            "policyengine": {
+                "latest": "4.18.5",
+                "4.18.5": "policyengine-simulation-py4-18-5",
+            },
+            "us": {},
+            "uk": {},
+        },
+        "-py",
+        "4.18.5",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "PolicyEngine .py bundle 4.18.5 is deployed" in result.stdout
+    assert "SUCCESS: PolicyEngine bundle route is deployed and ready" in result.stdout
+
+
+def test_policyengine_bundle_support_check_passes_pyproject_pin_to_guard(tmp_path):
+    capture_path = tmp_path / "guard-args.txt"
+    guard_script = tmp_path / "request-simulation-model-versions.sh"
+    guard_script.write_text(
+        'printf "%s\\n" "$@" > "$CAPTURE_PATH"\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["bash", ".github/check-policyengine-bundle-supported.sh"],
+        cwd=REPO,
+        env=_script_env(
+            SIMULATION_VERSION_GUARD_SCRIPT=str(guard_script),
+            CAPTURE_PATH=str(capture_path),
+        ),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    current_version = re.search(r"policyengine\[models\]==([0-9.]+)", pyproject).group(
+        1
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert capture_path.read_text(encoding="utf-8").splitlines() == [
+        "-py",
+        current_version,
+    ]
 
 
 def test_simulation_version_guard_rejects_country_route_to_different_app():

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -3,7 +3,6 @@ import subprocess
 import sys
 
 import pytest
-
 from policyengine_api.constants import (
     COUNTRY_PACKAGE_VERSIONS,
     POLICYENGINE_CORE_VERSION,
@@ -11,10 +10,10 @@ from policyengine_api.constants import (
     REGION_PREFIXES,
     UK_REGION_TYPES,
     US_REGION_TYPES,
-    get_py_manifest,
     _load_policyengine_bundle,
     _normalize_distribution_name,
     _resolve_distribution_version,
+    get_py_manifest,
 )
 
 
@@ -126,6 +125,23 @@ class TestDistributionVersionHelpers:
 
 
 class TestPolicyEngineBundleVersions:
+    @staticmethod
+    def _expected_bundle_versions() -> dict[str, str]:
+        manifest = json.loads(get_py_manifest().read_text(encoding="utf-8"))
+        packages = manifest["packages"]
+        normalized_packages = {
+            _normalize_distribution_name(package.get("name") or package_key): package
+            for package_key, package in packages.items()
+        }
+        return {
+            "policyengine": str(
+                manifest.get("policyengine_version") or manifest.get("bundle_version")
+            ),
+            "core": str(normalized_packages["policyengine-core"]["version"]),
+            "us": str(normalized_packages["policyengine-us"]["version"]),
+            "uk": str(normalized_packages["policyengine-uk"]["version"]),
+        }
+
     def test__get_py_manifest_returns_packaged_manifest_path(self):
         manifest_path = get_py_manifest()
 
@@ -173,12 +189,7 @@ print(
         )
 
         assert result.returncode == 0, result.stderr
-        assert json.loads(result.stdout) == {
-            "policyengine": "4.18.3",
-            "core": "3.27.1",
-            "us": "1.729.0",
-            "uk": "2.89.2",
-        }
+        assert json.loads(result.stdout) == self._expected_bundle_versions()
 
     def test__load_policyengine_bundle_rejects_missing_manifest(
         self, monkeypatch, tmp_path
@@ -205,7 +216,8 @@ print(
             _load_policyengine_bundle()
 
     def test__uses_policyengine_bundle_versions_for_us_uk_and_core(self):
-        assert POLICYENGINE_VERSION == "4.18.3"
-        assert POLICYENGINE_CORE_VERSION == "3.27.1"
-        assert COUNTRY_PACKAGE_VERSIONS["us"] == "1.729.0"
-        assert COUNTRY_PACKAGE_VERSIONS["uk"] == "2.89.2"
+        expected_versions = self._expected_bundle_versions()
+        assert POLICYENGINE_VERSION == expected_versions["policyengine"]
+        assert POLICYENGINE_CORE_VERSION == expected_versions["core"]
+        assert COUNTRY_PACKAGE_VERSIONS["us"] == expected_versions["us"]
+        assert COUNTRY_PACKAGE_VERSIONS["uk"] == expected_versions["uk"]

--- a/uv.lock
+++ b/uv.lock
@@ -2588,7 +2588,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.18.3"
+version = "4.18.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -2602,9 +2602,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/13/0dd4f39d7ec5d14add10c08e4d61aad296831802edae526e1907fc023aec/policyengine-4.18.3.tar.gz", hash = "sha256:ed95cfea02770e62bc0945a9e88bcbc96c94bf1fc717162c194b33948564a089", size = 697659, upload-time = "2026-06-25T19:05:19.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/2c/5e600a757fd03e227b99009067c6e4e05c97c9d05cc1e28410f7a3fef9b5/policyengine-4.18.5.tar.gz", hash = "sha256:a4d484964856debd1ce18fcf71ac9957e8a4cf897a2bb2652953bd191695b8c7", size = 697884, upload-time = "2026-06-27T06:44:22.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/b9/b3651013363f71c90795c7fd11ae7eed2b9acb2bafeb743260b972f2d58b/policyengine-4.18.3-py3-none-any.whl", hash = "sha256:fe2adbb576c08acb874ad98b5b03b8c41c38f654cd41ad6ada14a32427774aa0", size = 211031, upload-time = "2026-06-25T19:05:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b7/d2abead0bb24e497950b2e2cbd847c544c25d97dd4ad6c641084e6f754ed/policyengine-4.18.5-py3-none-any.whl", hash = "sha256:960469cec0ad47d85e64151c3c9cf0db6b38624b2bae66cedbd993ae32ee7a55", size = 211057, upload-time = "2026-06-27T06:44:20.607Z" },
 ]
 
 [package.optional-dependencies]
@@ -2616,7 +2616,7 @@ models = [
 
 [[package]]
 name = "policyengine-api"
-version = "3.43.1"
+version = "3.43.3"
 source = { editable = "." }
 dependencies = [
     { name = "a2wsgi" },
@@ -2683,7 +2683,7 @@ requires-dist = [
     { name = "markupsafe", specifier = ">=3,<4" },
     { name = "microdf-python", specifier = ">=1.0.0" },
     { name = "openai" },
-    { name = "policyengine", extras = ["models"], specifier = "==4.18.3" },
+    { name = "policyengine", extras = ["models"], specifier = "==4.18.5" },
     { name = "policyengine-canada", specifier = "==0.96.3" },
     { name = "policyengine-il", specifier = "==0.1.0" },
     { name = "policyengine-ng", specifier = "==0.5.1" },
@@ -2734,7 +2734,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-core"
-version = "3.27.1"
+version = "3.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dpath" },
@@ -2754,9 +2754,9 @@ dependencies = [
     { name = "standard-imghdr" },
     { name = "wheel" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/28/cbc23d0c61d431cbfdbaea3f7a71b2230187ab2e57f1430a551598b39515/policyengine_core-3.27.1.tar.gz", hash = "sha256:21471e3f6e95b8d5c00babcb5a5d363fdc1cd4b02c338e5eb4c9da18e08b6a10", size = 484853, upload-time = "2026-06-11T18:18:36.753Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/bf/d870af03abe76a64249fe9e95d7561c99c0484af1d3f3ae3773caa1c57d8/policyengine_core-3.28.0.tar.gz", hash = "sha256:3ae894577d8c40cb6c6d0f7d1df8ccdce2ee46aecbe52de0604e0af7ed454ecb", size = 484615, upload-time = "2026-06-26T13:38:51.09Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/81/098994e62401e9ce0d799e3f01329ba4a8792599d17ae0ef67fff1ddd3ff/policyengine_core-3.27.1-py3-none-any.whl", hash = "sha256:dac7928b502baa56fd22956f089689faa4d7e04a21aab7f1f29b34961d684ef8", size = 238480, upload-time = "2026-06-11T18:18:35.203Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b6/efec8f49cc926cd8aa4f6767ae56d1d29e31fc42fc1efebed611cb8499c3/policyengine_core-3.28.0-py3-none-any.whl", hash = "sha256:069b83f76f636c138975ca85270500e47b81f191bc00da47090b237500eeabc0", size = 238479, upload-time = "2026-06-26T13:38:49.705Z" },
 ]
 
 [[package]]
@@ -2802,7 +2802,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.729.0"
+version = "1.745.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2812,9 +2812,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/cb/b2efba2094a708cd71890d98d72b99394fabc5894a4cceec14381e03fa35/policyengine_us-1.729.0.tar.gz", hash = "sha256:ac05c4d621c7f848b0806effc14e913160d5d47d777eadced6bc18edf392d75c", size = 10373862, upload-time = "2026-06-14T18:05:25.747Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/87/bb5e15d5e63208d6451393818f35a1824f8808e44d9a491ade601e59e20c/policyengine_us-1.745.0.tar.gz", hash = "sha256:7c93f8e7c46ef85fb50871f44bceed7da697400484fe79318db7b2d981c855c0", size = 10561674, upload-time = "2026-06-25T04:18:52.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/7d/778f92ae94997b00c3c9ac34b345f6c9333435f905670ee4eeb2f5e19809/policyengine_us-1.729.0-py3-none-any.whl", hash = "sha256:8d21d3f7c0e82a9415edffe8ea53939330a63d9c8f6bd334299bddb697cf2c00", size = 11905076, upload-time = "2026-06-14T18:05:21.806Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/ef50de1108cd0e0b89a7820ac3262bda7701d5ac6d998c27e570e63b7b82/policyengine_us-1.745.0-py3-none-any.whl", hash = "sha256:2af30b694b681adca7c2e2bd695bbeb41c03769d9ae908f82f671f8502ce32d9", size = 12300884, upload-time = "2026-06-25T04:18:49.056Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update API v1 to policyengine[models]==4.18.5 and refresh uv.lock.
- Add a lightweight PR gate that checks the simulation API supports the updated .py bundle before other PR checks run.
- Use the same lightweight .py bundle support check in push-time staging and production guards.
- Make bundle version tests compare against the installed .py manifest instead of hard-coded current package versions.

## Notes

The live simulation gateway currently advertises 4.18.3 but not 4.18.5, so this PR's new support gate is expected to fail until the updated simulation API deployment publishes the 4.18.5 route.

## Verification

- uv run pytest tests/unit/test_constants.py tests/unit/test_cloud_run_deploy_scripts.py
- uv run ruff check tests/unit/test_constants.py tests/unit/test_cloud_run_deploy_scripts.py
- uv run ruff format tests/unit/test_constants.py tests/unit/test_cloud_run_deploy_scripts.py
- bash -n .github/check-policyengine-bundle-supported.sh
- bash -n .github/request-simulation-model-versions.sh
- git diff --check