### PR TITLE
Fit staging Cloud Run tag within the 46-char combined limit

### DIFF
--- a/.github/scripts/validate_cloud_run_deploy_env.sh
+++ b/.github/scripts/validate_cloud_run_deploy_env.sh
@@ -5,6 +5,15 @@ set -euo pipefail
 source .github/scripts/cloud_run_env.sh
 cloud_run_set_defaults
 
+# Cloud Run rejects deploys where the traffic tag and service name together
+# exceed 46 characters (they form the tag URL's DNS label). Fail fast here
+# with a clear message instead of at gcloud.
+combined_length=$(( ${#CLOUD_RUN_TAG} + ${#CLOUD_RUN_SERVICE} ))
+if (( combined_length > 46 )); then
+  echo "Cloud Run tag '${CLOUD_RUN_TAG}' (${#CLOUD_RUN_TAG}) + service '${CLOUD_RUN_SERVICE}' (${#CLOUD_RUN_SERVICE}) = ${combined_length} characters exceeds Cloud Run's 46-character combined limit." >&2
+  exit 1
+fi
+
 cloud_run_require_env \
   CLOUD_RUN_PROJECT \
   CLOUD_RUN_REGION \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -233,7 +233,8 @@ jobs:
         id: cloud_run
         run: |
           echo "image_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-          echo "revision_tag=stage3-staging-${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          # Short tag: Cloud Run caps tag + service name at 46 combined chars.
+          echo "revision_tag=stg-${GITHUB_RUN_NUMBER}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - name: Build and push Cloud Run image
         run: bash .github/scripts/build_cloud_run_image.sh
         env:

--- a/changelog.d/staging-cloud-run-tag-length.fixed.md
+++ b/changelog.d/staging-cloud-run-tag-length.fixed.md
@@ -1,0 +1,1 @@
+Shorten the staging Cloud Run revision tag to fit Cloud Run's 46-character combined tag + service name limit, and fail fast in deploy validation when the limit is exceeded.


### PR DESCRIPTION
Fixes #3729

## Summary

The first post-merge deploy after #3720 failed at **Deploy staging Cloud Run candidate** ([run 28809472052](https://github.com/PolicyEngine/policyengine-api/actions/runs/28809472052)): Cloud Run rejects deploys where traffic tag + service name exceed **46 combined characters** (they form the tag URL's DNS label). The Stage 1 rename to `policyengine-api-staging` (24 chars) leaves 22 for the tag, but `stage3-staging-<run#>-<sha7>` is ≥24 even with a one-digit run number — structurally impossible, every staging deploy fails, and the production promote gates depend on this leg, so master is undeployed until this merges.

## Changes

- `push.yml`: staging revision tag becomes `stg-<run#>-<sha7>` (16 chars today, ≤21 at nine-digit run numbers → combined ≤45). The prod tag is untouched — exit gates and traffic-isolation checks key on `stage3-prod-*`.
- `validate_cloud_run_deploy_env.sh`: fail-fast combined-length guard with an explicit message, so this class of error dies in validation rather than at gcloud. Verified against the exact failing combo (reports 51 > 46 and exits 1).

## Verification

- Guard trips on `stage3-staging-2401-7110f23` + `policyengine-api-staging` and passes on the new tag.
- `tests/unit/test_cloud_run_deploy_scripts.py`: 30/30 (including the inline-run-block length rule).
- actionlint: no new findings vs master (one pre-existing SC2046 warning, untouched line).

## After merge

This PR's own push cycle doubles as the Stage 1 exit-gate observation run (traffic isolation, staging service health, header presence, first-attempt-green Cloud Run deploys, container-start → ready duration for Stage 2).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)