### PR TITLE
Add Cloud Armor rate limiting for api.policyengine.org

### DIFF
--- a/changelog.d/calculate-malformed-payload-400.fixed.md
+++ b/changelog.d/calculate-malformed-payload-400.fixed.md
@@ -1,0 +1,1 @@
+Return 400 instead of 500 when a calculate payload fails situation parsing.

--- a/changelog.d/lb-cloud-armor-runbook.added.md
+++ b/changelog.d/lb-cloud-armor-runbook.added.md
@@ -1,0 +1,1 @@
+Add Cloud Armor rate-limiting runbook and policy snapshots for the public API load balancer.

--- a/docs/migration/armor/20260721T142259Z-pol-api-lb.yaml
+++ b/docs/migration/armor/20260721T142259Z-pol-api-lb.yaml
@@ -1,0 +1,50 @@
+creationTimestamp: '2026-07-21T07:16:39.177-07:00'
+description: Rate limiting for api.policyengine.org (lb-api). See docs/migration/lb-cloud-armor-runbook.md
+fingerprint: b-PKxv9L5OA=
+id: '200433714284642728'
+kind: compute#securityPolicy
+labelFingerprint: 42WmSpB8rSM=
+name: pol-api-lb
+rules:
+- action: throttle
+  description: ''
+  kind: compute#securityPolicyRule
+  match:
+    expr:
+      expression: request.path.matches('^/[a-z]{2}/metadata$')
+  preview: true
+  priority: 1000
+  rateLimitOptions:
+    conformAction: allow
+    enforceOnKey: IP
+    exceedAction: deny(429)
+    rateLimitThreshold:
+      count: 30
+      intervalSec: 60
+- action: throttle
+  description: ''
+  kind: compute#securityPolicyRule
+  match:
+    expr:
+      expression: request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')
+  preview: true
+  priority: 1100
+  rateLimitOptions:
+    conformAction: allow
+    enforceOnKey: IP
+    exceedAction: deny(429)
+    rateLimitThreshold:
+      count: 75
+      intervalSec: 60
+- action: allow
+  description: default rule
+  kind: compute#securityPolicyRule
+  match:
+    config:
+      srcIpRanges:
+      - '*'
+    versionedExpr: SRC_IPS_V1
+  preview: false
+  priority: 2147483647
+selfLink: https://www.googleapis.com/compute/v1/projects/policyengine-api/global/securityPolicies/pol-api-lb
+type: CLOUD_ARMOR

--- a/docs/migration/lb-cloud-armor-runbook.md
+++ b/docs/migration/lb-cloud-armor-runbook.md
@@ -1,124 +1,137 @@
-# Cloud Armor rate-limiting runbook (lb-api)
+# Cloud Armor rate-limiting runbook
 
-Repeated-use runbook for the Cloud Armor security policy on the public API load
-balancer. Created 2026-07-21 in response to overnight bot waves (2026-07-21
-00:00–06:00Z: facebookexternalhit re-crawl wave + three scraper networks, bursts
-to 893 req/30min in the traffic trough) that churned Cloud Run scale-outs
-(1→4→1→4, 18 instance boots) — each ~3-min import boot queues early-bind-routed
-requests, producing monitor timeouts and user-facing 504s, and (the prior week)
-CPU-saturating the single App Engine instance.
+Repeated-use runbook for managing Cloud Armor security policies on a load
+balancer's backend services: creating throttle rules safely (preview first),
+deciding when to enforce them, tuning, and rolling back. The authoritative
+record of what is currently deployed is the newest exported snapshot in
+`docs/migration/armor/` — this document describes procedure, not state.
 
-## Shape
+## Current deployment (summary — see newest snapshot for truth)
 
