### PR TITLE
Remove brittle changelog architecture test

### DIFF
--- a/changelog.d/3789.fixed.md
+++ b/changelog.d/3789.fixed.md
@@ -1,0 +1,1 @@
+Remove a brittle architecture test that depended on a Towncrier fragment remaining after release.

--- a/tests/unit/services/test_service_owned_session_architecture.py
+++ b/tests/unit/services/test_service_owned_session_architecture.py
@@ -120,11 +120,3 @@ def test_removed_persistence_abstractions_stay_removed():
     )
     assert [path for path in removed_files if (PACKAGE_ROOT / path).exists()] == []
     assert not any((PACKAGE_ROOT / "endpoints").rglob("*.py"))
-
-
-def test_changelog_describes_service_owned_sessions():
-    changelog = (PROJECT_ROOT / "changelog.d/3788.changed.md").read_text(
-        encoding="utf-8"
-    )
-    assert "service-owned" in changelog
-    assert "caller-owned" not in changelog


### PR DESCRIPTION
Fixes #3789

## Summary

- remove the wording-only test that reads a specific Towncrier fragment
- preserve the behavioral architecture guards for service-owned sessions
- add a changelog fragment for this fix

## Root cause

The test assumed `changelog.d/3788.changed.md` would remain in the repository. Towncrier correctly consumes and deletes that fragment in the generated release commit, so the post-release deployment test run failed with `FileNotFoundError` despite the architecture behavior remaining valid.

## Validation

- `.venv/bin/pytest tests/unit/services/test_service_owned_session_architecture.py -q` (13 passed)
- `git diff --check`
