### PR TITLE
Declare Make targets as phony

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,5 +19,8 @@ For SQLAlchemy model or Alembic migration work, read
 For API v2 route, service, or database-access module additions or moves, read
 `docs/engineering/skills/v2-code-organization.md`.
 
+For `Makefile` changes, read
+`docs/engineering/skills/repository-maintenance.md`.
+
 For pull requests, read `docs/engineering/skills/github-prs.md` before opening,
 replacing, or sharing a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ migration revisions, read
 When adding or moving API v2 route, service, or database-access modules, read
 `docs/engineering/skills/v2-code-organization.md`.
 
+When modifying the `Makefile`, read
+`docs/engineering/skills/repository-maintenance.md`.
+
 ## GitHub PRs
 
 Read `docs/engineering/skills/github-prs.md` before opening, replacing, or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,9 @@ migration revisions, read
 When adding or moving API v2 route, service, or database-access modules, read
 `docs/engineering/skills/v2-code-organization.md`.
 
+When modifying the `Makefile`, read
+`docs/engineering/skills/repository-maintenance.md`.
+
 ## Safety Boundaries
 
 Do not claim a route, database table, compute path, or deployment surface has

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: install setup-env debug debug-asgi test-env-vars test quality-guards typecheck-v2 debug-test format changelog
+
 install:
 	pip install -e ".[dev]"
 

--- a/changelog.d/2591.changed.md
+++ b/changelog.d/2591.changed.md
@@ -1,0 +1,1 @@
+Declare command-only Make targets as phony so matching filesystem entries cannot cause Make to skip their recipes.

--- a/docs/engineering/skills/README.md
+++ b/docs/engineering/skills/README.md
@@ -16,6 +16,8 @@ Current skills:
 - `github-prs.md`: PR workflow and migration PR handoff expectations.
 - `migration_contracts.md`: API v2 migration route contracts, route-group
   metadata, generated migration artifacts, and quality guards.
+- `repository-maintenance.md`: mandatory Makefile target and `.PHONY`
+  maintenance rules.
 - `testing.md`: focused test commands and dependency boundaries for migration
   work.
 - `v2-code-organization.md`: mandatory API v2 route, service, and database-access

--- a/docs/engineering/skills/repository-maintenance.md
+++ b/docs/engineering/skills/repository-maintenance.md
@@ -1,0 +1,14 @@
+# Repository Maintenance
+
+Read this guidance before modifying the repository's `Makefile`.
+
+## Command-only Make targets
+
+When a change adds or renames a Make target, determine whether its recipe creates
+a file or directory whose path is the target name. If it does not, the target is
+command-only and must be added to the `Makefile`'s `.PHONY` declaration in the
+same change.
+
+Keep the `.PHONY` declaration synchronized when command-only targets are renamed
+or removed. Do not declare a file-producing target phony unless the recipe is
+intentionally required to run on every invocation.


### PR DESCRIPTION
Fixes #2591

## Summary
- declare every current command-only Make target as phony
- require AI-authored Makefile changes to keep command-only targets in `.PHONY`
- add the canonical guidance and lookup pointers for Codex, Claude, and Copilot
- add a changelog fragment describing the Make behavior

## Verification
- `make -n install setup-env debug debug-asgi test-env-vars test quality-guards typecheck-v2 debug-test format changelog`
- `uv run --frozen towncrier build --draft`
- `git diff --check github/master...HEAD`