### PR TITLE
Fix axes results and remove unused household traces

### DIFF
--- a/changelog.d/2695.fixed.md
+++ b/changelog.d/2695.fixed.md
@@ -1,1 +1,1 @@
-Return consistently sized, type-preserving arrays for household calculations that use axes.
+Return consistently sized, type-preserving arrays for household calculations that use axes, including warnings preserved across stored-household cache hits.

--- a/changelog.d/2695.fixed.md
+++ b/changelog.d/2695.fixed.md
@@ -1,0 +1,1 @@
+Return consistently sized, type-preserving arrays for household calculations that use axes.

--- a/changelog.d/2695.fixed.md
+++ b/changelog.d/2695.fixed.md
@@ -1,1 +1,1 @@
-Return consistently sized, type-preserving arrays for household calculations that use axes, including warnings preserved across stored-household cache hits.
+Return consistently sized, type-preserving arrays for household calculations that use axes.

--- a/changelog.d/3803.removed.md
+++ b/changelog.d/3803.removed.md
@@ -1,0 +1,1 @@
+Stop generating and caching unused household calculation traces.

--- a/docs/engineering/skills/testing.md
+++ b/docs/engineering/skills/testing.md
@@ -85,10 +85,10 @@ RUNTIME_CACHE_TEST_URL="redis://127.0.0.1:6379/0" uv run pytest tests/integratio
 ```
 
 The real Redis-compatible suite must be an explicit integration run and cover
-two independent connections, TTL expiry, atomic household/tracer generations,
-bounded lookup indexes, completed-result miss semantics, and token-safe
-coordination claims. Unit tests use the deterministic in-memory fake and do
-not require network credentials.
+two independent connections, TTL expiry, atomic calculated-household results
+and warnings, bounded lookup indexes, completed-result miss semantics, and
+token-safe coordination claims. Unit tests use the deterministic in-memory
+fake and do not require network credentials.
 
 Startup, deployment, SQLite-removal, and unchanged API migration contracts:
 

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import json
+import logging
 from policyengine_core.taxbenefitsystems import TaxBenefitSystem
 from typing import Union
 from policyengine_api.utils import get_safe_json
@@ -15,7 +16,6 @@ from importlib.metadata import version as get_package_version
 from policyengine_core.model_api import Reform, Enum
 from policyengine_core.periods import instant
 import dpath
-import math
 import pandas as pd
 from datetime import date, datetime
 from pathlib import Path
@@ -27,6 +27,31 @@ from policyengine_api.constants import (
     get_bundle_default_dataset_option,
 )
 from policyengine_api.services.household_calculation_service import CalculationResult
+
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize_float(value):
+    serialized = float(str(value))
+    if serialized == float("inf"):
+        return "Infinity"
+    if serialized == float("-inf"):
+        return "-Infinity"
+    return serialized
+
+
+def _serialize_axis_result(result, variable, entity_index, count_entities):
+    if variable.value_type == Enum:
+        result = result.decode_to_str()
+
+    entity_values = result.reshape((-1, count_entities)).T[entity_index].tolist()
+
+    if variable.value_type is float:
+        return [_serialize_float(value) for value in entity_values]
+    if variable.value_type is str:
+        return [str(value) for value in entity_values]
+    return entity_values
 
 
 class PolicyEngineCountry:
@@ -366,7 +391,13 @@ class PolicyEngineCountry:
         household = json.loads(json.dumps(household))
 
         simulation.trace = True
-        requested_computations = get_requested_computations(household)
+        has_axes = "axes" in household
+        requested_computations = get_requested_computations(
+            household,
+            include_provided_values=has_axes,
+            variable_names=set(system.variables) if has_axes else None,
+        )
+        calculation_warnings: list[str] = []
 
         for (
             entity_plural,
@@ -374,42 +405,32 @@ class PolicyEngineCountry:
             variable_name,
             period,
         ) in requested_computations:
+            population = simulation.get_population(entity_plural)
             try:
                 variable = system.get_variable(variable_name)
                 result = simulation.calculate(variable_name, period)
-                population = simulation.get_population(entity_plural)
 
-                if "axes" in household:
+                if has_axes:
                     count_entities = len(household[entity_plural])
                     entity_index = 0
                     for _entity_id in household[entity_plural].keys():
                         if _entity_id == entity_id:
                             break
                         entity_index += 1
-                    result = (
-                        result.astype(float)
-                        .reshape((-1, count_entities))
-                        .T[entity_index]
-                        .tolist()
-                    )
-                    # If the result contains infinities, throw an error
-                    if any([math.isinf(value) for value in result]):
-                        raise ValueError("Infinite value")
-                    else:
-                        household[entity_plural][entity_id][variable_name][period] = (
-                            result
+                    household[entity_plural][entity_id][variable_name][period] = (
+                        _serialize_axis_result(
+                            result,
+                            variable,
+                            entity_index,
+                            count_entities,
                         )
+                    )
                 else:
                     entity_index = population.get_index(entity_id)
                     if variable.value_type == Enum:
                         entity_result = result.decode()[entity_index].name
                     elif variable.value_type is float:
-                        entity_result = float(str(result[entity_index]))
-                        # Convert infinities to JSON infinities
-                        if entity_result == float("inf"):
-                            entity_result = "Infinity"
-                        elif entity_result == float("-inf"):
-                            entity_result = "-Infinity"
+                        entity_result = _serialize_float(result[entity_index])
                     elif variable.value_type is str:
                         entity_result = str(result[entity_index])
                     else:
@@ -419,11 +440,27 @@ class PolicyEngineCountry:
                         entity_result
                     )
             except Exception as e:
-                if "axes" in household:
-                    pass
-                else:
-                    household[entity_plural][entity_id][variable_name][period] = None
-                    print(f"Error computing {variable_name} for {entity_id}: {e}")
+                if has_axes:
+                    count_entities = len(household[entity_plural])
+                    axis_point_count = population.count // count_entities
+                    household[entity_plural][entity_id][variable_name][period] = [
+                        None
+                    ] * axis_point_count
+                    warning = (
+                        f"Unable to calculate {variable_name} for {entity_id} in "
+                        f"{period}; returned {axis_point_count} null axis values: {e}"
+                    )
+                    calculation_warnings.append(warning)
+                    logger.warning("%s", warning)
+                    continue
+                household[entity_plural][entity_id][variable_name][period] = None
+                logger.warning(
+                    "Unable to calculate %s for %s in %s: %s",
+                    variable_name,
+                    entity_id,
+                    period,
+                    e,
+                )
 
         tracer_output = simulation.tracer.computation_log
         log_lines = tracer_output.lines(aggregate=False, max_depth=10)
@@ -431,6 +468,7 @@ class PolicyEngineCountry:
         return CalculationResult(
             household=household,
             tracer_output=log_lines,
+            warnings=tuple(calculation_warnings),
         )
 
     def _create_simulation(
@@ -543,11 +581,16 @@ def create_policy_reform(policy_data: dict) -> dict:
     return reform
 
 
-def get_requested_computations(household: dict):
+def get_requested_computations(
+    household: dict,
+    *,
+    include_provided_values: bool = False,
+    variable_names: set[str] | None = None,
+):
     requested_computations = dpath.util.search(
         household,
         "*/*/*/*",
-        afilter=lambda t: t is None,
+        afilter=lambda value: include_provided_values or value is None,
         yielded=True,
     )
     requested_computation_data = []
@@ -555,6 +598,8 @@ def get_requested_computations(household: dict):
     for computation in requested_computations:
         path = computation[0]
         entity_plural, entity_id, variable_name, period = path.split("/")
+        if variable_names is not None and variable_name not in variable_names:
+            continue
         requested_computation_data.append(
             (entity_plural, entity_id, variable_name, period)
         )

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -426,7 +426,6 @@ class PolicyEngineCountry:
 
         household = json.loads(json.dumps(household))
 
-        simulation.trace = True
         has_axes = "axes" in household
         requested_computations = get_requested_computations(
             household,
@@ -488,12 +487,8 @@ class PolicyEngineCountry:
                     error=error,
                 )
 
-        tracer_output = simulation.tracer.computation_log
-        log_lines = tracer_output.lines(aggregate=False, max_depth=10)
-
         return CalculationResult(
             household=household,
-            tracer_output=log_lines,
             warnings=tuple(calculation_warnings),
         )
 

--- a/policyengine_api/country.py
+++ b/policyengine_api/country.py
@@ -54,6 +54,42 @@ def _serialize_axis_result(result, variable, entity_index, count_entities):
     return entity_values
 
 
+def _record_calculation_failure(
+    household: dict,
+    calculation_warnings: list[str],
+    *,
+    has_axes: bool,
+    population,
+    entity_plural: str,
+    entity_id: str,
+    variable_name: str,
+    period: str,
+    error: Exception,
+) -> None:
+    if has_axes:
+        count_entities = len(household[entity_plural])
+        axis_point_count = population.count // count_entities
+        household[entity_plural][entity_id][variable_name][period] = [
+            None
+        ] * axis_point_count
+        warning = (
+            f"Unable to calculate {variable_name} for {entity_id} in "
+            f"{period}; returned {axis_point_count} null axis values: {error}"
+        )
+        calculation_warnings.append(warning)
+        logger.warning("%s", warning)
+        return
+
+    household[entity_plural][entity_id][variable_name][period] = None
+    logger.warning(
+        "Unable to calculate %s for %s in %s: %s",
+        variable_name,
+        entity_id,
+        period,
+        error,
+    )
+
+
 class PolicyEngineCountry:
     def __init__(self, country_package_name: str, country_id: str):
         self.country_package_name = country_package_name
@@ -439,27 +475,17 @@ class PolicyEngineCountry:
                     household[entity_plural][entity_id][variable_name][period] = (
                         entity_result
                     )
-            except Exception as e:
-                if has_axes:
-                    count_entities = len(household[entity_plural])
-                    axis_point_count = population.count // count_entities
-                    household[entity_plural][entity_id][variable_name][period] = [
-                        None
-                    ] * axis_point_count
-                    warning = (
-                        f"Unable to calculate {variable_name} for {entity_id} in "
-                        f"{period}; returned {axis_point_count} null axis values: {e}"
-                    )
-                    calculation_warnings.append(warning)
-                    logger.warning("%s", warning)
-                    continue
-                household[entity_plural][entity_id][variable_name][period] = None
-                logger.warning(
-                    "Unable to calculate %s for %s in %s: %s",
-                    variable_name,
-                    entity_id,
-                    period,
-                    e,
+            except Exception as error:
+                _record_calculation_failure(
+                    household,
+                    calculation_warnings,
+                    has_axes=has_axes,
+                    population=population,
+                    entity_plural=entity_plural,
+                    entity_id=entity_id,
+                    variable_name=variable_name,
+                    period=period,
+                    error=error,
                 )
 
         tracer_output = simulation.tracer.computation_log

--- a/policyengine_api/runtime_cache/household_calculations.py
+++ b/policyengine_api/runtime_cache/household_calculations.py
@@ -1,4 +1,4 @@
-"""Recoverable computed-household, tracer, and warning caching."""
+"""Recoverable calculated-household result caching."""
 
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -10,12 +10,12 @@ from policyengine_api.runtime_cache.core import (
 )
 
 
-HOUSEHOLD_TRACE_SCHEMA_VERSION = 2
-HOUSEHOLD_TRACE_TTL_SECONDS = 86_400
+HOUSEHOLD_CALCULATION_SCHEMA_VERSION = 1
+HOUSEHOLD_CALCULATION_TTL_SECONDS = 86_400
 
 
 @dataclass(frozen=True)
-class HouseholdTraceIdentity:
+class HouseholdCalculationIdentity:
     country_id: str
     household_id: int
     policy_id: int
@@ -26,53 +26,47 @@ class HouseholdTraceIdentity:
 
 
 @dataclass(frozen=True)
-class HouseholdTraceValue:
+class CachedHouseholdCalculation:
     household: dict[str, Any]
-    tracer_output: list[str]
     warnings: tuple[str, ...] = ()
 
 
-class HouseholdTraceCache:
-    """One atomic value for a computed household and its matching tracer."""
+class HouseholdCalculationCache:
+    """Cache a calculated household and its response warnings atomically."""
 
     def __init__(self, client: CacheBackend, namespace: CacheNamespace) -> None:
         self._cache = RecoverableJSONCache(
             client,
             namespace,
-            family="household-trace",
-            schema_version=HOUSEHOLD_TRACE_SCHEMA_VERSION,
-            ttl_seconds=HOUSEHOLD_TRACE_TTL_SECONDS,
+            family="household-calculation",
+            schema_version=HOUSEHOLD_CALCULATION_SCHEMA_VERSION,
+            ttl_seconds=HOUSEHOLD_CALCULATION_TTL_SECONDS,
         )
 
-    def cache_key(self, identity: HouseholdTraceIdentity) -> str:
+    def cache_key(self, identity: HouseholdCalculationIdentity) -> str:
         return self._cache.key(asdict(identity))
 
-    def get(self, identity: HouseholdTraceIdentity) -> HouseholdTraceValue | None:
+    def get(
+        self,
+        identity: HouseholdCalculationIdentity,
+    ) -> CachedHouseholdCalculation | None:
         payload = self._cache.get(asdict(identity))
         if not isinstance(payload, dict):
             return None
         household = payload.get("household")
-        tracer_output = payload.get("tracer_output")
         warnings = payload.get("warnings")
-        if (
-            not isinstance(household, dict)
-            or not isinstance(tracer_output, list)
-            or not isinstance(warnings, list)
-        ):
-            return None
-        if not all(isinstance(line, str) for line in tracer_output):
+        if not isinstance(household, dict) or not isinstance(warnings, list):
             return None
         if not all(isinstance(warning, str) for warning in warnings):
             return None
-        return HouseholdTraceValue(
+        return CachedHouseholdCalculation(
             household=household,
-            tracer_output=tracer_output,
             warnings=tuple(warnings),
         )
 
     def set(
         self,
-        identity: HouseholdTraceIdentity,
-        value: HouseholdTraceValue,
+        identity: HouseholdCalculationIdentity,
+        value: CachedHouseholdCalculation,
     ) -> bool:
         return self._cache.set(asdict(identity), asdict(value))

--- a/policyengine_api/runtime_cache/household_traces.py
+++ b/policyengine_api/runtime_cache/household_traces.py
@@ -1,4 +1,4 @@
-"""Recoverable computed-household and tracer caching."""
+"""Recoverable computed-household, tracer, and warning caching."""
 
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -10,7 +10,7 @@ from policyengine_api.runtime_cache.core import (
 )
 
 
-HOUSEHOLD_TRACE_SCHEMA_VERSION = 1
+HOUSEHOLD_TRACE_SCHEMA_VERSION = 2
 HOUSEHOLD_TRACE_TTL_SECONDS = 86_400
 
 
@@ -29,6 +29,7 @@ class HouseholdTraceIdentity:
 class HouseholdTraceValue:
     household: dict[str, Any]
     tracer_output: list[str]
+    warnings: tuple[str, ...] = ()
 
 
 class HouseholdTraceCache:
@@ -52,13 +53,21 @@ class HouseholdTraceCache:
             return None
         household = payload.get("household")
         tracer_output = payload.get("tracer_output")
-        if not isinstance(household, dict) or not isinstance(tracer_output, list):
+        warnings = payload.get("warnings")
+        if (
+            not isinstance(household, dict)
+            or not isinstance(tracer_output, list)
+            or not isinstance(warnings, list)
+        ):
             return None
         if not all(isinstance(line, str) for line in tracer_output):
+            return None
+        if not all(isinstance(warning, str) for warning in warnings):
             return None
         return HouseholdTraceValue(
             household=household,
             tracer_output=tracer_output,
+            warnings=tuple(warnings),
         )
 
     def set(

--- a/policyengine_api/services/household_calculation_service.py
+++ b/policyengine_api/services/household_calculation_service.py
@@ -30,6 +30,7 @@ from policyengine_api.utils.input_validation import find_unrecognized_inputs
 class CalculationResult:
     household: dict
     tracer_output: list[str]
+    warnings: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -249,7 +250,10 @@ class HouseholdCalculationService:
         )
         return HouseholdCalculationResult(
             household=calculation.household,
-            warnings=tuple(warning.message for warning in deprecated_inputs.warnings),
+            warnings=(
+                tuple(warning.message for warning in deprecated_inputs.warnings)
+                + calculation.warnings
+            ),
         )
 
     def calculate_household(
@@ -282,12 +286,16 @@ class HouseholdCalculationService:
             raise InvalidHouseholdInputsError(invalid_inputs)
 
         raw_calculation = country.calculate(household_json, policy_json)
-        household = (
-            raw_calculation
-            if isinstance(raw_calculation, dict)
-            else raw_calculation.household
-        )
+        if isinstance(raw_calculation, dict):
+            household = raw_calculation
+            calculation_warnings = ()
+        else:
+            household = raw_calculation.household
+            calculation_warnings = getattr(raw_calculation, "warnings", ())
         return HouseholdCalculationResult(
             household=household,
-            warnings=tuple(warning.message for warning in deprecated_inputs.warnings),
+            warnings=(
+                tuple(warning.message for warning in deprecated_inputs.warnings)
+                + calculation_warnings
+            ),
         )

--- a/policyengine_api/services/household_calculation_service.py
+++ b/policyengine_api/services/household_calculation_service.py
@@ -163,12 +163,14 @@ class HouseholdCalculationService:
         self,
         identity: HouseholdTraceIdentity,
         calculation: CalculationResult,
+        warnings: tuple[str, ...],
     ) -> None:
         self._cache.set(
             identity,
             HouseholdTraceValue(
                 household=calculation.household,
                 tracer_output=calculation.tracer_output,
+                warnings=warnings,
             ),
         )
 
@@ -194,6 +196,7 @@ class HouseholdCalculationService:
         if cached is not None:
             return HouseholdCalculationResult(
                 household=cached.household,
+                warnings=cached.warnings,
                 cached=True,
             )
 
@@ -244,16 +247,18 @@ class HouseholdCalculationService:
             event="recompute",
             started_at=calculation_started_at,
         )
+        response_warnings = (
+            tuple(warning.message for warning in deprecated_inputs.warnings)
+            + calculation.warnings
+        )
         self._store_result(
             cache_identity,
             calculation,
+            response_warnings,
         )
         return HouseholdCalculationResult(
             household=calculation.household,
-            warnings=(
-                tuple(warning.message for warning in deprecated_inputs.warnings)
-                + calculation.warnings
-            ),
+            warnings=response_warnings,
         )
 
     def calculate_household(

--- a/policyengine_api/services/household_calculation_service.py
+++ b/policyengine_api/services/household_calculation_service.py
@@ -17,10 +17,10 @@ from policyengine_api.data.v1_models import (
 )
 from policyengine_api.runtime_cache.dependencies import get_runtime_cache_context
 from policyengine_api.runtime_cache.core import record_cache_event
-from policyengine_api.runtime_cache.household_traces import (
-    HouseholdTraceCache,
-    HouseholdTraceIdentity,
-    HouseholdTraceValue,
+from policyengine_api.runtime_cache.household_calculations import (
+    CachedHouseholdCalculation,
+    HouseholdCalculationCache,
+    HouseholdCalculationIdentity,
 )
 from policyengine_api.utils.deprecated_inputs import drop_deprecated_inputs
 from policyengine_api.utils.input_validation import find_unrecognized_inputs
@@ -29,7 +29,6 @@ from policyengine_api.utils.input_validation import find_unrecognized_inputs
 @dataclass(frozen=True)
 class CalculationResult:
     household: dict
-    tracer_output: list[str]
     warnings: tuple[str, ...] = ()
 
 
@@ -100,13 +99,13 @@ class HouseholdCalculationService:
     def __init__(
         self,
         primary_session_factory: sessionmaker[Session] | None = None,
-        cache: HouseholdTraceCache | None = None,
+        cache: HouseholdCalculationCache | None = None,
         country_provider: Callable[[], dict] | None = None,
     ) -> None:
         self._injected_primary_session_factory = primary_session_factory
         if cache is None:
             context = get_runtime_cache_context()
-            cache = HouseholdTraceCache(context.client, context.namespace)
+            cache = HouseholdCalculationCache(context.client, context.namespace)
         self._cache = cache
         self._country_provider = country_provider
 
@@ -127,8 +126,8 @@ class HouseholdCalculationService:
         household: Household,
         policy: Policy,
         api_version: str,
-    ) -> HouseholdTraceIdentity:
-        return HouseholdTraceIdentity(
+    ) -> HouseholdCalculationIdentity:
+        return HouseholdCalculationIdentity(
             country_id=country_id,
             household_id=household.id,
             policy_id=policy.id,
@@ -161,15 +160,14 @@ class HouseholdCalculationService:
 
     def _store_result(
         self,
-        identity: HouseholdTraceIdentity,
+        identity: HouseholdCalculationIdentity,
         calculation: CalculationResult,
         warnings: tuple[str, ...],
     ) -> None:
         self._cache.set(
             identity,
-            HouseholdTraceValue(
+            CachedHouseholdCalculation(
                 household=calculation.household,
-                tracer_output=calculation.tracer_output,
                 warnings=warnings,
             ),
         )
@@ -222,7 +220,7 @@ class HouseholdCalculationService:
             raw_calculation = country.calculate(household_json, policy.policy_json)
         except Exception:
             record_cache_event(
-                family="household-trace",
+                family="household-calculation",
                 event="recompute-failed",
                 started_at=calculation_started_at,
                 severity="WARNING",
@@ -233,17 +231,16 @@ class HouseholdCalculationService:
         elif hasattr(raw_calculation, "household"):
             calculation = CalculationResult(
                 household=raw_calculation.household,
-                tracer_output=raw_calculation.tracer_output,
+                warnings=tuple(getattr(raw_calculation, "warnings", ())),
             )
         else:
             # Temporary compatibility for test doubles and country packages
             # that have not yet adopted CalculationResult.
             calculation = CalculationResult(
                 household=raw_calculation,
-                tracer_output=[],
             )
         record_cache_event(
-            family="household-trace",
+            family="household-calculation",
             event="recompute",
             started_at=calculation_started_at,
         )

--- a/tests/integration/test_runtime_cache_redis.py
+++ b/tests/integration/test_runtime_cache_redis.py
@@ -11,10 +11,10 @@ import redis
 
 from policyengine_api.runtime_cache.claims import ExpiringClaimStore
 from policyengine_api.runtime_cache.core import CacheNamespace, RecoverableJSONCache
-from policyengine_api.runtime_cache.household_traces import (
-    HouseholdTraceCache,
-    HouseholdTraceIdentity,
-    HouseholdTraceValue,
+from policyengine_api.runtime_cache.household_calculations import (
+    CachedHouseholdCalculation,
+    HouseholdCalculationCache,
+    HouseholdCalculationIdentity,
 )
 from policyengine_api.runtime_cache.reform_impacts import (
     CachedReformImpact,
@@ -73,11 +73,11 @@ def test_cross_connection_visibility_and_real_expiry(redis_pair) -> None:
     assert reader.get({"input": "same"}) is None
 
 
-def test_atomic_household_tracer_value_is_shared_between_connections(
+def test_cached_household_calculation_is_shared_between_connections(
     redis_pair,
 ) -> None:
     first, second, namespace = redis_pair
-    identity = HouseholdTraceIdentity(
+    identity = HouseholdCalculationIdentity(
         country_id="us",
         household_id=1,
         policy_id=2,
@@ -86,12 +86,12 @@ def test_atomic_household_tracer_value_is_shared_between_connections(
         country_package_version="1.2.3",
         policyengine_version="4.5.6",
     )
-    value = HouseholdTraceValue(
+    value = CachedHouseholdCalculation(
         household={"people": {"you": {}}},
-        tracer_output=["trace"],
+        warnings=("calculation warning",),
     )
-    assert HouseholdTraceCache(first, namespace).set(identity, value)
-    assert HouseholdTraceCache(second, namespace).get(identity) == value
+    assert HouseholdCalculationCache(first, namespace).set(identity, value)
+    assert HouseholdCalculationCache(second, namespace).get(identity) == value
 
 
 def test_real_claim_is_exclusive_token_safe_and_expires(redis_pair) -> None:

--- a/tests/integration/test_simulations.py
+++ b/tests/integration/test_simulations.py
@@ -1,6 +1,8 @@
 from policyengine_api.country import COUNTRIES
 from tests.fixtures.integration.simulations import (
     TEST_COUNTRY_ID,
+    TEST_STATE,
+    TEST_YEAR,
     SMALL_AXES_COUNT,
     setup_small_axes_household,
     create_base_household,
@@ -24,27 +26,34 @@ class TestSimsWithAxes:
         # This variable does not function like others; it is a list of member names and is not calculated
         FORBIDDEN_VARIABLES = ["members"]
 
-        # Verify we get array results
+        # Verify every variable value is expanded across the configured axis.
         for entity_type in result:
-            print("Entity type: ", entity_type)
             if entity_type == "axes":
                 continue
             for entity_id in result[entity_type]:
-                print("Entity ID: ", entity_id)
                 for variable_name in result[entity_type][entity_id]:
-                    print("Variable name: ", variable_name)
                     if variable_name in FORBIDDEN_VARIABLES:
                         continue
                     for period in result[entity_type][entity_id][variable_name]:
-                        print("Period: ", period)
                         value = result[entity_type][entity_id][variable_name][period]
-                        print(f"Value: {value}")
-                        if isinstance(value, list):
-                            # Assert no Nones
-                            assert all(v is not None for v in value), (
-                                f"None found in {variable_name} for {entity_id} in {period}"
-                            )
-                            # Assert correct length
-                            assert len(value) == SMALL_AXES_COUNT, (
-                                f"Expected {SMALL_AXES_COUNT} values for {variable_name}, got {len(value)}"
-                            )
+                        assert isinstance(value, list), (
+                            f"Expected an array for {variable_name} on "
+                            f"{entity_id} in {period}, got {type(value).__name__}"
+                        )
+                        assert len(value) == SMALL_AXES_COUNT, (
+                            f"Expected {SMALL_AXES_COUNT} values for "
+                            f"{variable_name}, got {len(value)}"
+                        )
+
+        assert result["people"]["adult"]["age"][TEST_YEAR] == [40] * SMALL_AXES_COUNT
+        assert result["people"]["adult"]["employment_income"][TEST_YEAR] == [
+            20_000,
+            25_000,
+            30_000,
+            35_000,
+            40_000,
+        ]
+        assert (
+            result["households"]["household"]["state_name"][TEST_YEAR]
+            == [TEST_STATE] * SMALL_AXES_COUNT
+        )

--- a/tests/unit/routes/test_household_and_user_policy_orm_routes.py
+++ b/tests/unit/routes/test_household_and_user_policy_orm_routes.py
@@ -13,10 +13,10 @@ from policyengine_api.data.v1_models import (
 )
 from policyengine_api.runtime_cache.core import CacheNamespace
 from policyengine_api.runtime_cache.fake import InMemoryCacheBackend
-from policyengine_api.runtime_cache.household_traces import (
-    HouseholdTraceCache,
-    HouseholdTraceIdentity,
-    HouseholdTraceValue,
+from policyengine_api.runtime_cache.household_calculations import (
+    CachedHouseholdCalculation,
+    HouseholdCalculationCache,
+    HouseholdCalculationIdentity,
 )
 from policyengine_api.routes.household_routes import get_household_under_policy
 from policyengine_api.routes.policy_routes import (
@@ -52,12 +52,12 @@ def test_household_under_policy_returns_cached_json_object(orm_session_factory):
                 ),
             ]
         )
-    cache = HouseholdTraceCache(
+    cache = HouseholdCalculationCache(
         InMemoryCacheBackend(),
         CacheNamespace("test", "api"),
     )
     cache.set(
-        HouseholdTraceIdentity(
+        HouseholdCalculationIdentity(
             country_id="us",
             household_id=1,
             policy_id=2,
@@ -66,7 +66,7 @@ def test_household_under_policy_returns_cached_json_object(orm_session_factory):
             country_package_version=COUNTRY_PACKAGE_VERSIONS["us"],
             policyengine_version=POLICYENGINE_VERSION,
         ),
-        HouseholdTraceValue(household=stored_result, tracer_output=[]),
+        CachedHouseholdCalculation(household=stored_result),
     )
     service = HouseholdCalculationService(
         primary_session_factory=orm_session_factory,
@@ -117,7 +117,7 @@ def test_household_under_policy_calculates_and_caches_json_as_an_object(
     )
     service = HouseholdCalculationService(
         primary_session_factory=orm_session_factory,
-        cache=HouseholdTraceCache(
+        cache=HouseholdCalculationCache(
             InMemoryCacheBackend(),
             CacheNamespace("test", "api"),
         ),

--- a/tests/unit/runtime_cache/test_household_calculations.py
+++ b/tests/unit/runtime_cache/test_household_calculations.py
@@ -1,11 +1,11 @@
-"""Computed-household and tracer cache tests."""
+"""Calculated-household result cache tests."""
 
 from policyengine_api.runtime_cache.core import CacheNamespace
 from policyengine_api.runtime_cache.fake import InMemoryCacheBackend
-from policyengine_api.runtime_cache.household_traces import (
-    HouseholdTraceCache,
-    HouseholdTraceIdentity,
-    HouseholdTraceValue,
+from policyengine_api.runtime_cache.household_calculations import (
+    CachedHouseholdCalculation,
+    HouseholdCalculationCache,
+    HouseholdCalculationIdentity,
 )
 
 
@@ -13,7 +13,7 @@ def _namespace() -> CacheNamespace:
     return CacheNamespace("test", "api")
 
 
-def _identity(**changes) -> HouseholdTraceIdentity:
+def _identity(**changes) -> HouseholdCalculationIdentity:
     values = {
         "country_id": "us",
         "household_id": 1,
@@ -24,15 +24,14 @@ def _identity(**changes) -> HouseholdTraceIdentity:
         "policyengine_version": "4.5.6",
     }
     values.update(changes)
-    return HouseholdTraceIdentity(**values)
+    return HouseholdCalculationIdentity(**values)
 
 
-def test_household_and_tracer_share_one_atomic_versioned_value() -> None:
+def test_household_and_warnings_share_one_atomic_versioned_value() -> None:
     backend = InMemoryCacheBackend()
-    cache = HouseholdTraceCache(backend, _namespace())
-    value = HouseholdTraceValue(
+    cache = HouseholdCalculationCache(backend, _namespace())
+    value = CachedHouseholdCalculation(
         household={"people": {"you": {"income": {"2026": 42}}}},
-        tracer_output=["income <2026>"],
         warnings=("income calculation used a fallback value",),
     )
     identity = _identity()
@@ -40,6 +39,7 @@ def test_household_and_tracer_share_one_atomic_versioned_value() -> None:
     assert cache.set(identity, value) is True
     assert cache.get(identity) == value
     assert list(backend._values) == [cache.cache_key(identity)]
+    assert "tracer" not in backend._values[cache.cache_key(identity)]
     assert cache.cache_key(identity) != cache.cache_key(
         _identity(household_hash="household-b")
     )

--- a/tests/unit/runtime_cache/test_household_traces.py
+++ b/tests/unit/runtime_cache/test_household_traces.py
@@ -33,6 +33,7 @@ def test_household_and_tracer_share_one_atomic_versioned_value() -> None:
     value = HouseholdTraceValue(
         household={"people": {"you": {"income": {"2026": 42}}}},
         tracer_output=["income <2026>"],
+        warnings=("income calculation used a fallback value",),
     )
     identity = _identity()
 

--- a/tests/unit/services/test_household_calculation_service.py
+++ b/tests/unit/services/test_household_calculation_service.py
@@ -148,9 +148,10 @@ def test_calculation_closes_reads_before_compute_and_caches_atomic_results(
 
         def calculate(self, household, policy):
             assert primary.active_scopes == 0
-            return SimpleNamespace(
+            return CalculationResult(
                 household={"people": {"you": {"net_income": {"2026": 42}}}},
                 tracer_output=["net_income <2026>"],
+                warnings=("net_income could not be calculated",),
             )
 
     service = HouseholdCalculationService(
@@ -166,6 +167,7 @@ def test_calculation_closes_reads_before_compute_and_caches_atomic_results(
     assert cached is not None
     assert cached.household == result.household
     assert cached.tracer_output == ["net_income <2026>"]
+    assert cached.warnings == result.warnings == ("net_income could not be calculated",)
     assert "recompute" in {
         call.args[0]["cache_event"] for call in mock_logger.log_struct.call_args_list
     }
@@ -177,7 +179,11 @@ def test_calculation_uses_local_cache_without_recomputing(orm_session_factory):
     cache = _cache()
     cache.set(
         _identity(),
-        HouseholdTraceValue(household=calculated, tracer_output=[]),
+        HouseholdTraceValue(
+            household=calculated,
+            tracer_output=[],
+            warnings=("net_income could not be calculated",),
+        ),
     )
     country = SimpleNamespace(
         metadata={"variables": {}, "entities": {}},
@@ -194,6 +200,7 @@ def test_calculation_uses_local_cache_without_recomputing(orm_session_factory):
     result = service.calculate_stored_household("us", 1, 2)
 
     assert result.household == calculated
+    assert result.warnings == ("net_income could not be calculated",)
     assert result.cached is True
 
 

--- a/tests/unit/services/test_household_calculation_service.py
+++ b/tests/unit/services/test_household_calculation_service.py
@@ -10,10 +10,10 @@ from policyengine_api.data.v1_models import (
 )
 from policyengine_api.runtime_cache.core import CacheNamespace
 from policyengine_api.runtime_cache.fake import InMemoryCacheBackend
-from policyengine_api.runtime_cache.household_traces import (
-    HouseholdTraceCache,
-    HouseholdTraceIdentity,
-    HouseholdTraceValue,
+from policyengine_api.runtime_cache.household_calculations import (
+    CachedHouseholdCalculation,
+    HouseholdCalculationCache,
+    HouseholdCalculationIdentity,
 )
 from policyengine_api.services.household_calculation_service import (
     CalculationResult,
@@ -72,15 +72,15 @@ def _seed_inputs(factory):
         )
 
 
-def _cache() -> HouseholdTraceCache:
-    return HouseholdTraceCache(
+def _cache() -> HouseholdCalculationCache:
+    return HouseholdCalculationCache(
         InMemoryCacheBackend(),
         CacheNamespace("test", "api"),
     )
 
 
-def _identity() -> HouseholdTraceIdentity:
-    return HouseholdTraceIdentity(
+def _identity() -> HouseholdCalculationIdentity:
+    return HouseholdCalculationIdentity(
         country_id="us",
         household_id=1,
         policy_id=2,
@@ -100,7 +100,6 @@ def test_household_route_and_country_do_not_manage_persistence():
     assert "from sqlalchemy" not in route_source
     assert "select(" not in route_source
     assert "get_v1_session_factory" not in country_source
-    assert "Tracer(" not in country_source
 
 
 def test_calculate_household_preserves_calculation_warnings():
@@ -116,7 +115,6 @@ def test_calculate_household_preserves_calculation_warnings():
         def calculate(self, household, policy):
             return CalculationResult(
                 household=household,
-                tracer_output=[],
                 warnings=("employment_income could not be calculated",),
             )
 
@@ -150,7 +148,6 @@ def test_calculation_closes_reads_before_compute_and_caches_atomic_results(
             assert primary.active_scopes == 0
             return CalculationResult(
                 household={"people": {"you": {"net_income": {"2026": 42}}}},
-                tracer_output=["net_income <2026>"],
                 warnings=("net_income could not be calculated",),
             )
 
@@ -166,7 +163,6 @@ def test_calculation_closes_reads_before_compute_and_caches_atomic_results(
     cached = cache.get(_identity())
     assert cached is not None
     assert cached.household == result.household
-    assert cached.tracer_output == ["net_income <2026>"]
     assert cached.warnings == result.warnings == ("net_income could not be calculated",)
     assert "recompute" in {
         call.args[0]["cache_event"] for call in mock_logger.log_struct.call_args_list
@@ -179,9 +175,8 @@ def test_calculation_uses_local_cache_without_recomputing(orm_session_factory):
     cache = _cache()
     cache.set(
         _identity(),
-        HouseholdTraceValue(
+        CachedHouseholdCalculation(
             household=calculated,
-            tracer_output=[],
             warnings=("net_income could not be calculated",),
         ),
     )
@@ -215,7 +210,6 @@ def test_failed_cache_write_does_not_invalidate_successful_calculation(
         },
         calculate=lambda *_: SimpleNamespace(
             household={"people": {"you": {}}},
-            tracer_output=["trace"],
         ),
     )
 
@@ -225,7 +219,7 @@ def test_failed_cache_write_does_not_invalidate_successful_calculation(
 
     service = HouseholdCalculationService(
         primary_session_factory=orm_session_factory,
-        cache=HouseholdTraceCache(
+        cache=HouseholdCalculationCache(
             BrokenBackend(),
             CacheNamespace("test", "api"),
         ),

--- a/tests/unit/services/test_household_calculation_service.py
+++ b/tests/unit/services/test_household_calculation_service.py
@@ -16,6 +16,7 @@ from policyengine_api.runtime_cache.household_traces import (
     HouseholdTraceValue,
 )
 from policyengine_api.services.household_calculation_service import (
+    CalculationResult,
     HouseholdCalculationService,
 )
 
@@ -100,6 +101,33 @@ def test_household_route_and_country_do_not_manage_persistence():
     assert "select(" not in route_source
     assert "get_v1_session_factory" not in country_source
     assert "Tracer(" not in country_source
+
+
+def test_calculate_household_preserves_calculation_warnings():
+    household = {"people": {"you": {"employment_income": {"2026": None}}}}
+
+    class Country:
+        metadata = {
+            "variables": {"employment_income": {"entity": "person"}},
+            "entities": {"person": {"plural": "people", "roles": {}}},
+            "parameters": {},
+        }
+
+        def calculate(self, household, policy):
+            return CalculationResult(
+                household=household,
+                tracer_output=[],
+                warnings=("employment_income could not be calculated",),
+            )
+
+    service = HouseholdCalculationService(
+        cache=_cache(),
+        country_provider=lambda: {"us": Country()},
+    )
+
+    result = service.calculate_household("us", household, {})
+
+    assert result.warnings == ("employment_income could not be calculated",)
 
 
 def test_calculation_closes_reads_before_compute_and_caches_atomic_results(

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -1,10 +1,24 @@
 import pytest
+import numpy as np
 import pandas as pd
 from datetime import date, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
-from policyengine_api.country import COUNTRIES, PolicyEngineCountry
+from policyengine_core.enums import EnumArray
+from policyengine_core.model_api import Enum
+
+from policyengine_api.country import (
+    COUNTRIES,
+    PolicyEngineCountry,
+    _serialize_axis_result,
+    get_requested_computations,
+)
+
+
+class ExampleEnum(Enum):
+    FIRST = "First"
+    SECOND = "Second"
 
 
 class TestCountryJsonSafety:
@@ -22,6 +36,134 @@ class TestCountryJsonSafety:
             "release_date": "2026-05-12",
             "nested": ["2026-05-12T08:30:45"],
         }
+
+
+class TestAxisResults:
+    @pytest.mark.parametrize(
+        ("value_type", "values", "expected"),
+        [
+            (float, [1.5, np.inf, -np.inf], [1.5, "Infinity", "-Infinity"]),
+            (int, [1, 2, 3], [1, 2, 3]),
+            (bool, [True, False, True], [True, False, True]),
+            (str, ["first", "second", "third"], ["first", "second", "third"]),
+        ],
+    )
+    def test__serialize_axis_result_preserves_value_type(
+        self,
+        value_type,
+        values,
+        expected,
+    ):
+        variable = SimpleNamespace(value_type=value_type)
+        result = np.array(values)
+
+        assert _serialize_axis_result(result, variable, 0, 1) == expected
+
+    def test__serialize_axis_result_decodes_enum_names(self):
+        variable = SimpleNamespace(value_type=Enum)
+        result = EnumArray(np.array([0, 1, 0]), ExampleEnum)
+
+        assert _serialize_axis_result(result, variable, 0, 1) == [
+            "FIRST",
+            "SECOND",
+            "FIRST",
+        ]
+
+    def test__axes_request_includes_provided_values_and_excludes_metadata(self):
+        household = {
+            "people": {
+                "you": {
+                    "age": {"2025": 40},
+                    "employment_income": {"2025": None},
+                }
+            },
+            "households": {"household": {"members": ["you"]}},
+            "axes": [
+                [
+                    {
+                        "name": "employment_income",
+                        "period": "2025",
+                        "min": 0,
+                        "max": 40_000,
+                        "count": 5,
+                    }
+                ]
+            ],
+        }
+
+        computations = get_requested_computations(
+            household,
+            include_provided_values=True,
+            variable_names={"age", "employment_income"},
+        )
+
+        assert set(computations) == {
+            ("people", "you", "age", "2025"),
+            ("people", "you", "employment_income", "2025"),
+        }
+
+    def test__ordinary_request_only_includes_null_values(self):
+        household = {
+            "people": {
+                "you": {
+                    "age": {"2025": 40},
+                    "employment_income": {"2025": None},
+                }
+            }
+        }
+
+        assert get_requested_computations(household) == [
+            ("people", "you", "employment_income", "2025")
+        ]
+
+    def test__axis_calculation_error_returns_null_array_and_warning(self, monkeypatch):
+        class BrokenSimulation:
+            trace = False
+            tracer = SimpleNamespace(
+                computation_log=SimpleNamespace(lines=lambda **kwargs: [])
+            )
+
+            def calculate(self, variable_name, period):
+                raise RuntimeError("calculation failed")
+
+            def get_population(self, entity_plural):
+                return SimpleNamespace(count=5)
+
+        variable = SimpleNamespace(value_type=float)
+        system = SimpleNamespace(
+            variables={"employment_income": variable},
+            get_variable=lambda variable_name: variable,
+        )
+        country = PolicyEngineCountry.__new__(PolicyEngineCountry)
+        monkeypatch.setattr(
+            country,
+            "_create_simulation",
+            lambda household, reform: (BrokenSimulation(), system),
+        )
+        household = {
+            "people": {"you": {"employment_income": {"2025": None}}},
+            "axes": [
+                [
+                    {
+                        "name": "employment_income",
+                        "period": "2025",
+                        "min": 0,
+                        "max": 40_000,
+                        "count": 5,
+                    }
+                ]
+            ],
+        }
+
+        result = country.calculate(household, None)
+
+        assert (
+            result.household["people"]["you"]["employment_income"]["2025"] == [None] * 5
+        )
+        assert result.warnings == (
+            "Unable to calculate employment_income for you in 2025; "
+            "returned 5 null axis values: calculation failed",
+        )
 
 
 class TestUKCountryMetadata:

--- a/tests/unit/test_country.py
+++ b/tests/unit/test_country.py
@@ -38,6 +38,37 @@ class TestCountryJsonSafety:
         }
 
 
+class TestHouseholdCalculation:
+    def test__calculate_does_not_enable_or_read_simulation_tracing(self, monkeypatch):
+        class SimulationWithoutTracing:
+            __slots__ = ()
+
+            def calculate(self, variable_name, period):
+                return np.array([40])
+
+            def get_population(self, entity_plural):
+                return SimpleNamespace(get_index=lambda entity_id: 0)
+
+        variable = SimpleNamespace(value_type=int)
+        system = SimpleNamespace(
+            variables={"age": variable},
+            get_variable=lambda variable_name: variable,
+        )
+        country = PolicyEngineCountry.__new__(PolicyEngineCountry)
+        monkeypatch.setattr(
+            country,
+            "_create_simulation",
+            lambda household, reform: (SimulationWithoutTracing(), system),
+        )
+
+        result = country.calculate(
+            {"people": {"you": {"age": {"2025": None}}}},
+            None,
+        )
+
+        assert result.household["people"]["you"]["age"]["2025"] == 40
+
+
 class TestAxisResults:
     @pytest.mark.parametrize(
         ("value_type", "values", "expected"),
@@ -118,10 +149,7 @@ class TestAxisResults:
 
     def test__axis_calculation_error_returns_null_array_and_warning(self, monkeypatch):
         class BrokenSimulation:
-            trace = False
-            tracer = SimpleNamespace(
-                computation_log=SimpleNamespace(lines=lambda **kwargs: [])
-            )
+            __slots__ = ()
 
             def calculate(self, variable_name, period):
                 raise RuntimeError("calculation failed")


### PR DESCRIPTION
Fixes #2695
Fixes #3803

## Summary

- Expand every recognized household variable value across configured axes, including values supplied in the request.
- Preserve float, integer, Boolean, string, and enum result types in axis result arrays.
- Return correctly sized null arrays and response warnings when an individual variable cannot be calculated.
- Stop enabling PolicyEngine calculation tracing and remove tracer output from internal calculation and cache records.
- Retain calculated-household result caching under a new cache family that stores only the household result and warnings.
- Keep non-axis calculations and HTTP response contracts unchanged.

## Testing

- Full pull-request suite: 1,483 passed.
- Focused household, cache, route, and contract suite: 112 passed.
- Exhaustive axes integration test: 1 passed with every variable represented by a five-element array.
- Local Redis integration suite: 5 passed.
- Ruff formatting and lint checks passed.
- Repository migration and quality checks passed.