-- **Policy:** `pol-api-lb` (Cloud Armor Standard, pay-as-you-go), project
-  `policyengine-api`.
-- **Attached to BOTH backend services** of URL map `lb-api`: `bs-app-engine` and
-  `bs-cloud-run` — one policy protects both platforms at the edge.
-- **Rules: targeted throttles only. No blanket rules, no bans.** The frontends
-  poll `/economy/...` (society-wide calcs, 1 req/s per client while pending —
-  `SocietyWideCalcStrategy.getRefetchConfig`) and `/report/{id}` (~1 req/s
-  observed); NAT'd offices sum several users onto one client IP. Any rule whose
-  match includes a polled path family will 429 legitimate sessions — treat that
-  as a design error, not a tuning problem.
+| | |
+|---|---|
+| Policy | `pol-api-lb`, attached to both backend services of the public API LB |
+| Rules | Per-IP throttles on the metadata and calculate path families; thresholds in the snapshot |
+| Mode | Created in preview 2026-07-21; enforcement pending the gates below |
 
-| Priority | Action | Match (CEL) | Per-IP limit | Rationale |
-|---|---|---|---|---|
-| 1000 | throttle → 429 | `request.path.matches('^/[a-z]{2}/metadata$')` | 30 / 60s | 10–11 MB CPU+transfer-heavy scrape target; fetched ~once per app session, never polled |
-| 1100 | throttle → 429 | `request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')` | 75 / 60s | Single-shot in app-v2 (no polling); generous headroom for NAT + retry storms (~24/min worst observed legit); catches single-IP hammering. NOTE: Cloud Armor regex rejects capture groups — use non-capturing `(?:...)` |
-| 2147483647 | allow (default) | `*` | — | |
+Origin: overnight bot waves saturated backends / churned autoscaling
+(2026-07-13 → 2026-07-21 incidents; details in the cutover execution plan).
 
-Deliberately NOT rate-limited: `/economy/`, `/report/`, `/simulation/`,
-`/household/...` (polled or retry-prone app surfaces — a 429 there breaks a live
-session) and scanner 404 paths (~150 ms each; no capacity impact). Per-IP
-throttles barely touch facebookexternalhit (Meta spreads across many IPs in
-2a03:2880::/29); the app-side malformed-payload 400 fix is the facebook-bot
-mitigation.
+## Design principles
+
+1. **Only throttle path families the frontends never poll.** Client apps poll
+   some endpoints at ~1 req/s per session (society-wide calculation status,
+   report status), and NAT'd offices aggregate many users onto one client IP.
+   A per-IP rule that matches a polled path will 429 legitimate sessions —
+   that is a design error, not a threshold-tuning problem. Before adding any
+   rule, check the frontend code and LB logs for polling behavior on the
+   matched paths.
+2. **No blanket rules, no ban actions.** Throttling (429 per excess request)
+   self-heals the moment a client slows down; bans amplify any false positive.
+3. **Preview first, always.** Every new or changed rule starts in preview
+   (matched and logged, never enforced) and graduates only through the gates
+   below.
+4. **Rate limits address volume abuse, not expensive-request abuse.** A
+   handful of heavy requests that saturate capacity sits below any threshold
+   that spares real users — that is a capacity/scaling problem, not a Cloud
+   Armor problem.
+5. Cloud Armor's CEL `.matches()` regex rejects capture groups — use
+   non-capturing `(?:...)`.
 
 ## Known caveat
 
-Cloud Armor only sees traffic that crosses the LB. The default
-`*.run.app` / `*.appspot.com` URLs bypass it. Ingress deliberately stays open
-through PR 4 (CI smoke tests need `*.run.app`); bots observed so far target
-`api.policyengine.org`, so coverage is acceptable. Revisit at PR 17 (ingress
-lockdown).
+Cloud Armor only sees traffic that crosses the load balancer. Serverless
+default URLs (`*.run.app`, `*.appspot.com`) bypass it entirely. This is
+acceptable while ingress must stay open for CI smoke tests; revisit when
+ingress is locked down to the LB.
 
-## Create (executed 2026-07-21; preview mode)
+## Procedures
 
