### PR TITLE
Lower ASGI gzip compresslevel from 9 to 4

### DIFF
--- a/changelog.d/metadata-gzip-compresslevel.fixed.md
+++ b/changelog.d/metadata-gzip-compresslevel.fixed.md
@@ -1,0 +1,1 @@
+Lower the ASGI gzip compression level from 9 to 4 so large responses like /us/metadata spend seconds less CPU compressing on Cloud Run, restoring warm-latency parity with App Engine.

--- a/policyengine_api/asgi_factory.py
+++ b/policyengine_api/asgi_factory.py
@@ -53,7 +53,12 @@ def create_asgi_app(wsgi_app) -> FastAPI:
         redoc_url=None,
         openapi_url=None,
     )
-    app.add_middleware(GZipMiddleware, minimum_size=1000)
+    # compresslevel 4 instead of starlette's default 9: /us/metadata is ~70MB
+    # raw, and level-9 compression inside the request costs seconds of CPU on
+    # Cloud Run (where no nginx sidecar handles gzip, unlike App Engine flex).
+    # Measured on the real payload: level 9 = 5.5s -> 9.0MB, level 4 = 0.7s ->
+    # 9.9MB — 7.5x faster for ~10% larger output.
+    app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=4)
 
     @app.middleware("http")
     async def add_cors_for_native_routes(request, call_next):


### PR DESCRIPTION
Fixes #3734

## Summary

Stage 2 of the Cloud Run cutover failed its warm-parity gate at **3.25×** (limit 1.20×), localized entirely to `/us/metadata`: p95 13.2 s on Cloud Run vs 4.3 s on App Engine, while liveness/readiness are *faster* on Cloud Run. The ~70 MB raw metadata payload is gzipped in-request by starlette's `GZipMiddleware` at its default `compresslevel=9` on Cloud Run; App Engine flex never pays this cost because its nginx sidecar handles gzip natively at a low level.

## Change

One line in `asgi_factory.py`: explicit `compresslevel=4`.

Measured on the actual production metadata payload (70.8 MB):

| Level | Compress time | Output |
|---|---|---|
| 9 (current default) | 5.46 s | 9.0 MB |
| 6 | 1.33 s | 9.1 MB |
| **4 (this PR)** | **0.73 s** | **9.9 MB** |
| 1 | 0.40 s | 10.9 MB |

7.5× faster compression for ~10% larger output (~0.2 s extra transfer at typical bandwidth vs ~5 s of CPU saved per request).

## Verification

- `tests/unit/test_asgi_factory.py`: 15/15 pass; ruff clean.
- Empirical projection: CR metadata TTFB ≈ 9.8 s − (level-9 − level-4 compression delta on Cloud Run CPU) → expected to land near GAE's ~2–4 s.
- Definitive check after merge+deploy: re-run the Stage 2 Phase A parity capture (`capture_migration_baseline.py --repetitions 10` both platforms) — gate is CR p95 ≤ GAE p95 × 1.20.

Out of scope per maintainer: the 70 MB payload itself (metadata slimming planned separately) and the `Accept-Encoding: identity` 500 (Cloud Run ~32 MB response cap; single known consumer always sends gzip; mooted by slimming).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)