### PR TITLE
Cut API v1 simulations over to the Cloud Run entrypoint

### DIFF
--- a/changelog.d/stage5-simulation-entrypoint-cutover.changed.md
+++ b/changelog.d/stage5-simulation-entrypoint-cutover.changed.md
@@ -1,0 +1,1 @@
+Route API v1 simulation requests through the qualified Cloud Run Simulation Entrypoint while retaining direct Modal routing as the deployment rollback path.

--- a/docs/migration/history/stage5-simulation-entrypoint-cutover.md
+++ b/docs/migration/history/stage5-simulation-entrypoint-cutover.md
@@ -1,0 +1,62 @@
+# Stage 5 Simulation Entrypoint Cutover Record
+
+This is the auditable release record for moving API v1's outbound simulation
+requests to the separate Cloud Run Simulation Entrypoint. The merge commit for
+this record intentionally triggers the normal API v1 staging-to-production
+release after the environment selector is changed.
+
+## Scope
+
+The cutover changes only the network path used by API v1 for simulation
+submissions and polling:
+
+```text
+API v1 -> canonical Simulation Entrypoint -> Modal gateway -> Modal executor
+```
+
+It does not change API v1's public routes or response contracts, move
+simulation compute or durable job state out of Modal, or migrate SQL-backed
+application data. Direct Modal routing remains configured for rollback.
+
+## Qualification completed before cutover
+
+- The canonical entrypoint passed health, readiness, version, authentication,
+  comparison, and one-year budget-window checks.
+- Comparison and budget-window IDs were unchanged and pollable through both
+  the canonical entrypoint and direct Modal, with identical completed payloads.
+- `X-PolicyEngine-Request-ID` correlated requests from the canonical edge
+  through the Cloud Run entry service, the Modal gateway, and the executor.
+- Cloud Run used its own client-credentials identity for Modal rather than
+  forwarding the API caller's bearer token.
+- Three alternating paired runs per path put every canonical median latency
+  and completion metric within the 20% migration gate; the largest measured
+  canonical median increase was 9.4%.
+- The standard Simulation API workflow completed its full staging integration
+  suite before deploying, promoting, and verifying production and the
+  canonical hostname.
+
+## Release behavior
+
+Immediately before this PR is merged, both API v1 GitHub environments must set
+`SIM_ENTRYPOINT=cloud_run_simulation_entrypoint`. The qualified canonical URL
+must remain present as the environment-scoped `SIMULATION_ENTRYPOINT_URL`
+secret, and the direct Modal URL must remain available under
+`OLD_SIMULATION_GATEWAY_URL`.
+
+The normal API v1 workflow then owns the entire release:
+
+1. Deploy staging with the Cloud Run selector.
+2. Run the complete staging calculation, economy, and budget-window suite.
+3. Block production on any staging failure.
+4. Automatically deploy and verify production with the same selector.
+5. Assign stable API v1 traffic to the exact tested production revision.
+
+Production does not repeat the calculation suite already completed in the
+production-equivalent staging environment.
+
+## Rollback
+
+For a later regression, restore both environment selectors to
+`old_gateway_direct` and run the normal release workflow. Staging must again
+pass before production returns to direct Modal. Do not change DNS or manually
+adjust Cloud Run traffic percentages for this rollback.


### PR DESCRIPTION
Fixes #3783

## Summary

- add the changelog fragment for the Stage 5 simulation-path cutover;
- add an auditable historical record of the qualified path, release gates, and Git-based rollback; and
- use this intentionally non-functional merge commit to trigger the normal API v1 staging-to-production workflow after the external environment selectors are verified.

## Why

PR #3776 introduced the selectable Cloud Run Simulation Entrypoint while keeping API v1 on direct Modal. The canonical Cloud Run path has now passed health, readiness, authentication, comparison, one-year budget-window, unchanged-ID cross-polling, request-ID/log correlation, backend-identity, and paired runtime qualification. Stage 5 now needs a small, independently reviewed commit to trigger the actual release without coupling the cutover to another client refactor.

## Impact

This PR does not change application code or the public API contract. Immediately before merge, both existing API v1 GitHub environment variables must be changed from `old_gateway_direct` to `cloud_run_simulation_entrypoint`. The already-qualified canonical URL remains environment-scoped configuration, and the direct Modal URL remains configured for rollback.

Merging then runs the existing release sequence: the complete staging calculation, economy, and budget-window suite must pass before production begins; production deploys automatically and assigns stable API v1 traffic to the exact tested revision.

## Migration scope

- Covered workflow: API v1 outbound simulation submission and polling.
- Still on API v1/Flask: every public route and response contract; no native route ownership changes here.
- Prepared boundary: the already-deployed Cloud Run Simulation Entrypoint remains an authenticated proxy to the existing Modal gateway and executor.
- Not included: SQLAlchemy/Alembic, Supabase, durable job state, Modal compute, DNS, API v2 route migration, or percentage traffic ramping.
- Intentional user-visible API changes: none.

## Validation

- `make format` (`205 files left unchanged`)
- `python scripts/export_migration_contracts.py` (generated artifacts unchanged)
- `python scripts/run_quality_guards.py` (`migration-contracts: passed`)
- `python -m pytest tests/unit/test_migration_contract_artifacts.py -q`
- `.github/scripts/check_changelog_fragment.sh`
- `git diff --check`

## Pre-merge gate

Keep this PR in draft until both GitHub environment selectors are set to `cloud_run_simulation_entrypoint` and read back immediately before merge. The URL secrets and direct-Modal rollback variable must also still exist.