-```sh
-gcloud compute security-policies create pol-api-lb \
-  --project=policyengine-api \
-  --description="Rate limiting for api.policyengine.org (lb-api). See docs/migration/lb-cloud-armor-runbook.md"
-
-gcloud compute security-policies rules create 1000 \
-  --project=policyengine-api --security-policy=pol-api-lb \
-  --expression="request.path.matches('^/[a-z]{2}/metadata$')" \
-  --action=throttle \
-  --rate-limit-threshold-count=30 --rate-limit-threshold-interval-sec=60 \
-  --conform-action=allow --exceed-action=deny-429 --enforce-on-key=IP \
-  --preview
-
-gcloud compute security-policies rules create 1100 \
-  --project=policyengine-api --security-policy=pol-api-lb \
-  --expression="request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')" \
-  --action=throttle \
-  --rate-limit-threshold-count=75 --rate-limit-threshold-interval-sec=60 \
-  --conform-action=allow --exceed-action=deny-429 --enforce-on-key=IP \
-  --preview
-
-gcloud compute backend-services update bs-cloud-run  --security-policy=pol-api-lb --global --project=policyengine-api
-gcloud compute backend-services update bs-app-engine --security-policy=pol-api-lb --global --project=policyengine-api
-```
-
-Post-attach verification: header-sampled curls (split unchanged, all 200),
-BetterStack green, one live-suite run. Export a snapshot after every policy
-change:
+Set once per shell:
 
 ```sh
-gcloud compute security-policies export pol-api-lb --project=policyengine-api \
-  --file-name=docs/migration/armor/$(date -u +%Y%m%dT%H%M%SZ)-pol-api-lb.yaml
+PROJECT=<project-id>
+POLICY=<policy-name>
+BACKENDS="<backend-service> [<backend-service> ...]"
 ```
 
-## Preview → enforce gates
+### Create a policy and attach it
 
-Rules start in `--preview` (matched + logged, never enforced). Enforce a rule
-only when BOTH hold:
+```sh
+gcloud compute security-policies create $POLICY --project=$PROJECT \
+  --description="<why>. See docs/migration/lb-cloud-armor-runbook.md"
 
-1. **Preview observation (≥24h, must span an overnight bot window):** LB log
-   entries carry `jsonPayload.previewSecurityPolicy` (`name`, `outcome`).
-   Group would-be THROTTLE/DENY hits by client IP network, user agent, and
-   path. Gate: **zero hits from monitor / app-referer / polling traffic; hits
-   present on known scraper networks.**
+for BS in $BACKENDS; do
+  gcloud compute backend-services update $BS \
+    --security-policy=$POLICY --global --project=$PROJECT
+done
+```
+
+Immediately after attaching: verify serving is unaffected (sampled curls
+against the public hostname, uptime monitor green, one live-suite run).
+
+### Add a per-IP throttle rule (in preview)
+
+```sh
+gcloud compute security-policies rules create <priority> \
+  --project=$PROJECT --security-policy=$POLICY \
+  --expression="request.path.matches('<RE2 without capture groups>')" \
+  --action=throttle \
+  --rate-limit-threshold-count=<n> --rate-limit-threshold-interval-sec=<secs> \
+  --conform-action=allow --exceed-action=deny-429 --enforce-on-key=IP \
+  --preview
+```
+
+### Snapshot after every policy change
+
+```sh
+gcloud compute security-policies export $POLICY --project=$PROJECT \
+  --file-name=docs/migration/armor/$(date -u +%Y%m%dT%H%M%SZ)-$POLICY.yaml
+```
+
+Commit the snapshot (mirrors the `urlmap/` convention).
+
+### Preview → enforce gates
+
+Enforce a rule only when BOTH hold:
+
+1. **Preview observation (≥24h, spanning the traffic pattern the rule
+   targets — e.g. an overnight bot window):** LB log entries carry
+   `jsonPayload.previewSecurityPolicy` (`name`, `outcome`). Group would-be
+   throttle hits by client IP network, user agent, and path. Gate: **zero
+   hits from monitors, app-referred traffic, or polling clients; hits present
+   on the abusive sources the rule targets.**
 2. **Empirical threshold check:** from ≥7 days of LB logs, compute the per-IP
