### PR TITLE
Default US metadata to Populace

### DIFF
--- a/changelog.d/populace-default-dataset.changed.md
+++ b/changelog.d/populace-default-dataset.changed.md
@@ -1,0 +1,1 @@
+Default US economy metadata to the certified Populace dataset while keeping CPS and enhanced CPS as explicit non-default legacy options.

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -199,10 +199,16 @@ class PolicyEngineCountry:
             ]
             datasets = [
                 dict(
+                    name="default",
+                    label="Populace",
+                    title="Certified Populace dataset",
+                    default=True,
+                ),
+                dict(
                     name="cps",
                     label="CPS",
                     title="Current Population Survey",
-                    default=True,
+                    default=False,
                 ),
                 dict(
                     name="enhanced_cps",

--- a/tests/unit/services/test_metadata_service.py
+++ b/tests/unit/services/test_metadata_service.py
@@ -1,6 +1,5 @@
 import pytest
 from policyengine_api.services.metadata_service import MetadataService
-from policyengine_api.country import COUNTRIES
 
 
 class TestMetadataService:
@@ -117,6 +116,30 @@ class TestMetadataService:
         # Verify datasets exist and are of correct type
         assert "datasets" in metadata["economy_options"]
         assert isinstance(metadata["economy_options"]["datasets"], list)
+
+    def test_us_default_dataset_is_certified_populace(self):
+        """US metadata should select the bundle-resolved Populace dataset by default."""
+        service = MetadataService()
+        metadata = service.get_metadata("us")
+
+        datasets = metadata["economy_options"]["datasets"]
+        default_datasets = [dataset for dataset in datasets if dataset.get("default")]
+
+        assert default_datasets == [
+            {
+                "name": "default",
+                "label": "Populace",
+                "title": "Certified Populace dataset",
+                "default": True,
+            }
+        ]
+        assert any(
+            dataset["name"] == "cps" and not dataset["default"] for dataset in datasets
+        )
+        assert any(
+            dataset["name"] == "enhanced_cps" and not dataset["default"]
+            for dataset in datasets
+        )
 
     @pytest.mark.parametrize(
         "country_id, expected_types",


### PR DESCRIPTION
## Summary\n- advertise the certified Populace bundle as the default US economy dataset in metadata\n- keep legacy CPS and enhanced CPS as explicit non-default options\n- add a regression test so app-v2 continues to omit dataset= for default Populace runs\n\nThis complements PolicyEngine/populace#228, which makes the sparse L0+refit build the default release artifact. API economy runs already omit the concrete data field for dataset=default, allowing the simulation gateway/policyengine.py bundle to resolve the certified Populace dataset and apply state/CD row filters.\n\n## Tests\n- uv run ruff format policyengine_api/country.py tests/unit/services/test_metadata_service.py\n- uv run ruff check policyengine_api/country.py tests/unit/services/test_metadata_service.py\n- uv run pytest tests/unit/services/test_metadata_service.py tests/unit/services/test_economy_service.py::TestEconomicImpactSetupOptions::TestSetupSimOptions tests/unit/libs/test_simulation_api_modal.py::TestSimulationAPIModal::TestRun::test__given_api_v1_default_bundle_payload__then_posts_gateway_contract_body