### PR TITLE
Remove Redis from legacy API test client

### DIFF
--- a/changelog.d/2112.changed.md
+++ b/changelog.d/2112.changed.md
@@ -1,0 +1,1 @@
+Remove unnecessary Redis startup from legacy route tests so they run without a local Redis service.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 import os
 from pathlib import Path
-import time
-from contextlib import contextmanager
-from subprocess import Popen, TimeoutExpired
 import sys
+
 import pytest
 
 # API startup now requires an explicit direct-gateway rollback target. Tests use
@@ -19,29 +17,10 @@ sys.path.append(str(root_dir))
 """Shared fixtures"""
 
 
-@contextmanager
-def running(process_arguments, seconds_to_wait_after_launch=0):
-    """run a process and kill it after"""
-    process = Popen(process_arguments)
-    time.sleep(seconds_to_wait_after_launch)
-    try:
-        yield process
-    finally:
-        process.kill()
-        try:
-            process.wait(10)
-        except TimeoutExpired:
-            process.terminate()
-
-
-@pytest.fixture(name="rest_client", scope="session")
-def client():
-    """run the app for the tests to run against"""
+@pytest.fixture(scope="session")
+def api_client():
+    """Provide a Flask client without starting a Redis server."""
     from policyengine_api.api import app
-    import redis
 
     app.config["TESTING"] = True
-    with running(["redis-server"], 3):
-        redis_client = redis.Redis()
-        redis_client.ping()
-        yield app.test_client()
+    yield app.test_client()

--- a/tests/to_refactor/api/test_api_client_context.py
+++ b/tests/to_refactor/api/test_api_client_context.py
@@ -1,10 +1,10 @@
 import flask
 
 
-def test_rest_client_does_not_preserve_request_context(rest_client):
+def test_api_client_does_not_preserve_request_context(api_client):
     assert not flask.has_request_context()
 
-    response = rest_client.get("/readiness-check")
+    response = api_client.get("/readiness-check")
 
     assert response.status_code == 200
     assert not flask.has_request_context()

--- a/tests/to_refactor/python/test_economy_budget_window_routes.py
+++ b/tests/to_refactor/python/test_economy_budget_window_routes.py
@@ -29,9 +29,9 @@ def _mock_budget_window_result(cache_status=None):
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_rejects_cliff_target(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window"
         "?region=us&start_year=2026&window_size=10&target=cliff"
     )