-   peak 60s request rate for each matched path family, split app-referer vs
-   other. Gate: **worst legitimate rate ≤ half the rule's threshold.**
-
-Enforce per rule with:
+   peak request rate over the rule's interval for the matched path family,
+   split legitimate vs other. Gate: **worst legitimate rate ≤ half the
+   threshold.**
 
 ```sh
-gcloud compute security-policies rules update 1000 \
-  --project=policyengine-api --security-policy=pol-api-lb --no-preview
+gcloud compute security-policies rules update <priority> \
+  --project=$PROJECT --security-policy=$POLICY --no-preview
 ```
 
-Then export + commit a new snapshot, and verify on the next bot wave: 429s in
-LB logs (`jsonPayload.enforcedSecurityPolicy.outcome="DENY"`), Cloud Run
-`instance_count` stays low overnight, no BetterStack incidents.
+Snapshot and commit; verify on the next abuse wave: 429s appear in LB logs
+(`jsonPayload.enforcedSecurityPolicy.outcome="DENY"`), autoscaler churn and
+monitor incidents stop.
 
-If a legitimate source appears in preview hits: raise that rule's threshold
-(`rules update <prio> --rate-limit-threshold-count=<n>`), keep preview, restart
-the observation window.
+If a legitimate source shows up in preview hits: raise the threshold
+(`rules update <priority> --rate-limit-threshold-count=<n>`), stay in
+preview, restart the observation window.
 
-## Tuning / rollback
+### Tuning / rollback
 
-- Loosen/tighten a rule: `rules update <priority> --rate-limit-threshold-count=<n>`
+- Change a threshold: `rules update <priority> --rate-limit-threshold-count=<n>`
   (snapshot after).
 - Disable enforcement fast: `rules update <priority> --preview` (back to
   log-only; propagates in minutes).
-- Full detach (the rollback): `gcloud compute backend-services update
-  bs-cloud-run --security-policy="" --global --project=policyengine-api` (and
-  same for `bs-app-engine`). The policy remains, unattached.
+- Full detach: `gcloud compute backend-services update <backend-service>
+  --security-policy="" --global --project=$PROJECT` per backend service. The
+  policy remains, unattached.
 
 ## Cost
 
-Standard tier: $5/policy/mo + $1/rule/mo + $0.75/M requests (global policies).
-At ~0.3–0.45M req/mo ≈ **$7.30/mo** for 1 policy + 2 rules. Verified against the
-Billing Catalog API 2026-07-21.
+Standard tier, pay-as-you-go: $5/policy/mo + $1/rule/mo + $0.75/M requests
+evaluated (global policies; verified against the Billing Catalog API
+2026-07-21). Order-of-magnitude ~$10/mo for one policy with a few rules at
+sub-million monthly request volume.

