### PR TITLE
Enforce Cloud Armor metadata rate-limit rule

### DIFF
--- a/changelog.d/armor-enforce-metadata.changed.md
+++ b/changelog.d/armor-enforce-metadata.changed.md
@@ -1,0 +1,1 @@
+Enforce the Cloud Armor metadata rate-limit rule; keep the calculate rule in preview.

--- a/docs/migration/armor/20260721T214911Z-pol-api-lb-metadata-enforced.yaml
+++ b/docs/migration/armor/20260721T214911Z-pol-api-lb-metadata-enforced.yaml
@@ -1,0 +1,50 @@
+creationTimestamp: '2026-07-21T07:16:39.177-07:00'
+description: Rate limiting for api.policyengine.org (lb-api). See docs/migration/lb-cloud-armor-runbook.md
+fingerprint: dT_5QmeI6h8=
+id: '200433714284642728'
+kind: compute#securityPolicy
+labelFingerprint: 42WmSpB8rSM=
+name: pol-api-lb
+rules:
+- action: throttle
+  description: ''
+  kind: compute#securityPolicyRule
+  match:
+    expr:
+      expression: request.path.matches('^/[a-z]{2}/metadata$')
+  preview: false
+  priority: 1000
+  rateLimitOptions:
+    conformAction: allow
+    enforceOnKey: IP
+    exceedAction: deny(429)
+    rateLimitThreshold:
+      count: 30
+      intervalSec: 60
+- action: throttle
+  description: ''
+  kind: compute#securityPolicyRule
+  match:
+    expr:
+      expression: request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')
+  preview: true
+  priority: 1100
+  rateLimitOptions:
+    conformAction: allow
+    enforceOnKey: IP
+    exceedAction: deny(429)
+    rateLimitThreshold:
+      count: 75
+      intervalSec: 60
+- action: allow
+  description: default rule
+  kind: compute#securityPolicyRule
+  match:
+    config:
+      srcIpRanges:
+      - '*'
+    versionedExpr: SRC_IPS_V1
+  preview: false
+  priority: 2147483647
+selfLink: https://www.googleapis.com/compute/v1/projects/policyengine-api/global/securityPolicies/pol-api-lb
+type: CLOUD_ARMOR

--- a/docs/migration/armor/20260830T141827Z-pol-api-lb-metadata-enforced.yaml
+++ b/docs/migration/armor/20260830T141827Z-pol-api-lb-metadata-enforced.yaml
@@ -1,0 +1,50 @@
+creationTimestamp: '2026-07-21T07:16:39.177-07:00'
+description: Rate limiting for api.policyengine.org (lb-api). See docs/migration/lb-cloud-armor-runbook.md
+fingerprint: dT_5QmeI6h8=
+id: '200433714284642728'
+kind: compute#securityPolicy
+labelFingerprint: 42WmSpB8rSM=
+name: pol-api-lb
+rules:
+- action: throttle
+  description: ''
+  kind: compute#securityPolicyRule
+  match:
+    expr:
+      expression: request.path.matches('^/[a-z]{2}/metadata$')
+  preview: false
+  priority: 1000
+  rateLimitOptions:
+    conformAction: allow
+    enforceOnKey: IP
+    exceedAction: deny(429)
+    rateLimitThreshold:
+      count: 30
+      intervalSec: 60
+- action: throttle
+  description: ''
+  kind: compute#securityPolicyRule
+  match:
+    expr:
+      expression: request.path.matches('^/[a-z]{2}/calculate(?:-full)?$')
+  preview: true
+  priority: 1100
+  rateLimitOptions:
+    conformAction: allow
+    enforceOnKey: IP
+    exceedAction: deny(429)
+    rateLimitThreshold:
+      count: 75
+      intervalSec: 60
+- action: allow
+  description: default rule
+  kind: compute#securityPolicyRule
+  match:
+    config:
+      srcIpRanges:
+      - '*'
+    versionedExpr: SRC_IPS_V1
+  preview: false
+  priority: 2147483647
+selfLink: https://www.googleapis.com/compute/v1/projects/policyengine-api/global/securityPolicies/pol-api-lb
+type: CLOUD_ARMOR

--- a/docs/migration/lb-cloud-armor-runbook.md
+++ b/docs/migration/lb-cloud-armor-runbook.md
@@ -12,7 +12,13 @@ record of what is currently deployed is the newest exported snapshot in
 |---|---|
 | Policy | `pol-api-lb`, attached to both backend services of the public API LB |
 | Rules | Per-IP throttles on the metadata and calculate path families; thresholds in the snapshot |
-| Mode | Created in preview 2026-07-21; enforcement pending the gates below |
+| Mode | metadata rule **ENFORCED** 2026-07-21 (worst legit observed 5/min vs 30 threshold — 6× headroom); calculate rule **stays in preview at 75/60s** — observed legit/partner clients run 39–88/min there, so enforcing would 429 real use (incl. the partner API fallback) |
+
+Note on the preview gate: Cloud Armor **throttle** rules in preview only ever
+log `CONFORM` (never `EXCEEDED`), so the `previewSecurityPolicy` outcome field
+cannot be used to count would-be-throttled requests. Judge a throttle rule's
+enforcement readiness from **raw per-IP request-rate analysis of LB logs**, not
+from preview outcome counts.
 
 Origin: overnight bot waves saturated backends / churned autoscaling
 (2026-07-13 → 2026-07-21 incidents; details in the cutover execution plan).


### PR DESCRIPTION
## Summary
- Enforces the `/{cc}/metadata` per-IP throttle (30/60s) on `pol-api-lb` — removes preview. Worst legitimate per-IP rate in the preview window was 5/min (6× headroom); the rule's target is overnight scraper waves.
- Keeps the `/{cc}/calculate(-full)` throttle (75/60s) **in preview**: observed legitimate/partner clients run 39–88/min on that path, so enforcing would 429 real use — including a partner's documented "fall back to the internal API when household API latency > 30s" behavior.
- Adds the enforced-policy snapshot under `docs/migration/armor/` and documents that Cloud Armor throttle rules only log `CONFORM` in preview (so enforcement readiness is judged from raw LB-log rate analysis, not preview outcome counts).
- Re-exports the live `pol-api-lb` policy on 2026-08-30. The refreshed snapshot is byte-for-byte identical to the 2026-07-21 enforced-policy snapshot, confirming that the deployed configuration has not drifted.

Verified: normal (gzip) metadata fetches return 200 post-enforcement; rule state confirmed via `security-policies describe` (1000 preview=false, 1100 preview=true); current deployed policy re-exported and compared with the prior snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