@@ -48,9 +48,9 @@ def test_budget_window_route_rejects_cliff_target(
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_requires_region(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window?start_year=2026&window_size=2"
     )
 
@@ -66,9 +66,9 @@ def test_budget_window_route_requires_region(
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_requires_start_year(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window?region=us&window_size=2"
     )
 
@@ -84,9 +84,9 @@ def test_budget_window_route_requires_start_year(
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_requires_window_size(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window?region=us&start_year=2026"
     )
 
@@ -102,9 +102,9 @@ def test_budget_window_route_requires_window_size(
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_requires_integer_window_size(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window"
         "?region=us&start_year=2026&window_size=abc"
     )
@@ -117,8 +117,8 @@ def test_budget_window_route_requires_integer_window_size(
     mock_get_budget_window_economic_impact.assert_not_called()
 
 
-def test_budget_window_route_rejects_oversized_window(rest_client):
-    response = rest_client.get(
+def test_budget_window_route_rejects_oversized_window(api_client):
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window"
         "?region=us&start_year=2026&window_size=999"
     )
@@ -130,8 +130,8 @@ def test_budget_window_route_rejects_oversized_window(rest_client):
     assert "window_size must be between 1 and" in data["message"]
 
 
-def test_budget_window_route_rejects_end_year_after_2099(rest_client):
-    response = rest_client.get(
+def test_budget_window_route_rejects_end_year_after_2099(api_client):
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window"
         "?region=us&start_year=2090&window_size=20"
     )
@@ -147,12 +147,12 @@ def test_budget_window_route_rejects_end_year_after_2099(rest_client):
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_passes_version_to_service(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
     mock_result = _mock_budget_window_result()
     mock_get_budget_window_economic_impact.return_value = mock_result
 
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window"
         "?region=us&start_year=2026&window_size=2&version=1.2.3"
     )
@@ -179,11 +179,11 @@ def test_budget_window_route_passes_version_to_service(
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_ignores_deprecated_breakdown_flag(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
     mock_get_budget_window_economic_impact.return_value = _mock_budget_window_result()
 
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window"
         "?region=us&start_year=2026&window_size=2"
         "&include_district_breakdowns=true"
@@ -200,13 +200,13 @@ def test_budget_window_route_ignores_deprecated_breakdown_flag(
     "policyengine_api.routes.economy_routes.economy_service.get_budget_window_economic_impact"
 )
 def test_budget_window_route_sets_cache_status_header(
-    mock_get_budget_window_economic_impact, rest_client
+    mock_get_budget_window_economic_impact, api_client
 ):
     mock_get_budget_window_economic_impact.return_value = _mock_budget_window_result(
         cache_status="result-hit"
     )
 
-    response = rest_client.get(
+    response = api_client.get(
         "/us/economy/123/over/456/budget-window?region=us&start_year=2026&window_size=2"
     )
 

--- a/tests/to_refactor/python/test_household_routes.py
+++ b/tests/to_refactor/python/test_household_routes.py
@@ -11,47 +11,47 @@ pytest_plugins = ["tests.to_refactor.fixtures.to_refactor_household_fixtures"]
 
 
 class TestGetHousehold:
-    def test_get_existing_household(self, rest_client, mock_database):
+    def test_get_existing_household(self, api_client, mock_database):
         """Test getting an existing household."""
         mock_database.get_household.return_value = Household(
             **{**valid_db_row, "household_json": valid_request_body["data"]}
         )
 
         # Make request
-        response = rest_client.get("/us/household/1")
+        response = api_client.get("/us/household/1")
         data = json.loads(response.data)
 
         assert response.status_code == 200
         assert data["status"] == "ok"
         assert data["result"]["household_json"] == valid_request_body["data"]
 
-    def test_get_nonexistent_household(self, rest_client, mock_database):
+    def test_get_nonexistent_household(self, api_client, mock_database):
         """Test getting a non-existent household."""
         mock_database.get_household.return_value = None
 
-        response = rest_client.get("/us/household/999")
+        response = api_client.get("/us/household/999")
         data = json.loads(response.data)
 
         assert response.status_code == 404
         assert data["status"] == "error"
         assert "not found" in data["message"]
 
-    def test_get_household_invalid_id(self, rest_client):
+    def test_get_household_invalid_id(self, api_client):
         """Test getting a household with invalid ID."""
-        response = rest_client.get("/us/household/invalid")
+        response = api_client.get("/us/household/invalid")
 
         assert response.status_code == 404
         assert b"The requested URL was not found on the server" in response.data
 
 
 class TestCreateHousehold:
-    def test_create_household_success(self, rest_client, mock_database):
+    def test_create_household_success(self, api_client, mock_database):
         """Test successfully creating a new household."""
         mock_database.create_household.return_value = Household(
             **{**valid_db_row, "id": 1, "household_json": valid_request_body["data"]}
         )
 
-        response = rest_client.post(
+        response = api_client.post(
             "/us/household",
             json=valid_request_body,
             content_type="application/json",
@@ -62,14 +62,14 @@ class TestCreateHousehold:
         assert data["status"] == "ok"
         assert data["result"]["household_id"] == 1
 
-    def test_create_household_invalid_payload(self, rest_client):
+    def test_create_household_invalid_payload(self, api_client):
         """Test creating a household with invalid payload."""
         invalid_payload = {
             "label": "Test",
             # Missing required 'data' field
         }
 
-        response = rest_client.post(
+        response = api_client.post(
             "/us/household",
             json=invalid_payload,
             content_type="application/json",
@@ -78,14 +78,14 @@ class TestCreateHousehold:
         assert response.status_code == 400
         assert b"Missing required keys" in response.data
 
-    def test_create_household_invalid_label(self, rest_client):
+    def test_create_household_invalid_label(self, api_client):
         """Test creating a household with invalid label type."""
         invalid_payload = {
             "data": {},
             "label": 123,  # Should be string or None
         }
 
-        response = rest_client.post(
+        response = api_client.post(
             "/us/household",
             json=invalid_payload,
             content_type="application/json",
@@ -96,7 +96,7 @@ class TestCreateHousehold:
 
 
 class TestUpdateHousehold:
-    def test_update_household_success(self, rest_client, mock_database):
+    def test_update_household_success(self, api_client, mock_database):
         """Test successfully updating an existing household."""
         mock_database.get_household.return_value = Household(
             **{**valid_db_row, "household_json": valid_request_body["data"]}
@@ -112,7 +112,7 @@ class TestUpdateHousehold:
             **{**valid_db_row, "household_json": updated_household}
         )
 
-        response = rest_client.put(
+        response = api_client.put(
             "/us/household/1",
             json=updated_data,
             content_type="application/json",
@@ -130,11 +130,11 @@ class TestUpdateHousehold:
             valid_request_body["label"],
         )
 
-    def test_update_nonexistent_household(self, rest_client, mock_database):
+    def test_update_nonexistent_household(self, api_client, mock_database):
         """Test updating a non-existent household."""
         mock_database.update_household.side_effect = LookupError("No household")
 
-        response = rest_client.put(
+        response = api_client.put(
             "/us/household/999",
             json=valid_request_body,
             content_type="application/json",
@@ -145,14 +145,14 @@ class TestUpdateHousehold:
         assert data["status"] == "error"
         assert "not found" in data["message"]
 
-    def test_update_household_invalid_payload(self, rest_client):
+    def test_update_household_invalid_payload(self, api_client):
         """Test updating a household with invalid payload."""
         invalid_payload = {
             "label": "Test",
             # Missing required 'data' field
         }
 
-        response = rest_client.put(
+        response = api_client.put(
             "/us/household/1",
             json=invalid_payload,
             content_type="application/json",
@@ -166,11 +166,11 @@ class TestHouseholdRouteServiceErrors:
     """Test handling of service-level errors in routes."""
 
     @patch("policyengine_api.services.household_service.HouseholdService.get_household")
-    def test_get_household_service_error(self, mock_get, rest_client):
+    def test_get_household_service_error(self, mock_get, api_client):
         """Test GET endpoint when service raises an error."""
         mock_get.side_effect = Exception("Database connection failed")
 
-        response = rest_client.get("/us/household/1")
+        response = api_client.get("/us/household/1")
         data = json.loads(response.data)
 
         assert response.status_code == 500
@@ -180,11 +180,11 @@ class TestHouseholdRouteServiceErrors:
     @patch(
         "policyengine_api.services.household_service.HouseholdService.create_household"
     )
-    def test_post_household_service_error(self, mock_create, rest_client):
+    def test_post_household_service_error(self, mock_create, api_client):
         """Test POST endpoint when service raises an error."""
         mock_create.side_effect = Exception("Failed to create household")
 
-        response = rest_client.post(
+        response = api_client.post(
             "/us/household",
             json={"data": {"valid": "payload"}},
             content_type="application/json",
@@ -198,11 +198,11 @@ class TestHouseholdRouteServiceErrors:
     @patch(
         "policyengine_api.services.household_service.HouseholdService.update_household"
     )
-    def test_put_household_service_error(self, mock_update, rest_client):
+    def test_put_household_service_error(self, mock_update, api_client):
         """Test PUT endpoint when service raises an error."""
         mock_update.side_effect = Exception("Failed to update household")
 
-        response = rest_client.put(
+        response = api_client.put(
             "/us/household/1",
             json={"data": {"valid": "payload"}},
             content_type="application/json",
@@ -213,22 +213,22 @@ class TestHouseholdRouteServiceErrors:
         assert data["status"] == "error"
         assert "Failed to update household" in data["message"]
 
-    def test_missing_json_body(self, rest_client):
+    def test_missing_json_body(self, api_client):
         """Test endpoints when JSON body is missing."""
         # Test POST without JSON
-        post_response = rest_client.post("/us/household")
+        post_response = api_client.post("/us/household")
         # Actually intercepted by server, which responds with 415,
         # before we can even return a 400
         assert post_response.status_code in [400, 415]
 
         # Test PUT without JSON
-        put_response = rest_client.put("/us/household/1")
+        put_response = api_client.put("/us/household/1")
         assert put_response.status_code in [400, 415]
 
-    def test_malformed_json_body(self, rest_client):
+    def test_malformed_json_body(self, api_client):
         """Test endpoints with malformed JSON body."""
         # Test POST with malformed JSON
-        post_response = rest_client.post(
+        post_response = api_client.post(
             "/us/household",
             data="invalid json{",
             content_type="application/json",
@@ -236,7 +236,7 @@ class TestHouseholdRouteServiceErrors:
         assert post_response.status_code == 400
 
         # Test PUT with malformed JSON
-        put_response = rest_client.put(
+        put_response = api_client.put(
             "/us/household/1",
             data="invalid json{",
             content_type="application/json",

--- a/tests/to_refactor/python/test_policy.py
+++ b/tests/to_refactor/python/test_policy.py
@@ -21,7 +21,7 @@ class TestPolicyCreation:
     need for a separate Python-based test
     """
 
-    def test_create_unique_policy(self, rest_client):
+    def test_create_unique_policy(self, api_client):
         with get_v1_session_factory().begin() as session:
             session.execute(
                 delete(Policy).where(
@@ -31,14 +31,14 @@ class TestPolicyCreation:
                 )
             )
 
-        res = rest_client.post("/us/policy", json=self.test_policy)
+        res = api_client.post("/us/policy", json=self.test_policy)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-    def test_create_nonunique_policy(self, rest_client):
-        res = rest_client.post("/us/policy", json=self.test_policy)
+    def test_create_nonunique_policy(self, api_client):
+        res = api_client.post("/us/policy", json=self.test_policy)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
@@ -53,8 +53,8 @@ class TestPolicyCreation:
                 )
             )
 
-    def test_create_policy_invalid_country(self, rest_client):
-        res = rest_client.post("/au/policy", json=self.test_policy)
+    def test_create_policy_invalid_country(self, api_client):
+        res = api_client.post("/au/policy", json=self.test_policy)
         assert res.status_code == 400
 
 
@@ -86,8 +86,8 @@ class TestPolicyCreation:
 #         (label,),
 #     ).fetchall()
 #
-#     def test_search_all_policies(self, rest_client):
-#         res = rest_client.get("/us/policies")
+#     def test_search_all_policies(self, api_client):
+#         res = api_client.get("/us/policies")
 #         return_object = json.loads(res.text)
 #
 #         filtered_return = list(
@@ -97,8 +97,8 @@ class TestPolicyCreation:
 #         assert return_object["status"] == "ok"
 #         assert len(filtered_return) == len(self.db_output)
 #
-#     def test_search_unique_policies(self, rest_client):
-#         res = rest_client.get("/us/policies?unique_only=true")
+#     def test_search_unique_policies(self, api_client):
+#         res = api_client.get("/us/policies?unique_only=true")
 #         return_object = json.loads(res.text)
 #
 #         filtered_return = list(

--- a/tests/to_refactor/python/test_user_profile_routes.py
+++ b/tests/to_refactor/python/test_user_profile_routes.py
@@ -24,7 +24,7 @@ class TestUserProfiles:
     Test adding a record to user_profiles
     """
 
-    def test_set_and_get_record(self, rest_client):
+    def test_set_and_get_record(self, api_client):
         with get_v1_session_factory().begin() as session:
             session.execute(
                 delete(UserProfile).where(
@@ -33,13 +33,13 @@ class TestUserProfiles:
                 )
             )
 
-        res = rest_client.post("/us/user-profile", json=self.test_profile)
+        res = api_client.post("/us/user-profile", json=self.test_profile)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
         assert res.status_code == 201
 
-        res = rest_client.get(f"/us/user-profile?auth0_id={self.auth0_id}")
+        res = api_client.get(f"/us/user-profile?auth0_id={self.auth0_id}")
         return_object = json.loads(res.text)
 
         assert res.status_code == 200
@@ -50,7 +50,7 @@ class TestUserProfiles:
 
         user_id = return_object["result"]["user_id"]
 
-        res = rest_client.get(f"/us/user-profile?user_id={user_id}")
+        res = api_client.get(f"/us/user-profile?user_id={user_id}")
         return_object = json.loads(res.text)
 
         assert res.status_code == 200
@@ -62,7 +62,7 @@ class TestUserProfiles:
         test_username = "maxwell"
         updated_profile = {"user_id": user_id, "username": test_username}
 
-        res = rest_client.put("/us/user-profile", json=updated_profile)
+        res = api_client.put("/us/user-profile", json=updated_profile)
         return_object = json.loads(res.text)
 
         assert return_object["status"] == "ok"
@@ -79,7 +79,7 @@ class TestUserProfiles:
 
         malicious_updated_profile = {**updated_profile, "auth0_id": "BOGUS"}
 
-        res = rest_client.put("/us/user-profile", json=malicious_updated_profile)
+        res = api_client.put("/us/user-profile", json=malicious_updated_profile)
         return_object = json.loads(res.text)
 
         assert res.status_code == 200
@@ -91,8 +91,8 @@ class TestUserProfiles:
             assert row.auth0_id == self.auth0_id
             session.delete(row)
 
-    def test_non_existent_record(self, rest_client):
+    def test_non_existent_record(self, api_client):
         non_existent_auth0_id = "non-existent-auth0-id"
 
-        res = rest_client.get(f"/us/user-profile?auth0_id={non_existent_auth0_id}")
+        res = api_client.get(f"/us/user-profile?auth0_id={non_existent_auth0_id}")
         assert res.status_code == 404

--- a/tests/to_refactor/python/test_validate_household_payload.py
+++ b/tests/to_refactor/python/test_validate_household_payload.py
@@ -14,9 +14,9 @@ class TestHouseholdRouteValidation:
             {"data": {}, "label": 123},  # Invalid label type
         ],
     )
-    def test_post_household_invalid_payload(self, rest_client, invalid_payload):
+    def test_post_household_invalid_payload(self, api_client, invalid_payload):
         """Test POST endpoint with various invalid payloads."""
-        response = rest_client.post(
+        response = api_client.post(
             "/us/household",
             json=invalid_payload,
             content_type="application/json",
@@ -32,9 +32,9 @@ class TestHouseholdRouteValidation:
             "1.5",  # Float
         ],
     )
-    def test_get_household_invalid_id(self, rest_client, invalid_id):
+    def test_get_household_invalid_id(self, api_client, invalid_id):
         """Test GET endpoint with invalid household IDs."""
-        response = rest_client.get(f"/us/household/{invalid_id}")
+        response = api_client.get(f"/us/household/{invalid_id}")
 
         # Default Werkzeug validation returns 404, not 400
         assert response.status_code == 404
@@ -49,14 +49,14 @@ class TestHouseholdRouteValidation:
             "a" * 100,  # Too long
         ],
     )
-    def test_invalid_country_id(self, rest_client, country_id):
+    def test_invalid_country_id(self, api_client, country_id):
         """Test endpoints with invalid country IDs."""
         # Test GET
-        get_response = rest_client.get(f"/{country_id}/household/1")
+        get_response = api_client.get(f"/{country_id}/household/1")
         assert get_response.status_code == 400
 
         # Test POST
-        post_response = rest_client.post(
+        post_response = api_client.post(
             f"/{country_id}/household",
             json={"data": {}},
             content_type="application/json",
@@ -64,7 +64,7 @@ class TestHouseholdRouteValidation:
         assert post_response.status_code == 400
 
         # Test PUT
-        put_response = rest_client.put(
+        put_response = api_client.put(
             f"/{country_id}/household/1",
             json={"data": {}},
             content_type="application/json",


### PR DESCRIPTION
Fixes #2112

## Summary
- replace the legacy rest_client fixture with a Redis-independent api_client fixture
- remove Redis subprocess startup, connection checking, and the fixed startup delay
- update the six affected legacy route-test modules to use the renamed fixture

## Testing
- uv run --extra dev ruff check on all changed Python files
- uv run --extra dev pytest on the six affected legacy test modules: 41 passed