--- a/docs/migration/lb-cloud-armor-runbook.md
+++ b/docs/migration/lb-cloud-armor-runbook.md
@@ -1,0 +1,124 @@
+# Cloud Armor rate-limiting runbook (lb-api)
+
+Repeated-use runbook for the Cloud Armor security policy on the public API load
+balancer. Created 2026-07-21 in response to overnight bot waves (2026-07-21
+00:00–06:00Z: facebookexternalhit re-crawl wave + three scraper networks, bursts
+to 893 req/30min in the traffic trough) that churned Cloud Run scale-outs
+(1→4→1→4, 18 instance boots) — each ~3-min import boot queues early-bind-routed
+requests, producing monitor timeouts and user-facing 504s, and (the prior week)
+CPU-saturating the single App Engine instance.
+
+## Shape
+
+- **Policy:** `pol-api-lb` (Cloud Armor Standard, pay-as-you-go), project
+  `policyengine-api`.
+- **Attached to BOTH backend services** of URL map `lb-api`: `bs-app-engine` and
+  `bs-cloud-run` — one policy protects both platforms at the edge.
+- **Rules: targeted throttles only. No blanket rules, no bans.** The frontends
+  poll `/economy/...` (society-wide calcs, 1 req/s per client while pending —
+  `SocietyWideCalcStrategy.getRefetchConfig`) and `/report/{id}` (~1 req/s
+  observed); NAT'd offices sum several users onto one client IP. Any rule whose
+  match includes a polled path family will 429 legitimate sessions — treat that
+  as a design error, not a tuning problem.
+
+| Priority | Action | Match (CEL) | Per-IP limit | Rationale |
+|---|---|---|---|---|
+| 1000 | throttle → 429 | `request.path.matches('^/[a-z]{2}/metadata$')` | 30 / 60s | 10–11 MB CPU+transfer-heavy scrape target; fetched ~once per app session, never polled |
+| 1100 | throttle → 429 | `request.path.matches('^/[a-z]{2}/calculate(-full)?$')` | 75 / 60s | Single-shot in app-v2 (no polling); generous headroom for NAT + retry storms (~24/min worst observed legit); catches single-IP hammering |
+| 2147483647 | allow (default) | `*` | — | |
+
+Deliberately NOT rate-limited: `/economy/`, `/report/`, `/simulation/`,
+`/household/...` (polled or retry-prone app surfaces — a 429 there breaks a live
+session) and scanner 404 paths (~150 ms each; no capacity impact). Per-IP
+throttles barely touch facebookexternalhit (Meta spreads across many IPs in
+2a03:2880::/29); the app-side malformed-payload 400 fix is the facebook-bot
+mitigation.
+
+## Known caveat
+
+Cloud Armor only sees traffic that crosses the LB. The default
+`*.run.app` / `*.appspot.com` URLs bypass it. Ingress deliberately stays open
+through PR 4 (CI smoke tests need `*.run.app`); bots observed so far target
+`api.policyengine.org`, so coverage is acceptable. Revisit at PR 17 (ingress
+lockdown).
+
+## Create (executed 2026-07-21; preview mode)
+
+```sh
+gcloud compute security-policies create pol-api-lb \
+  --project=policyengine-api \
+  --description="Rate limiting for api.policyengine.org (lb-api). See docs/migration/lb-cloud-armor-runbook.md"
+
+gcloud compute security-policies rules create 1000 \
+  --project=policyengine-api --security-policy=pol-api-lb \
+  --expression="request.path.matches('^/[a-z]{2}/metadata$')" \
+  --action=throttle \
+  --rate-limit-threshold-count=30 --rate-limit-threshold-interval-sec=60 \
+  --conform-action=allow --exceed-action=deny-429 --enforce-on-key=IP \
+  --preview
+
+gcloud compute security-policies rules create 1100 \
+  --project=policyengine-api --security-policy=pol-api-lb \
+  --expression="request.path.matches('^/[a-z]{2}/calculate(-full)?$')" \
+  --action=throttle \
+  --rate-limit-threshold-count=75 --rate-limit-threshold-interval-sec=60 \
+  --conform-action=allow --exceed-action=deny-429 --enforce-on-key=IP \
+  --preview
+
+gcloud compute backend-services update bs-cloud-run  --security-policy=pol-api-lb --global --project=policyengine-api
+gcloud compute backend-services update bs-app-engine --security-policy=pol-api-lb --global --project=policyengine-api
+```
+
+Post-attach verification: header-sampled curls (split unchanged, all 200),
+BetterStack green, one live-suite run. Export a snapshot after every policy
+change:
+
+```sh
+gcloud compute security-policies export pol-api-lb --project=policyengine-api \
+  --file-name=docs/migration/armor/$(date -u +%Y%m%dT%H%M%SZ)-pol-api-lb.yaml
+```
+
+## Preview → enforce gates
+
+Rules start in `--preview` (matched + logged, never enforced). Enforce a rule
+only when BOTH hold:
+
+1. **Preview observation (≥24h, must span an overnight bot window):** LB log
+   entries carry `jsonPayload.previewSecurityPolicy` (`name`, `outcome`).
+   Group would-be THROTTLE/DENY hits by client IP network, user agent, and
+   path. Gate: **zero hits from monitor / app-referer / polling traffic; hits
+   present on known scraper networks.**
+2. **Empirical threshold check:** from ≥7 days of LB logs, compute the per-IP
+   peak 60s request rate for each matched path family, split app-referer vs
+   other. Gate: **worst legitimate rate ≤ half the rule's threshold.**
+
+Enforce per rule with:
+
+```sh
+gcloud compute security-policies rules update 1000 \
+  --project=policyengine-api --security-policy=pol-api-lb --no-preview
+```
+
+Then export + commit a new snapshot, and verify on the next bot wave: 429s in
+LB logs (`jsonPayload.enforcedSecurityPolicy.outcome="DENY"`), Cloud Run
+`instance_count` stays low overnight, no BetterStack incidents.
+
+If a legitimate source appears in preview hits: raise that rule's threshold
+(`rules update <prio> --rate-limit-threshold-count=<n>`), keep preview, restart
+the observation window.
+
+## Tuning / rollback
+
+- Loosen/tighten a rule: `rules update <priority> --rate-limit-threshold-count=<n>`
+  (snapshot after).
+- Disable enforcement fast: `rules update <priority> --preview` (back to
+  log-only; propagates in minutes).
+- Full detach (the rollback): `gcloud compute backend-services update
+  bs-cloud-run --security-policy="" --global --project=policyengine-api` (and
+  same for `bs-app-engine`). The policy remains, unattached.
+
+## Cost
+
+Standard tier: $5/policy/mo + $1/rule/mo + $0.75/M requests (global policies).
+At ~0.3–0.45M req/mo ≈ **$7.30/mo** for 1 policy + 2 rules. Verified against the
+Billing Catalog API 2026-07-21.

