### PR TITLE
Serialize local sqlite initialization under a file lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gha-creds-*.json
 
 ## vscode settings
 /.vscode
+*.db.init.lock

--- a/changelog.d/local-db-init-race.fixed.md
+++ b/changelog.d/local-db-init-race.fixed.md
@@ -1,0 +1,1 @@
+Serialize local sqlite initialization under a file lock so concurrent gunicorn worker boots cannot race the seed inserts or observe a partially initialized database.

--- a/policyengine_api/data/data.py
+++ b/policyengine_api/data/data.py
@@ -1,3 +1,4 @@
+import fcntl
 import sqlite3
 from policyengine_api.constants import REPO, COUNTRY_PACKAGE_VERSIONS
 from policyengine_api.utils import hash_object
@@ -106,8 +107,20 @@ class PolicyEngineDatabase:
         if local:
             # Local development uses a sqlite database.
             self.db_url = REPO / "policyengine_api" / "data" / "policyengine.db"
-            if initialize or not Path(self.db_url).exists():
-                self.initialize()
+            # Serialize the exists-check + initialize under an exclusive file
+            # lock: with multiple gunicorn workers importing concurrently on a
+            # fresh instance, both can otherwise pass the exists() check and
+            # race initialize() (seed INSERTs collide -> worker dies at boot),
+            # or one can observe a created-but-unseeded file and skip
+            # initialization entirely.
+            lock_path = str(self.db_url) + ".init.lock"
+            with open(lock_path, "w") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                try:
+                    if initialize or not Path(self.db_url).exists():
+                        self.initialize()
+                finally:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
         else:
             self._create_pool()
             if initialize:


### PR DESCRIPTION
Fixes #3746

## Summary

Stage 5's 50/50 LB test triggered the Cloud Run service's first real scale-out, and cold instances served brief 503 bursts: with `WEB_CONCURRENCY=2`, both gunicorn workers import the app concurrently on a fresh instance, both can pass the sqlite `exists()` check, and both run `initialize()` against the same file — the loser dies at boot with `sqlite3.IntegrityError: UNIQUE constraint failed: policy.id` (revision logs, 2026-07-08 20:07). A worse silent variant also exists: a worker can observe the file *created but not yet seeded*, skip initialization, and serve with empty reference tables.

## Change

One block in `data.py`: the exists-check + `initialize()` now runs under an exclusive `fcntl` file lock — exactly one process initializes; the others block until it finishes, then see the complete database and skip. ~10 lines, local-sqlite path only; the remote (Cloud SQL) path is untouched.

## Verification

Empirical 6-way concurrent fresh-boot test (fork model, mirroring gunicorn):

| | Unfixed (3 rounds) | Fixed |
|---|---|---|
| All workers boot | ❌ every round | ✅ |
| Policy rows seen across workers | {0, 2, 5} — including the silent empty-table variant | {5} exactly |

Unit suite: 658 passed (one pre-existing local-env error in `ai_prompts` reproduces identically on unfixed master; CI arbitrates).

## Context

This is the last known blocker class before ramp stages: any scale-out under real traffic would otherwise risk 503 bursts and silently mis-initialized workers. Stage 5's zero-5xx gate re-runs after this deploys.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)