### PR TITLE
Snapshot LB URL map: Stage 11 cutover to 100% Cloud Run

### DIFF
--- a/changelog.d/urlmap-cloud-run-100-cutover.changed.md
+++ b/changelog.d/urlmap-cloud-run-100-cutover.changed.md
@@ -1,0 +1,1 @@
+Record the Stage 11 cutover of api.policyengine.org to 100% Cloud Run (load-balancer url-map weights bs-cloud-run=100 / bs-app-engine=0) as a committed snapshot under docs/migration/urlmap/.

--- a/docs/migration/urlmap/20260723T235025Z-cloud-run-100.yaml
+++ b/docs/migration/urlmap/20260723T235025Z-cloud-run-100.yaml
@@ -1,0 +1,8 @@
+defaultRouteAction:
+  weightedBackendServices:
+  - backendService: https://www.googleapis.com/compute/v1/projects/policyengine-api/global/backendServices/bs-app-engine
+    weight: 0
+  - backendService: https://www.googleapis.com/compute/v1/projects/policyengine-api/global/backendServices/bs-cloud-run
+    weight: 100
+fingerprint: 8_M-sPEYJUQ=
+name: lb-api


### PR DESCRIPTION
Records the load-balancer url-map weight change that flipped `api.policyengine.org` to **100% Cloud Run** (`bs-cloud-run=100 / bs-app-engine=0`), imported 2026-07-23 ~23:33Z — the Stage 11 milestone of the PR 4 host cutover.

## Verified after the flip
- Readback: weights `bs-app-engine=0 / bs-cloud-run=100`
- Live distribution: 24/24 sampled requests served by `cloud_run` (`x-policyengine-backend`)
- Health: zero 502/503/504; the only 5xx are the pre-existing `jsdom` bot malformed `/us/calculate-full` 500s (below the pre-flip baseline rate)
- Serving revision `00079-poq` (warmup + max 8 / service-min 2 / concurrency 6 / 480s startup probe)

## Rollback
App Engine stays deployed and warm as the rollback target through the soak — reverse the url-map weights to roll back in seconds.

⚠️ **Note on merge:** this PR carries a changelog fragment (required by `check-changelog`), so **merging it triggers a release + full deploy**. The code is unchanged, so it produces a functionally identical prod Cloud Run revision — low risk, but it is a deploy during the soak window. Merge whenever suits the soak (there's no rush; the snapshot is purely an audit-trail artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)