--- a/docs/migration/lb-cloud-armor-runbook.md
+++ b/docs/migration/lb-cloud-armor-runbook.md
@@ -59,7 +59,7 @@ gcloud compute security-policies rules create 1000 \
 
 gcloud compute security-policies rules create 1100 \
   --project=policyengine-api --security-policy=pol-api-lb \
-  --expression="request.path.matches('^/[a-z]{2}/calculate(-full)?$')" \
+  --expression="request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')" \
   --action=throttle \
   --rate-limit-threshold-count=75 --rate-limit-threshold-interval-sec=60 \
   --conform-action=allow --exceed-action=deny-429 --enforce-on-key=IP \

--- a/docs/migration/lb-cloud-armor-runbook.md
+++ b/docs/migration/lb-cloud-armor-runbook.md
@@ -24,7 +24,7 @@ CPU-saturating the single App Engine instance.
 | Priority | Action | Match (CEL) | Per-IP limit | Rationale |
 |---|---|---|---|---|
 | 1000 | throttle → 429 | `request.path.matches('^/[a-z]{2}/metadata$')` | 30 / 60s | 10–11 MB CPU+transfer-heavy scrape target; fetched ~once per app session, never polled |
-| 1100 | throttle → 429 | `request.path.matches('^/[a-z]{2}/calculate(-full)?$')` | 75 / 60s | Single-shot in app-v2 (no polling); generous headroom for NAT + retry storms (~24/min worst observed legit); catches single-IP hammering |
+| 1100 | throttle → 429 | `request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')` | 75 / 60s | Single-shot in app-v2 (no polling); generous headroom for NAT + retry storms (~24/min worst observed legit); catches single-IP hammering. NOTE: Cloud Armor regex rejects capture groups — use non-capturing `(?:...)` |
 | 2147483647 | allow (default) | `*` | — | |
 
 Deliberately NOT rate-limited: `/economy/`, `/report/`, `/simulation/`,

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -46,11 +46,7 @@ def add_yearly_variables(household, country_id, countries=None):
                         if variables[variable]["isInputVariable"]:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
