### PR TITLE
Fix staging cache test environment

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -216,6 +216,12 @@ jobs:
       - name: Run push-time tests
         run: make test
         env:
+          RUNTIME_CACHE_MODE: local
+          RUNTIME_CACHE_URL: redis://127.0.0.1:6379/0
+          RUNTIME_CACHE_URL_SECRET_RESOURCE: ""
+          RUNTIME_CACHE_CA_CERT_SECRET_RESOURCE: ""
+          RUNTIME_CACHE_ENVIRONMENT: test
+          RUNTIME_CACHE_SERVICE: api
           POLICYENGINE_DB_PASSWORD: ${{ secrets.POLICYENGINE_DB_PASSWORD }}
           POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN: ${{ secrets.POLICYENGINE_GITHUB_MICRODATA_AUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/changelog.d/staging-cache-test-environment.fixed.md
+++ b/changelog.d/staging-cache-test-environment.fixed.md
@@ -1,0 +1,1 @@
+Fix the post-merge staging workflow so its predeployment test suite uses the local Redis service instead of inheriting managed-cache secret references.

--- a/tests/unit/test_cloud_run_deploy_scripts.py
+++ b/tests/unit/test_cloud_run_deploy_scripts.py
@@ -1727,6 +1727,23 @@ def test_push_workflow_tests_app_engine_and_cloud_run_staging_tracks():
     )
 
 
+def test_push_workflow_uses_local_redis_for_predeployment_test_suite():
+    staging = _workflow_job_block(_push_workflow(), "deploy-staging")
+    test_step_start = staging.index("- name: Run push-time tests")
+    test_step_end = staging.index(
+        "- name: Validate App Engine deployment configuration",
+        test_step_start,
+    )
+    test_step = staging[test_step_start:test_step_end]
+
+    assert "RUNTIME_CACHE_MODE: local" in test_step
+    assert "RUNTIME_CACHE_URL: redis://127.0.0.1:6379/0" in test_step
+    assert 'RUNTIME_CACHE_URL_SECRET_RESOURCE: ""' in test_step
+    assert 'RUNTIME_CACHE_CA_CERT_SECRET_RESOURCE: ""' in test_step
+    assert "RUNTIME_CACHE_ENVIRONMENT: test" in test_step
+    assert "RUNTIME_CACHE_SERVICE: api" in test_step
+
+
 def test_push_workflow_staging_fully_gates_all_production_deployments():
     workflow = _push_workflow()
     app_engine_candidate = _workflow_job_block(workflow, "deploy-production-candidate")


### PR DESCRIPTION
Fixes #3794

## Summary

- run the post-merge predeployment test suite against the local Redis service that the staging job already starts
- clear inherited managed-cache Secret Manager references only for that test step
- require an explicit test namespace and service name
- add regression coverage for the complete cache environment expected by the workflow

## Root cause

The staging App Engine job defined managed-cache Secret Manager references at job scope. Its earlier `make test` step inherited those references without selecting a cache mode, so the cache loader selected disabled mode and rejected the inconsistent secret configuration during collection. The workflow stopped before image construction or deployment.

## Impact

The correction affects only the predeployment test process. Actual App Engine and Cloud Run revisions continue to receive deployed-mode managed Redis configuration. Cloud SQL, API routes, compute selection, and the dormant v2 database remain unchanged.

## Verification

- `uv run pytest tests/unit/test_cloud_run_deploy_scripts.py -q` — 94 passed
- `.venv/bin/python3 -m pytest tests/unit/test_cloud_run_deploy_scripts.py tests/unit/runtime_cache/test_settings.py -q` — 111 passed
- corrected release environment with the full `make test` scope and `--collect-only` — 1,191 tests collected successfully
- `python3 scripts/run_quality_guards.py` — passed
- `python3 scripts/export_migration_contracts.py` — generated artifacts unchanged
- `uv run ruff format .` — unchanged
- `uv run ruff check tests/unit/test_cloud_run_deploy_scripts.py` — passed