### PR TITLE
Fix production Cloud Run smoke-test collection

### DIFF
--- a/changelog.d/production-smoke-test-dependencies.fixed.md
+++ b/changelog.d/production-smoke-test-dependencies.fixed.md
@@ -1,0 +1,1 @@
+Allow production Cloud Run smoke tests to load shared integration fixtures without installing database dependencies.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,6 @@ import uuid
 
 import httpx
 import pytest
-from sqlalchemy.engine import make_url
 
 INTEGRATION_TIMEOUT_SECONDS = float(
     os.environ.get("STAGING_API_TEST_TIMEOUT_SECONDS", "900")
@@ -18,6 +17,8 @@ TRANSIENT_POLL_STATUS_CODES = {500, 502, 503, 504}
 @pytest.fixture(scope="session")
 def disposable_v1_database_url() -> str:
     """Return a validated local MySQL URL for destructive integration tests."""
+
+    from sqlalchemy.engine import make_url
 
     database_url = os.environ.get("ALEMBIC_DATABASE_URL", "")
     if not database_url:

--- a/tests/unit/test_cloud_run_deploy_scripts.py
+++ b/tests/unit/test_cloud_run_deploy_scripts.py
@@ -5,6 +5,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -2026,6 +2027,32 @@ def test_workflows_do_not_inline_long_run_blocks():
                 )
 
     assert oversized_blocks == []
+
+
+def test_production_smoke_test_configuration_loads_without_sqlalchemy():
+    script = """
+import builtins
+import runpy
+
+original_import = builtins.__import__
+
+def reject_sqlalchemy(name, *args, **kwargs):
+    if name == "sqlalchemy" or name.startswith("sqlalchemy."):
+        raise ModuleNotFoundError("production smoke tests do not install SQLAlchemy")
+    return original_import(name, *args, **kwargs)
+
+builtins.__import__ = reject_sqlalchemy
+runpy.run_path("tests/integration/conftest.py", run_name="integration_conftest")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_push_workflow_promotes_production_cloud_run_after_candidate_smoke():


### PR DESCRIPTION
Fixes #3831

## Summary

- Move the SQLAlchemy URL parser import inside the disposable MySQL fixture.
- Keep shared integration-test configuration importable in the production smoke-test environment, which installs only Pytest and HTTPX.
- Add a regression test that blocks SQLAlchemy imports while loading the shared integration-test configuration.
- Add a bug-fix changelog fragment.

## Cause

The production deployment workflow loaded shared integration-test configuration before collecting its seven read-only Cloud Run smoke tests. A module-level SQLAlchemy import caused test discovery to fail even though those smoke tests do not request either disposable-database fixture.

This change keeps SQLAlchemy available when the disposable MySQL fixture executes without making it a dependency of unrelated deployed smoke tests.

## API behavior

This PR does not change application routes, request fields, response fields, database behavior, or Cloud Run configuration.

## Testing

- Confirmed the new regression failed with ModuleNotFoundError before the implementation change and passed afterward.
- 125 workflow and deployment tests passed.
- All 7 production Cloud Run smoke tests collected successfully.
- All 16 policy, saved-policy association, and household cross-database tests collected successfully.
- Ruff formatting and lint checks passed.
- Migration validation passed, and regenerated migration-contract artifacts produced no diff.