-                            ] = {
-                                household_year: variables[variable][
-                                    "defaultValue"
-                                ]
-                            }
+                            ] = {household_year: variables[variable]["defaultValue"]}
                         else:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
@@ -102,9 +98,7 @@ def get_household_year(household):
 
 
 @validate_country
-def get_household_under_policy(
-    country_id: str, household_id: str, policy_id: str
-):
+def get_household_under_policy(country_id: str, household_id: str, policy_id: str):
     """Get a household's output data under a given policy.
 
     Args:

--- a/policyengine_api/endpoints/household.py
+++ b/policyengine_api/endpoints/household.py
@@ -10,6 +10,7 @@ from policyengine_api.utils.input_validation import (
     format_unrecognized_inputs_message,
 )
 from policyengine_api.utils.payload_validators import validate_country
+from policyengine_core.errors import SituationParsingError
 
 
 def get_countries():
@@ -45,7 +46,11 @@ def add_yearly_variables(household, country_id, countries=None):
                         if variables[variable]["isInputVariable"]:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
-                            ] = {household_year: variables[variable]["defaultValue"]}
+                            ] = {
+                                household_year: variables[variable][
+                                    "defaultValue"
+                                ]
+                            }
                         else:
                             household[entity_plural][entity][
                                 variables[variable]["name"]
@@ -97,7 +102,9 @@ def get_household_year(household):
 
 
 @validate_country
-def get_household_under_policy(country_id: str, household_id: str, policy_id: str):
+def get_household_under_policy(
+    country_id: str, household_id: str, policy_id: str
+):
     """Get a household's output data under a given policy.
 
     Args:
@@ -274,6 +281,19 @@ def get_calculate(country_id: str, add_missing: bool = False) -> dict:
 
     try:
         result = country.calculate(household_json, policy_json)
