### PR TITLE
Wait for prod Cloud Run candidate readiness before smoke tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -517,6 +517,8 @@ jobs:
           echo "Cloud Run candidate URL: ${url}"
         env:
           CLOUD_RUN_TAG: ${{ steps.cloud_run.outputs.revision_tag }}
+      - name: Wait for Cloud Run candidate health
+        run: bash .github/scripts/health_check.sh "${{ steps.cloud_run_url.outputs.url }}/readiness-check"
       - name: Install Cloud Run smoke test dependencies
         run: pip install pytest httpx
       - name: Run Cloud Run candidate smoke tests

--- a/changelog.d/prod-candidate-health-wait.fixed.md
+++ b/changelog.d/prod-candidate-health-wait.fixed.md
@@ -1,0 +1,1 @@
+Wait for the production Cloud Run candidate to pass its readiness check before running smoke tests, matching the staging job, so tests no longer race the app import that now happens after the port binds.


### PR DESCRIPTION
Fixes #3731

## Summary

The Stage 1 observation deploy ([run 28811205668](https://github.com/PolicyEngine/policyengine-api/actions/runs/28811205668)) failed at **Run Cloud Run candidate smoke tests** with `httpx.ReadTimeout`. Correlated revision logs show the mechanism: the gunicorn early-bind entrypoint (#3720) makes `gcloud run deploy` return the moment the port binds (18:07:13), while the app import completes ~2.7 minutes later (18:09:55, `Application startup complete`) — and the prod job fired its smoke tests in between (~18:08:50). The step order relied on the old uvicorn boot behavior where port-bound implied app-ready.

No traffic was affected: the failure precedes the promote step, and App Engine production promoted successfully in the same run. The staging job already had the correct pattern (health wait before test traffic), which is why it passed.

## Change

One step in `push.yml`'s `deploy-cloud-run-candidate` job: `Wait for Cloud Run candidate health` — `health_check.sh` polling the candidate **tag URL**'s `/readiness-check` (900s budget, 15s request timeout, 5s interval) — inserted between URL resolution and the smoke tests. The prod job is now symmetric with staging: deploy → resolve → wait until app-ready → smoke test → promote → existing post-promote service-URL health check.

## Verification

- `tests/unit/test_cloud_run_deploy_scripts.py`: 30/30, including the workflow-structure invariant that promote follows the smoke tests.
- actionlint: no new findings vs master.
- Expected timing: the wait absorbs the ~160s import (same as the staging leg's 2.8-min health wait in the last run); no change to total chain duration beyond that.

## After merge

This PR's push cycle becomes the Stage 1 exit-gate observation run — third attempt, with both post-merge discoveries (tag length, smoke-test race) fixed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)