### PR TITLE
Update policyengine to 4.18.9

### DIFF
--- a/changelog.d/update-policyengine-4.18.9.changed.md
+++ b/changelog.d/update-policyengine-4.18.9.changed.md
@@ -1,0 +1,1 @@
+Update policyengine to 4.18.9, which fixes a dataset-corruption bug: constructing a region-scoped dataset copy no longer auto-saves over the shared source dataset file it was filtered from.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "policyengine_canada==0.96.3",
     "policyengine-ng==0.5.1",
     "policyengine-il==0.1.0",
-    "policyengine[models]==4.18.8",
+    "policyengine[models]==4.18.9",
     "pydantic",
     "pymysql",
     "python-dotenv",

--- a/uv.lock
+++ b/uv.lock
@@ -2461,7 +2461,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2588,7 +2588,7 @@ wheels = [
 
 [[package]]
 name = "policyengine"
-version = "4.18.8"
+version = "4.18.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -2602,9 +2602,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/50/bd4427530435a73cf1f09f8e1912115e11b8dcbc5b9c386ee16a62eec75d/policyengine-4.18.8.tar.gz", hash = "sha256:684b89d4bb88c77cebc4b3b44389ac48be8336305c4c0c8baa179ef557149a67", size = 696784, upload-time = "2026-07-01T23:11:19.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/f0/452c855cdb162e19dfdeb2f04939b763ab98e4cf07ce2caf7a4c619ba34f/policyengine-4.18.9.tar.gz", hash = "sha256:4f7a58d9e88256076b474debda02c61019011215196c7f8b8265560486aa4ec7", size = 699680, upload-time = "2026-07-02T23:34:11.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/cb/58327139aaf54ef7d8f893d1ef8671c5a6924bd4228d063baa2f0660920a/policyengine-4.18.8-py3-none-any.whl", hash = "sha256:d55e7b06ec403dc0a13f6dc604b0e0469c58206e66d2be5e23601d8cdd180d5c", size = 208899, upload-time = "2026-07-01T23:11:17.789Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/15/908db27608da1981b4b45992eb58ee616eeefd70abe5dfd62a0511edec6d/policyengine-4.18.9-py3-none-any.whl", hash = "sha256:fda8d3069151fcfe3e5bb2ac6fc2402b1d0de9600f296086c9a254406bb16f05", size = 210079, upload-time = "2026-07-02T23:34:10.119Z" },
 ]
 
 [package.optional-dependencies]
@@ -2616,7 +2616,7 @@ models = [
 
 [[package]]
 name = "policyengine-api"
-version = "3.43.6"
+version = "3.43.7"
 source = { editable = "." }
 dependencies = [
     { name = "a2wsgi" },
@@ -2683,7 +2683,7 @@ requires-dist = [
     { name = "markupsafe", specifier = ">=3,<4" },
     { name = "microdf-python", specifier = ">=1.0.0" },
     { name = "openai" },
-    { name = "policyengine", extras = ["models"], specifier = "==4.18.8" },
+    { name = "policyengine", extras = ["models"], specifier = "==4.18.9" },
     { name = "policyengine-canada", specifier = "==0.96.3" },
     { name = "policyengine-il", specifier = "==0.1.0" },
     { name = "policyengine-ng", specifier = "==0.5.1" },


### PR DESCRIPTION
Fixes #3722

## What

Raises the `policyengine[models]` pin from `4.18.8` to **`4.18.9`** and relocks `uv.lock`.

## Why

policyengine 4.18.9 ships the dataset-autosave-corruption fix ([policyengine.py #450](https://github.com/PolicyEngine/policyengine.py/pull/450), issue [#449](https://github.com/PolicyEngine/policyengine.py/issues/449)). In 4.18.8, constructing a region-scoped dataset copy auto-saved over the shared source dataset file it was filtered from, corrupting it in processes that reuse a dataset file — crashing subsequent region runs (`No households found matching state_fips=N`) or silently computing results on one region's data. 4.18.9 removes the construction-time autosave and builds scoped copies with `filepath=None`.

## Changes

- `pyproject.toml`: `policyengine[models]==4.18.8` → `4.18.9` (one line).
- `uv.lock`: relocked — `policyengine v4.18.8 -> v4.18.9`. Also syncs the project's own `3.43.6 -> 3.43.7` (already in `pyproject.toml`, stale in the committed lock); companion country packages unchanged.
- `changelog.d/update-policyengine-4.18.9.changed.md` (towncrier fragment).

## Verification

- `uv lock` resolved cleanly (193 packages).
- `make format` clean (no Python changed).
- The published 4.18.9 wheel was confirmed to contain the fix (verified in the sibling api-v2 bump, PolicyEngine/policyengine-api-v2#601, now merged and deployed).