+    except SituationParsingError as e:
+        # Malformed household payloads (e.g. a dict where a number belongs)
+        # are client errors, not server errors — mostly bot traffic.
+        response_body = dict(
+            status="error",
+            message=f"Invalid household payload: {e}",
+            result=None,
+        )
+        return Response(
+            json.dumps(response_body),
+            status=400,
+            mimetype="application/json",
+        )
     except Exception as e:
         logging.exception(e)
         response_body = dict(

--- a/tests/unit/endpoints/test_calculate_error_statuses.py
+++ b/tests/unit/endpoints/test_calculate_error_statuses.py
@@ -1,0 +1,99 @@
+from flask import Flask
+import pytest
+from policyengine_core.errors import SituationParsingError
+
+from policyengine_api.endpoints import household as household_endpoint
+
+from .test_calculate_deprecated_inputs import DummyCountry
+
+HOUSEHOLD = {
+    "people": {
+        "you": {
+            "age": {"2026": 40},
+            "employment_income": {"2026": 30_000},
+        }
+    }
+}
+
+
+class ParsingErrorCountry(DummyCountry):
+    def calculate(self, household, policy):
+        raise SituationParsingError(
+            ["people", "you", "employment_income", "2026"],
+            "Can't deal with value: expected type number, received '{}'.",
+        )
+
+
+class CrashingCountry(DummyCountry):
+    def calculate(self, household, policy):
+        raise RuntimeError("engine exploded")
+
+
+def make_client(monkeypatch, country, add_missing=False):
+    monkeypatch.setattr(
+        household_endpoint,
+        "get_countries",
+        lambda: {"us": country},
+    )
+    app = Flask(__name__)
+    if add_missing:
+        monkeypatch.setattr(
+            household_endpoint,
+            "add_yearly_variables",
+            lambda household, country_id: household,
+        )
+
+        def handler(country_id):
+            return household_endpoint.get_calculate(
+                country_id, add_missing=True
+            )
+
+        app.add_url_rule(
+            "/<country_id>/calculate-full",
+            "calculate_full",
+            handler,
+            methods=["POST"],
+        )
+    else:
+        app.add_url_rule(
+            "/<country_id>/calculate",
+            "calculate",
+            household_endpoint.get_calculate,
+            methods=["POST"],
+        )
+    return app.test_client()
+
+
+def test__calculate__returns_400_on_situation_parsing_error(monkeypatch):
+    client = make_client(monkeypatch, ParsingErrorCountry())
+
+    response = client.post("/us/calculate", json={"household": HOUSEHOLD})
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["result"] is None
+    assert payload["message"].startswith("Invalid household payload")
+
+
+def test__calculate_full__returns_400_on_situation_parsing_error(monkeypatch):
+    client = make_client(monkeypatch, ParsingErrorCountry(), add_missing=True)
+
+    response = client.post("/us/calculate-full", json={"household": HOUSEHOLD})
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert payload["result"] is None
+    assert payload["message"].startswith("Invalid household payload")
+
+
+def test__calculate__returns_500_on_unexpected_error(monkeypatch):
+    client = make_client(monkeypatch, CrashingCountry())
+
+    response = client.post("/us/calculate", json={"household": HOUSEHOLD})
+
+    assert response.status_code == 500
+    payload = response.get_json()
+    assert payload["status"] == "error"
+    assert "engine exploded" in payload["message"]

--- a/tests/unit/endpoints/test_calculate_error_statuses.py
+++ b/tests/unit/endpoints/test_calculate_error_statuses.py
@@ -44,9 +44,7 @@ def make_client(monkeypatch, country, add_missing=False):
         )
 
         def handler(country_id):
-            return household_endpoint.get_calculate(
-                country_id, add_missing=True
-            )
+            return household_endpoint.get_calculate(country_id, add_missing=True)
 
         app.add_url_rule(
             "/<country_id>/calculate-full",


### PR DESCRIPTION
Fixes #3759
Fixes #3760

## Summary
- New repeated-use runbook `docs/migration/lb-cloud-armor-runbook.md`: Cloud Armor Standard policy `pol-api-lb` attached to both LB backend services (`bs-app-engine`, `bs-cloud-run`)
- Two targeted per-IP throttle rules — `/{cc}/metadata` at 30/60s, `/{cc}/calculate(-full)` at 75/60s — created in preview mode; enforcement gated on ≥24h preview observation + 7-day empirical per-IP rate analysis
- Deliberately no blanket/ban rules: app-v2 polls `/economy/` and `/report/` at ~1 req/s per client, and NAT'd offices aggregate users onto single IPs
- Policy snapshots will be committed under `docs/migration/armor/` as they change (mirrors the `urlmap/` convention)

## Also included: calculate malformed-payload 400 fix (#3760)
`get_calculate` (serving `/calculate` and `/calculate-full`) now catches `SituationParsingError` before the generic catch-all and returns **400** with the standard error shape; unexpected exceptions still 500. These payloads are overwhelmingly bot traffic (facebookexternalhit, 300–700/day) and were the dominant noise source in 5xx monitoring. Tests: 400 on both routes + control that real errors still 500. Folded in from #3757 — this PR's merge carries it through the deploy chain.

## Context
Overnight 2026-07-21 bot waves (facebookexternalhit re-crawl + three scraper networks) churned Cloud Run scale-outs all night; each ~3-min import boot queued requests into monitor timeouts and 504s. This rate-limits the abuse surface at the edge for both backends. Cost ≈ $7.30/mo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

