### PR TITLE
Correct the service-level min-instances runbook flag

### DIFF
--- a/changelog.d/service-min-instances-runbook.fixed.md
+++ b/changelog.d/service-min-instances-runbook.fixed.md
@@ -1,0 +1,1 @@
+Fix the service-level minimum-instances runbook command: the flag is --min; --min-instances would set the revision-level minimum the runbook itself warns against.

--- a/docs/migration/cloud-run-operations.md
+++ b/docs/migration/cloud-run-operations.md
@@ -75,14 +75,22 @@ Values measured and justified in
   instance alive per accumulated `stage3-*` tag:
 
   ```bash
+  # NOTE: the flag is --min, NOT --min-instances. --min-instances sets the
+  # REVISION-level minimum — the per-tag cost bomb this section warns about.
+  # --min requires a recent gcloud; older SDKs (e.g. 461) lack it — fall back
+  # to exporting the service YAML, adding metadata annotation
+  # run.googleapis.com/minScale: "1" (service metadata, NOT spec.template),
+  # and `gcloud run services replace` (which needs the Cloud Resource
+  # Manager API enabled on the project).
   gcloud run services update policyengine-api \
     --project policyengine-api --region us-central1 \
-    --min-instances 1
+    --min 1
   ```
 
   **When:** once, immediately after the Stage 3 PR merges — before evaluating the
   Stage 3 exit gates (the idle-readiness gate cannot pass without it) and before any
-  public traffic. **Verify** it took, and re-verify during ramp incident response:
+  public traffic. Done 2026-07-08 via the YAML-replace fallback. **Verify** it took,
+  and re-verify during ramp incident response:
 
   ```bash
   gcloud run services describe policyengine-api \


### PR DESCRIPTION
## Summary

Executing the Stage 3 post-merge runbook surfaced that its command was wrong: `gcloud run services update --min-instances 1` sets the **revision-level** minimum — the exact per-tag warm-16Gi cost bomb the surrounding section warns against. The service-level flag is `--min` (verified against current Cloud Run docs).

The runbook now documents the correct flag, the gcloud-version caveat (older SDKs lack `--min`; the YAML-replace fallback sets `run.googleapis.com/minScale` on service metadata and requires the Cloud Resource Manager API), and records that the step was executed 2026-07-08 via that fallback.

Docs + changelog only; no runtime changes. (The actual production service already carries the correct service-level annotation — verified: template minScale absent, service metadata minScale=1.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)